### PR TITLE
Add campaign history timeline feature

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -28,10 +28,10 @@ const menuOptions: any[] = [
     label: () => h(RouterLink, { to: '/' }, 'Home'),
     key: 'home',
   },
-  // {
-  //   label: () => h(RouterLink, { to: '/campanhas' }, 'Campanhas'),
-  //   key: 'campanhas',
-  // },
+  {
+    label: () => h(RouterLink, { to: '/campanhas' }, 'Campanhas'),
+    key: 'campanhas',
+  },
   {
     label: () => h(RouterLink, { to: '/regras' }, 'Regras'),
     key: 'regras',

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -753,3 +753,173 @@ main {
     color: #faac55;
   }
 }
+
+.campaign-timeline {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 100px;
+
+  @media (max-width: 900px) {
+    .campaign-timeline-item {
+      .campaign-timeline-item-left {
+        order: 3 !important;
+      }
+
+      .campaign-timeline-item-right {
+        order: 1 !important;
+        display: none;
+      }
+    }
+  }
+
+  .campaign-timeline-item {
+    display: flex;
+    position: relative;
+
+    &:last-child {
+      .campaign-timeline__line {
+        display: none;
+      }
+    }
+
+    &:nth-child(even) {
+      .campaign-timeline-item-left {
+        order: 3;
+      }
+
+      .campaign-timeline-item-right {
+        order: 1;
+      }
+    }
+  }
+
+  .campaign-timeline-item-timeline {
+    width: 30px;
+    position: relative;
+    bottom: 0;
+    min-height: 30px;
+    display: flex;
+    /*align-items: center;*/
+    justify-content: center;
+    order: 2;
+  }
+
+  .campaign-timeline__line {
+    transition: background-color 0.3s;
+    position: absolute;
+    /*top: 50%;*/
+    bottom: 0px;
+    width: 2px;
+    background-color: transparent;
+    height: calc(100% - 14px);
+    transform: translateY(calc(50% - 7px));
+    z-index: 1;
+    background-image: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.3),
+      rgba(255, 255, 255, 0.3) 50%,
+      transparent 50%,
+      transparent 100%
+    );
+    background-size: 1px 10px;
+  }
+
+  .campaign-timeline__circle {
+    border: 2px solid #ffca8e;
+    transition:
+      background-color 0.3s,
+      border-color 0.3s;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    box-sizing: border-box;
+    position: absolute;
+    top: calc(50% - 14px);
+  }
+
+  .campaign-timeline-item-left,
+  .campaign-timeline-item-right {
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 0;
+  }
+
+  .campaign-timeline-item-left {
+    order: 1;
+  }
+
+  .campaign-timeline-item-right {
+    order: 3;
+  }
+}
+
+.campaign-item {
+  display: flex;
+  align-items: center;
+  height: 200px;
+  background: #18131c;
+  border-radius: 5px;
+  border: 1px solid #3d2e294a;
+  border-top: 1px solid #b07663;
+  box-shadow: 0 5px 12px rgba(0, 0, 0, 0.2);
+  transition:
+    transform 0.3s,
+    margin 0.3s;
+  width: 100%;
+
+  @media (max-width: 900px) {
+    margin-bottom: 30px;
+  }
+
+  .campaign-item-cover {
+    height: 100%;
+    position: relative;
+    width: 100%;
+
+    .campaign-item-cover-bg {
+      background-repeat: no-repeat;
+      background-color: black;
+      background-size: cover;
+      background-position: center;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      opacity: 0.2;
+      z-index: 1;
+    }
+
+    .campaign-item-cover-content {
+      height: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+      padding: 20px 30px;
+
+      p {
+        color: white;
+        text-align: center;
+        font-size: 20px;
+        margin: 0;
+        font-weight: 400;
+      }
+
+      h2 {
+        text-transform: uppercase;
+        color: var(--color-accent);
+        text-align: center;
+        font-size: 38px;
+        margin: 0;
+        font-weight: 500;
+        text-shadow: 0 3px 2px rgba(0, 0, 0, 0.8);
+      }
+    }
+  }
+}

--- a/client/src/services/campaignService.ts
+++ b/client/src/services/campaignService.ts
@@ -11,6 +11,12 @@ export const getCurrentCampaign = async (): Promise<Campaign | null> => {
   return campaign
 }
 
+export const getCampaignHistory = async (): Promise<Campaign[] | null> => {
+  const { data: campaigns } = await api.get<Campaign[]>('/campaign/history')
+
+  return campaigns
+}
+
 export const updatePlayerGameInformation = async (
   playerGameInformation: PlayerGameInformation,
 ): Promise<Campaign> => {

--- a/client/src/views/Campaigns.vue
+++ b/client/src/views/Campaigns.vue
@@ -1,22 +1,71 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import VueMarkdown from 'vue-markdown-render'
+import { getCampaignHistory } from '@/services/campaignService'
+import type { Campaign } from '@/types/Campaign'
+import { NTimeline, NTimelineItem, NButton, NSpace } from 'naive-ui'
+import { ref, onMounted } from 'vue'
+import { getGameCover } from '@/services/gameService.ts'
+import { LogoSteam, LogoYoutube } from '@vicons/ionicons5'
 
-import rules from '@/assets/rules.md?raw'
+const campaigns = ref<Campaign[]>([])
 
-const formattedRules = computed(() => {
-  return rules.replace(/\\n/g, '\n')
+onMounted(async () => {
+  campaigns.value = ((await getCampaignHistory()) || []).reverse()
 })
 </script>
 
 <template>
   <div>
-    <div class="main-block">
-      <div class="main-block-content">
-        <vue-markdown
-          :source="formattedRules"
-          :options="{ breaks: true, html: true, linkify: true }"
-        />
+    <div v-if="campaigns.length" class="campaign-timeline">
+      <div v-for="campaign in campaigns" :key="campaign.id" class="campaign-timeline-item">
+        <div class="campaign-timeline-item-left">
+          <div class="campaign-item">
+            <div class="campaign-item-cover">
+              <div
+                class="campaign-item-cover-bg"
+                :style="`background-image: url('${getGameCover(campaign?.game)}')`"
+              ></div>
+              <div class="campaign-item-cover-content">
+                <p v-if="campaign?.month">{{ campaign.month }} - {{ campaign.year }}</p>
+                <h2>{{ campaign.game.title }}</h2>
+
+                <div style="margin-top: 28px">
+                  <n-space>
+                    <n-button
+                      v-if="campaign?.game?.steam"
+                      icon-placement="left"
+                      :tag="'a'"
+                      :href="campaign.game.steam"
+                      target="_blank"
+                    >
+                      <template #icon>
+                        <LogoSteam />
+                      </template>
+                      Steam
+                    </n-button>
+
+                    <n-button
+                      v-if="campaign?.game?.trailer"
+                      icon-placement="left"
+                      :tag="'a'"
+                      :href="campaign.game.trailer"
+                      target="_blank"
+                    >
+                      <template #icon>
+                        <LogoYoutube />
+                      </template>
+                      Trailer
+                    </n-button>
+                  </n-space>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="campaign-timeline-item-timeline">
+          <div class="campaign-timeline__line"></div>
+          <div class="campaign-timeline__circle"></div>
+        </div>
+        <div class="campaign-timeline-item-right"></div>
       </div>
     </div>
   </div>

--- a/server/src/campaign/campaign.controller.ts
+++ b/server/src/campaign/campaign.controller.ts
@@ -46,6 +46,11 @@ export class CampaignController {
     return this.campaignService.current(player);
   }
 
+  @Get('history')
+  async findAllHistory(): Promise<Campaign[]> {
+    return this.campaignService.findAllHistory();
+  }
+
   @Get('recalculate-election-result')
   async recalculateElectionResult(): Promise<
     { optionId: number; game: string; tokens: number }[]

--- a/server/src/campaign/campaign.service.ts
+++ b/server/src/campaign/campaign.service.ts
@@ -10,6 +10,36 @@ import { Player } from '../players/entities/player.entity';
 import { UpdateGameInformationDto } from './dto/update-game-information.dto';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 
+const sortCampaigns = (campaigns: Campaign[]): Campaign[] => {
+  const months = [
+    'Janeiro',
+    'Fevereiro',
+    'Março',
+    'Abril',
+    'Maio',
+    'Junho',
+    'Julho',
+    'Agosto',
+    'Setembro',
+    'Outubro',
+    'Novembro',
+    'Dezembro',
+  ];
+
+  return campaigns.sort((a, b) => {
+    // sort by year
+    if (a.year !== b.year) {
+      return +a.year - +b.year;
+    }
+
+    // sort by month
+    const indexA = months.findIndex((month) => month === a.month);
+    const indexB = months.findIndex((month) => month === b.month);
+
+    return indexA - indexB;
+  });
+};
+
 @Injectable()
 export class CampaignService {
   constructor(
@@ -39,6 +69,14 @@ export class CampaignService {
 
   findAll(): Promise<Campaign[]> {
     return this.campaignRepository.find({ relations: this.defaultRelations });
+  }
+
+  async findAllHistory(): Promise<Campaign[]> {
+    const campaigns = await this.campaignRepository.find({
+      relations: ['game'],
+    });
+
+    return sortCampaigns(campaigns);
   }
 
   findOne(id: number): Promise<Campaign | null> {


### PR DESCRIPTION
Introduces a campaign history endpoint on the backend and a new timeline UI on the frontend to display past campaigns. Adds sorting logic for campaigns by year and month, updates styles for timeline and campaign items, and integrates campaign history retrieval and display in the Campaigns view.