### PR TITLE
Store website rules in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The repository is split into three workspace packages:
 
 - View the current game campaign.
 - View campaign history.
-- Render rules and campaign descriptions from Markdown.
+- Render database-backed rules and campaign descriptions from Markdown.
 - Login with Discord.
 - Track whether an authenticated player started or finished the current game.
 - Vote and undo votes in campaign election pools.
@@ -59,6 +59,7 @@ The repository is split into three workspace packages:
 ├── server/                  # NestJS API
 │   ├── src/auth/            # Discord OAuth and JWT auth
 │   ├── src/campaign/        # Campaign logic and voting endpoints
+│   ├── src/content/         # Public, database-backed website content
 │   ├── src/games/           # Game CRUD
 │   ├── src/players/         # Player CRUD/profile logic
 │   ├── src/pool/            # Election pool logic
@@ -186,11 +187,17 @@ The server exposes routes for:
 
 - `GET /campaign/current` — current campaign, optionally enriched with authenticated player data.
 - `GET /campaign/history` — campaign history.
+- `GET /content/rules` — Markdown rules currently published on the website.
 - `PUT /campaign/update-player-game-information` — update authenticated player's current campaign progress.
 - `POST /campaign/vote` and `POST /campaign/undo-vote` — campaign voting actions.
 - `GET /auth/discord` — start Discord OAuth flow.
 - `GET /auth/discord/callback` — Discord OAuth callback.
 - CRUD-style routes under `/campaign`, `/games`, `/players`, `/pool`, and `/users`.
+
+The MCP/admin API also exposes guarded `GET /admin/rules` and
+`PATCH /admin/rules` endpoints. The `get_rules` and `update_rules` MCP tools use
+these endpoints so the published Markdown can be reviewed and changed without a
+code deployment.
 
 ## Testing
 
@@ -224,6 +231,10 @@ pnpm run db:sync:prod
 
 The generated SQLite file lives at `server/data/local.sqlite` by default and is ignored by Git.
 
+Website rules are stored in the `site_content` table under the `rules` key. The
+initial migration preserves the rules that were previously bundled with the
+frontend, and later updates take effect as soon as the Rules page is refreshed.
+
 PostgreSQL is still available for local development through `server/docker-compose.yml` if needed:
 
 - Host: `localhost`
@@ -236,7 +247,7 @@ Unset `DATABASE_TYPE` or set it to `postgres` to use the Postgres configuration 
 
 ## CI
 
-GitHub Actions runs on pull requests and pushes to `main`:
+GitHub Actions runs on pull requests and pushes to `develop` and `master`:
 
 1. Install dependencies with pnpm.
 2. Run frontend type-checking and server linting.

--- a/client/src/services/contentService.ts
+++ b/client/src/services/contentService.ts
@@ -1,0 +1,12 @@
+import api from './api'
+
+export interface SiteContent {
+  key: string
+  content: string
+  updatedAt: string
+}
+
+export const getRules = async (): Promise<SiteContent> => {
+  const { data } = await api.get<SiteContent>('/content/rules')
+  return data
+}

--- a/client/src/views/Rules.vue
+++ b/client/src/views/Rules.vue
@@ -1,11 +1,25 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { NSpin, useMessage } from 'naive-ui'
 import VueMarkdown from 'vue-markdown-render'
+import { getRules, type SiteContent } from '@/services/contentService'
 
-import rules from '@/assets/rules.md?raw'
+const rules = ref<SiteContent | null>(null)
+const loading = ref(true)
+const message = useMessage()
 
 const formattedRules = computed(() => {
-  return rules.replace(/\\n/g, '\n')
+  return rules.value?.content.replace(/\\n/g, '\n').replace(/<br\s*\/?\s*>/gi, '\n') ?? ''
+})
+
+onMounted(async () => {
+  try {
+    rules.value = await getRules()
+  } catch {
+    message.error('Não foi possível carregar as regras. Tente novamente.')
+  } finally {
+    loading.value = false
+  }
 })
 </script>
 
@@ -13,9 +27,11 @@ const formattedRules = computed(() => {
   <div>
     <div class="main-block">
       <div class="main-block-content">
+        <n-spin v-if="loading" size="large" />
         <vue-markdown
+          v-else-if="rules"
           :source="formattedRules"
-          :options="{ breaks: true, html: true, linkify: true }"
+          :options="{ breaks: true, html: false, linkify: true }"
         />
       </div>
     </div>

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -12,6 +12,7 @@ import {
   monthlyPlanSchema,
   querySchema,
   updateCampaignSchema,
+  updateRulesSchema,
   upsertGamesSchema,
 } from "./schemas.js";
 
@@ -81,6 +82,28 @@ server.registerTool(
     const search = query ? `?query=${encodeURIComponent(query)}` : "";
     return jsonContent(await adminApi.get(`/admin/players${search}`));
   },
+);
+
+server.registerTool(
+  "get_rules",
+  {
+    title: "Get website rules",
+    description:
+      "Returns the Markdown rules currently shown on the public website.",
+    inputSchema: {},
+  },
+  async () => jsonContent(await adminApi.get("/admin/rules")),
+);
+
+server.registerTool(
+  "update_rules",
+  {
+    title: "Update website rules",
+    description:
+      "Replaces the Markdown rules shown on the public website. Only use after explicit user confirmation.",
+    inputSchema: updateRulesSchema.shape,
+  },
+  async (input) => jsonContent(await adminApi.patch("/admin/rules", input)),
 );
 
 server.registerTool(
@@ -230,27 +253,24 @@ server.registerResource(
   "token_rules",
   "sobaluz://rules/tokens",
   {
-    title: "Token rules",
+    title: "Website rules",
     description:
-      "Explains how Sob a Luz do Bonfire voting tokens are calculated.",
-    mimeType: "text/plain",
+      "Rules currently published on the Sob a Luz do Bonfire website.",
+    mimeType: "text/markdown",
   },
-  async (uri) => ({
-    contents: [
-      {
-        uri: uri.href,
-        mimeType: "text/plain",
-        text: [
-          "Sob a Luz do Bonfire token rules:",
-          "- Base participation: 1 token",
-          "- played_the_game: +1 token",
-          "- finished_the_game: +1 token",
-          "- partook_in_the_meeting: +1 token",
-          "- suggested_a_game: -1 token",
-        ].join("\n"),
-      },
-    ],
-  }),
+  async (uri) => {
+    const rules = await adminApi.get<{ content: string }>("/admin/rules");
+
+    return {
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "text/markdown",
+          text: rules.content,
+        },
+      ],
+    };
+  },
 );
 
 server.registerPrompt(

--- a/mcp/src/schemas.ts
+++ b/mcp/src/schemas.ts
@@ -91,3 +91,12 @@ export const finalizeElectionSchema = campaignIdSchema.extend({
 export const querySchema = z.object({
   query: z.string().optional(),
 });
+
+export const updateRulesSchema = z.object({
+  content: z
+    .string()
+    .max(100_000)
+    .refine((value) => value.trim().length > 0, {
+      message: "Rules must contain visible text",
+    }),
+});

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -19,6 +19,7 @@ import {
   UpsertGamesDto,
 } from './dto/admin-operations.dto';
 import { ApplyMonthlyPlanDto, MonthlyPlanDto } from './dto/monthly-plan.dto';
+import { UpdateRulesDto } from './dto/update-rules.dto';
 import { AdminApiKeyGuard } from './guards/admin-api-key.guard';
 import { AdminService } from './admin.service';
 
@@ -40,6 +41,16 @@ export class AdminController {
   @Get('players')
   listPlayers(@Query() query: CampaignQueryDto) {
     return this.adminService.listPlayers(query.query);
+  }
+
+  @Get('rules')
+  getRules() {
+    return this.adminService.getRules();
+  }
+
+  @Patch('rules')
+  updateRules(@Body() body: UpdateRulesDto) {
+    return this.adminService.updateRules(body);
   }
 
   @Post('monthly-plan/preview')

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
+import { ContentModule } from '../content/content.module';
 import { Game } from '../games/entities/game.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
@@ -15,6 +16,7 @@ import { AdminApiKeyGuard } from './guards/admin-api-key.guard';
 @Module({
   imports: [
     ConfigModule,
+    ContentModule,
     TypeOrmModule.forFeature([
       Campaign,
       CampaignPlayer,

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -9,6 +9,8 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
+import { ContentService } from '../content/content.service';
+import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
@@ -30,6 +32,7 @@ import {
   ApplyMonthlyPlanDto,
   MonthlyPlanDto,
 } from './dto/monthly-plan.dto';
+import { UpdateRulesDto } from './dto/update-rules.dto';
 import { AdminAuditLog } from './entities/admin-audit-log.entity';
 
 type ParticipantFlag =
@@ -124,6 +127,7 @@ export class AdminService {
     private readonly poolRepository: Repository<Pool>,
     private readonly dataSource: DataSource,
     private readonly config: ConfigService,
+    private readonly contentService: ContentService,
   ) {}
 
   async getState(): Promise<{
@@ -180,6 +184,23 @@ export class AdminService {
         value ? normalizeText(value).includes(normalizedQuery) : false,
       ),
     );
+  }
+
+  getRules(): Promise<SiteContent> {
+    return this.contentService.getRules();
+  }
+
+  async updateRules(dto: UpdateRulesDto): Promise<SiteContent> {
+    return this.dataSource.transaction(async (manager) => {
+      const rules = await this.contentService.updateRules(dto.content, manager);
+
+      await this.writeAuditLog(manager, 'rules_updated', dto, {
+        key: rules.key,
+        updatedAt: rules.updatedAt,
+      });
+
+      return rules;
+    });
   }
 
   async previewMonthlyPlan(plan: MonthlyPlanDto): Promise<MonthlyPlanPreview> {

--- a/server/src/admin/dto/update-rules.dto.ts
+++ b/server/src/admin/dto/update-rules.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, Matches, MaxLength } from 'class-validator';
+import { RULES_MAX_LENGTH } from '../../content/default-rules';
+
+export class UpdateRulesDto {
+  @IsString()
+  @Matches(/\S/, { message: 'content must contain visible text' })
+  @MaxLength(RULES_MAX_LENGTH)
+  content!: string;
+}

--- a/server/src/admin/entities/admin-audit-log.entity.ts
+++ b/server/src/admin/entities/admin-audit-log.entity.ts
@@ -16,10 +16,10 @@ export class AdminAuditLog {
   @Column({ default: 'mcp' })
   actor!: string;
 
-  @Column({ type: 'jsonb', nullable: true })
+  @Column({ type: 'json', nullable: true })
   payload!: Record<string, unknown> | null;
 
-  @Column({ type: 'jsonb', nullable: true })
+  @Column({ type: 'json', nullable: true })
   result!: Record<string, unknown> | null;
 
   @CreateDateColumn()

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module';
 import { PoolModule } from './pool/pool.module';
 import { AdminModule } from './admin/admin.module';
 import { createTypeOrmModuleOptions } from './db/database.config';
+import { ContentModule } from './content/content.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { createTypeOrmModuleOptions } from './db/database.config';
     GamesModule,
     AuthModule,
     PoolModule,
+    ContentModule,
     AdminModule,
   ],
   controllers: [],

--- a/server/src/content/content.controller.ts
+++ b/server/src/content/content.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ContentService } from './content.service';
+import { SiteContent } from './entities/site-content.entity';
+
+@ApiTags('content')
+@Controller('content')
+export class ContentController {
+  constructor(private readonly contentService: ContentService) {}
+
+  @Get('rules')
+  getRules(): Promise<SiteContent> {
+    return this.contentService.getRules();
+  }
+}

--- a/server/src/content/content.module.ts
+++ b/server/src/content/content.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+import { SiteContent } from './entities/site-content.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SiteContent])],
+  controllers: [ContentController],
+  providers: [ContentService],
+  exports: [ContentService],
+})
+export class ContentModule {}

--- a/server/src/content/content.service.spec.ts
+++ b/server/src/content/content.service.spec.ts
@@ -1,0 +1,53 @@
+import { DataSource } from 'typeorm';
+import { ContentService } from './content.service';
+import { DEFAULT_RULES_MARKDOWN, RULES_CONTENT_KEY } from './default-rules';
+import { SiteContent } from './entities/site-content.entity';
+
+describe('ContentService', () => {
+  let dataSource: DataSource;
+  let service: ContentService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqljs',
+      entities: [SiteContent],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+    service = new ContentService(dataSource.getRepository(SiteContent));
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('seeds the existing website rules when no database value exists', async () => {
+    const rules = await service.getRules();
+
+    expect(rules).toMatchObject({
+      key: RULES_CONTENT_KEY,
+      content: DEFAULT_RULES_MARKDOWN,
+    });
+    await expect(dataSource.getRepository(SiteContent).count()).resolves.toBe(
+      1,
+    );
+  });
+
+  it('updates and persists the website rules', async () => {
+    await service.getRules();
+    await dataSource.query('UPDATE site_content SET updated_at = ?', [
+      '2000-01-01 00:00:00',
+    ]);
+
+    const updatedRules = await service.updateRules('# Regras atualizadas');
+
+    expect(updatedRules).toMatchObject({
+      key: RULES_CONTENT_KEY,
+      content: '# Regras atualizadas',
+    });
+    expect(updatedRules.updatedAt.getUTCFullYear()).toBeGreaterThan(2000);
+    await expect(dataSource.getRepository(SiteContent).count()).resolves.toBe(
+      1,
+    );
+  });
+});

--- a/server/src/content/content.service.ts
+++ b/server/src/content/content.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { EntityManager, Repository } from 'typeorm';
+import { DEFAULT_RULES_MARKDOWN, RULES_CONTENT_KEY } from './default-rules';
+import { SiteContent } from './entities/site-content.entity';
+
+@Injectable()
+export class ContentService {
+  constructor(
+    @InjectRepository(SiteContent)
+    private readonly contentRepository: Repository<SiteContent>,
+  ) {}
+
+  async getRules(): Promise<SiteContent> {
+    const rules = await this.contentRepository.findOneBy({
+      key: RULES_CONTENT_KEY,
+    });
+
+    if (rules) {
+      return rules;
+    }
+
+    try {
+      return await this.contentRepository.save(
+        this.contentRepository.create({
+          key: RULES_CONTENT_KEY,
+          content: DEFAULT_RULES_MARKDOWN,
+        }),
+      );
+    } catch (error: unknown) {
+      const concurrentlyCreatedRules = await this.contentRepository.findOneBy({
+        key: RULES_CONTENT_KEY,
+      });
+
+      if (concurrentlyCreatedRules) {
+        return concurrentlyCreatedRules;
+      }
+
+      throw error;
+    }
+  }
+
+  async updateRules(
+    content: string,
+    manager?: EntityManager,
+  ): Promise<SiteContent> {
+    const repository = manager
+      ? manager.getRepository(SiteContent)
+      : this.contentRepository;
+    await repository.upsert(
+      {
+        key: RULES_CONTENT_KEY,
+        content,
+        updatedAt: new Date(),
+      },
+      ['key'],
+    );
+
+    return repository.findOneByOrFail({
+      key: RULES_CONTENT_KEY,
+    });
+  }
+}

--- a/server/src/content/default-rules.ts
+++ b/server/src/content/default-rules.ts
@@ -1,5 +1,7 @@
+export const RULES_CONTENT_KEY = 'rules';
+export const RULES_MAX_LENGTH = 100_000;
 
-<br>
+export const DEFAULT_RULES_MARKDOWN = `<br>
 
 ## Regras do sistema de votos:
 
@@ -21,3 +23,4 @@
 
 Nós não temos regras específicas para recomendar jogos.
 Porém nós recomendamos jogos curtos, no máximo 15 horas (main + extras) segundo o [How Long To Beat](https://howlongtobeat.com/), mas preferencialmente de 5 a 10 horas.
+`;

--- a/server/src/content/entities/site-content.entity.ts
+++ b/server/src/content/entities/site-content.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('site_content')
+export class SiteContent {
+  @PrimaryColumn({ type: 'varchar', length: 100 })
+  key!: string;
+
+  @Column({ type: 'text' })
+  content!: string;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/server/src/db/database-metadata.spec.ts
+++ b/server/src/db/database-metadata.spec.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
 import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
+import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
@@ -15,22 +16,25 @@ class MetadataDataSource extends DataSource {
   }
 }
 
-describe('PostgreSQL entity metadata', () => {
-  it('uses supported column types for every entity', async () => {
-    const dataSource = new MetadataDataSource({
-      type: 'postgres',
-      entities: [
-        AdminAuditLog,
-        Campaign,
-        CampaignPlayer,
-        Game,
-        Player,
-        Pool,
-        PoolOption,
-        User,
-      ],
-    });
+const entities = [
+  AdminAuditLog,
+  Campaign,
+  CampaignPlayer,
+  Game,
+  Player,
+  Pool,
+  PoolOption,
+  SiteContent,
+  User,
+];
 
-    await expect(dataSource.validateMetadata()).resolves.toBeUndefined();
-  });
+describe('database entity metadata', () => {
+  it.each(['postgres', 'sqljs'] as const)(
+    'uses column types supported by %s',
+    async (type) => {
+      const dataSource = new MetadataDataSource({ type, entities });
+
+      await expect(dataSource.validateMetadata()).resolves.toBeUndefined();
+    },
+  );
 });

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -1,7 +1,13 @@
 import type { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import type { DataSourceOptions } from 'typeorm';
+import { AdminAutomation1763760000000 } from './migrations/1763760000000-AdminAutomation';
+import { SiteContent1785729600000 } from './migrations/1785729600000-SiteContent';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
+const safeRuntimeMigrations = [
+  AdminAutomation1763760000000,
+  SiteContent1785729600000,
+];
 
 const getDatabasePort = (): number => {
   const port = Number(process.env.DATABASE_PORT);
@@ -27,7 +33,8 @@ export function createTypeOrmModuleOptions(): TypeOrmModuleOptions {
     password: process.env.DATABASE_PASSWORD,
     database: process.env.DATABASE_NAME,
     autoLoadEntities: true,
-    migrations: ['db/migrations/*{.ts,.js}'],
+    migrations: safeRuntimeMigrations,
+    migrationsRun: process.env.NODE_ENV === 'production',
     synchronize: process.env.NODE_ENV !== 'production',
   };
 }

--- a/server/src/db/migrations/1785729600000-SiteContent.ts
+++ b/server/src/db/migrations/1785729600000-SiteContent.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+  DEFAULT_RULES_MARKDOWN,
+  RULES_CONTENT_KEY,
+} from '../../content/default-rules';
+
+export class SiteContent1785729600000 implements MigrationInterface {
+  name = 'SiteContent1785729600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "site_content" (
+        "key" character varying(100) NOT NULL,
+        "content" text NOT NULL,
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_site_content" PRIMARY KEY ("key")
+      )
+    `);
+
+    await queryRunner.query(
+      `INSERT INTO "site_content" ("key", "content")
+       VALUES ($1, $2)
+       ON CONFLICT ("key") DO NOTHING`,
+      [RULES_CONTENT_KEY, DEFAULT_RULES_MARKDOWN],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "site_content"`);
+  }
+}

--- a/server/src/db/sync-production-to-sqlite.ts
+++ b/server/src/db/sync-production-to-sqlite.ts
@@ -5,6 +5,11 @@ import { dirname, resolve } from 'node:path';
 import { DataSource, type FindManyOptions } from 'typeorm';
 import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
+import {
+  DEFAULT_RULES_MARKDOWN,
+  RULES_CONTENT_KEY,
+} from '../content/default-rules';
+import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
@@ -21,6 +26,7 @@ const entities = [
   PoolOption,
   Campaign,
   CampaignPlayer,
+  SiteContent,
 ];
 
 function getSqlitePath(): string {
@@ -72,6 +78,19 @@ async function copyRepository<T extends object>(
   console.log(`Copied ${rows.length} ${label}`);
 }
 
+async function hasTable(
+  source: DataSource,
+  tableName: string,
+): Promise<boolean> {
+  const queryRunner = source.createQueryRunner();
+
+  try {
+    return await queryRunner.hasTable(tableName);
+  } finally {
+    await queryRunner.release();
+  }
+}
+
 async function syncProductionToSqlite(): Promise<void> {
   const sqlitePath = getSqlitePath();
   mkdirSync(dirname(sqlitePath), { recursive: true });
@@ -108,6 +127,16 @@ async function syncProductionToSqlite(): Promise<void> {
     await copyRepository('campaign players', source, target, CampaignPlayer, {
       relations: { campaign: true, player: true },
     });
+
+    if (await hasTable(source, 'site_content')) {
+      await copyRepository('site content entries', source, target, SiteContent);
+    } else {
+      await target.getRepository(SiteContent).save({
+        key: RULES_CONTENT_KEY,
+        content: DEFAULT_RULES_MARKDOWN,
+      });
+      console.log('Production has no site content table; seeded default rules');
+    }
 
     console.log(`SQLite database created at ${sqlitePath}`);
   } finally {


### PR DESCRIPTION
## Summary

- move the public rules page from a bundled Markdown asset to database-backed site content
- seed the existing rules through a production-safe TypeORM migration
- add public read and guarded admin update endpoints with validation and audit logging
- expose live rules through MCP get/update tools and the existing rules resource
- preserve rules when syncing production data to the local SQL.js database
- make admin audit JSON columns portable across PostgreSQL and SQL.js
- disable arbitrary HTML in editable rules while preserving existing line-break formatting

## Verification

- `pnpm run ci`
- live SQL.js API smoke test for `PATCH /admin/rules` and `GET /content/rules`
- PostgreSQL and SQL.js entity metadata validation