### PR TITLE
Add player avatars and names to Canvas rendering

### DIFF
--- a/client/src/stores/campaign.ts
+++ b/client/src/stores/campaign.ts
@@ -25,8 +25,6 @@ export const useCampaignStore = defineStore('campaign', () => {
       campaign.value = await getCurrentCampaign()
     }
 
-    console.log(campaign.value)
-
     currentGame.value = campaign?.value?.game as Game
 
     const user = auth.user


### PR DESCRIPTION
Introduced a Player class to render player avatars and names around the bonfire in Canvas.vue, using campaign store data. Player positions are dynamically generated, and the canvas updates when campaign player data changes. Also refactored bonfire vertical positioning and removed a debug log from campaign store.