### PR TITLE
Redesign the current game hearth

### DIFF
--- a/.agents/skills/manage-bonfire-cycle/references/workflows.md
+++ b/.agents/skills/manage-bonfire-cycle/references/workflows.md
@@ -2,18 +2,18 @@
 
 ## Tool selection
 
-| Task | Preferred tool |
-| --- | --- |
-| Read current state | `get_admin_state`, `get_current_campaign` |
-| Resolve records | `list_games`, `list_players` |
-| Combined monthly change | `preview_monthly_plan`, then `apply_monthly_plan` |
-| Standalone game upsert | `upsert_games` |
-| Standalone pool creation | `create_pool_from_games` |
-| Attach existing pool | `attach_pool_to_campaign` |
-| Campaign-only update | `update_campaign` |
-| Attendance and participant flags | `bulk_update_campaign_participants` |
-| Read election totals | `get_election_result` |
-| Assign winner and close voting | `finalize_election` |
+| Task                             | Preferred tool                                    |
+| -------------------------------- | ------------------------------------------------- |
+| Read current state               | `get_admin_state`, `get_current_campaign`         |
+| Resolve records                  | `list_games`, `list_players`                      |
+| Combined monthly change          | `preview_monthly_plan`, then `apply_monthly_plan` |
+| Standalone game upsert           | `upsert_games`                                    |
+| Standalone pool creation         | `create_pool_from_games`                          |
+| Attach existing pool             | `attach_pool_to_campaign`                         |
+| Campaign-only update             | `update_campaign`                                 |
+| Attendance and participant flags | `bulk_update_campaign_participants`               |
+| Read election totals             | `get_election_result`                             |
+| Assign winner and close voting   | `finalize_election`                               |
 
 ## Monthly plan shape
 
@@ -22,6 +22,9 @@
   "campaign": {
     "id": 16,
     "description": "Markdown in Portuguese",
+    "meetingAt": "2026-08-27T20:00:00-03:00",
+    "meetingLocation": "Discord",
+    "meetingUrl": "https://discord.com/events/example",
     "electionActive": true
   },
   "games": [
@@ -30,7 +33,10 @@
       "cover": "https://example.com/banner.jpg",
       "suggestion": true,
       "steam": "https://store.steampowered.com/app/123/Example/",
-      "trailer": "https://www.youtube.com/watch?v=example"
+      "trailer": "https://www.youtube.com/watch?v=example",
+      "summary": "Resumo curto para o destaque do jogo atual.",
+      "howLongToBeatUrl": "https://howlongtobeat.com/game/example",
+      "durationLabel": "11 a 18 horas"
     }
   ],
   "pool": {

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -665,6 +665,511 @@ main {
   margin: 0 auto;
 }
 
+.current-game-hearth {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 76px;
+  background:
+    radial-gradient(ellipse 68% 210px at 50% -22px, rgba(186, 79, 43, 0.17), transparent 72%),
+    linear-gradient(155deg, rgba(29, 21, 29, 0.985), rgba(17, 14, 21, 0.99));
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top-color: rgba(238, 160, 105, 0.5);
+  border-bottom-color: rgba(0, 0, 0, 0.78);
+  border-radius: 9px;
+  box-shadow:
+    0 -14px 38px rgba(174, 65, 32, 0.07),
+    0 18px 46px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 222, 190, 0.05);
+}
+
+.current-game-hearth::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 23%;
+  width: 54%;
+  height: 1px;
+  z-index: 2;
+  background: linear-gradient(90deg, transparent, rgba(255, 200, 146, 0.72), transparent);
+  pointer-events: none;
+}
+
+.hearth-heading {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  padding: 21px 24px 18px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+}
+
+.hearth-heading > div > p {
+  margin: 0 0 3px;
+  color: rgba(242, 164, 92, 0.74);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hearth-heading h2 {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: clamp(22px, 3vw, 30px);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  text-shadow: 0 7px 16px rgba(0, 0, 0, 0.58);
+}
+
+.meeting-callout {
+  display: inline-flex;
+  min-width: 0;
+  padding: 8px 11px;
+  align-items: center;
+  gap: 11px;
+  color: #eba86f;
+  background: rgba(9, 7, 11, 0.24);
+  border: 1px solid rgba(238, 160, 105, 0.18);
+  border-top-color: rgba(238, 160, 105, 0.34);
+  border-radius: 6px;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    background 180ms ease;
+}
+
+a.meeting-callout:hover,
+a.meeting-callout:focus-visible {
+  color: #f4b184;
+  background: rgba(242, 164, 92, 0.08);
+  border-color: rgba(242, 164, 92, 0.34);
+}
+
+.meeting-callout > span {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 3px 7px;
+}
+
+.meeting-callout small {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.meeting-callout strong {
+  color: #f0ad72;
+  font-size: 13px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.meeting-callout strong + strong {
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 11px;
+  font-weight: 550;
+}
+
+.game-spotlight {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.game-spotlight__art {
+  position: relative;
+  height: clamp(295px, 37vw, 385px);
+  overflow: hidden;
+  background-color: #2d2543;
+  background-position: center;
+  background-size: cover;
+}
+
+.game-spotlight__art::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(235, 137, 79, 0.18), transparent 48%),
+    linear-gradient(180deg, rgba(10, 8, 13, 0.06), transparent 34%, rgba(10, 8, 13, 0.14));
+}
+
+.game-spotlight__shade {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: linear-gradient(180deg, rgba(12, 10, 15, 0.08), transparent 52%);
+  box-shadow: inset 0 -1px rgba(255, 255, 255, 0.05);
+}
+
+.game-spotlight__details {
+  display: flex;
+  padding: 18px 20px 20px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  background: rgba(11, 9, 14, 0.24);
+}
+
+.game-spotlight__copy {
+  max-width: 590px;
+}
+
+.game-spotlight__copy h3 {
+  margin: 0 0 5px;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Mulish', sans-serif;
+  font-size: clamp(22px, 2.7vw, 30px);
+  font-weight: 850;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+}
+
+.game-spotlight__copy p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.game-links {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.game-links a {
+  display: inline-flex;
+  min-height: 34px;
+  padding: 7px 11px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 5px;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.game-links a:hover,
+.game-links a:focus-visible {
+  color: #f4b184;
+  background: rgba(242, 164, 92, 0.055);
+  border-color: rgba(242, 164, 92, 0.34);
+}
+
+.hearth-community {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-width: 0;
+  padding: 21px 24px 24px;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
+  background:
+    radial-gradient(ellipse 42% 100px at 50% 0, rgba(147, 59, 34, 0.11), transparent 78%),
+    rgba(9, 7, 11, 0.17);
+  border-top: 1px solid rgba(238, 160, 105, 0.12);
+}
+
+.hearth-community__header {
+  position: relative;
+  display: flex;
+  width: 100%;
+  min-height: 15px;
+  align-items: center;
+  justify-content: center;
+}
+
+.hearth-community__header h3 {
+  margin: 0;
+  color: rgba(242, 164, 92, 0.76);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hearth-community__header span {
+  position: absolute;
+  top: 1px;
+  right: 0;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 9px;
+  font-weight: 550;
+}
+
+.journey-shell {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.group-progress {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  padding: 2px 18px 0;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  margin: 1.1em 0;
+}
+
+.journey-roster {
+  position: relative;
+  display: flex;
+  width: min(100%, 760px);
+  align-items: flex-start;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 9px clamp(8px, 2.2vw, 28px);
+}
+
+.journey-roster::before {
+  content: '';
+  position: absolute;
+  top: 16px;
+  right: 5%;
+  left: 5%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(221, 115, 66, 0.13) 18%,
+    rgba(238, 160, 105, 0.2) 50%,
+    rgba(221, 115, 66, 0.13) 82%,
+    transparent
+  );
+}
+
+.player-chip {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.58);
+  background: rgba(6, 5, 8, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+}
+
+.player-chip--current {
+  border-color: rgba(255, 225, 186, 0.48);
+}
+
+.player-chip--finished,
+.player-chip--finished.player-chip--current {
+  border-color: #f2a45c;
+  box-shadow: 0 0 33px rgba(229, 96, 50, 0.8);
+  animation: finished-player-glow 2.8s ease-in-out infinite;
+  will-change: box-shadow;
+}
+
+@keyframes finished-player-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 30px rgba(180, 96, 50, 0.8);
+  }
+
+  50% {
+    box-shadow: 0 0 33px rgba(229, 96, 50, 0.8);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .player-chip--finished,
+  .player-chip--finished.player-chip--current {
+    animation: none;
+  }
+}
+
+.player-chip img,
+.player-chip__initial {
+  width: 100%;
+  height: 100%;
+  flex: 0 0 100%;
+  border-radius: inherit;
+}
+
+.player-chip img {
+  object-fit: cover;
+}
+
+.player-chip__initial {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 9px;
+  font-weight: 800;
+  background: #504259;
+}
+
+.personal-progress {
+  display: flex;
+  width: min(100%, 530px);
+  min-width: 0;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+}
+
+.journey-control {
+  display: grid;
+  width: 100%;
+  padding: 4px;
+  grid-template-columns: repeat(3, auto);
+  gap: 0;
+  background: rgba(5, 4, 7, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 7px;
+  box-shadow: inset 0 1px 8px rgba(0, 0, 0, 0.14);
+}
+
+.journey-control button {
+  display: inline-flex;
+  min-height: 38px;
+  padding: 8px 14px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: rgba(255, 255, 255, 0.45);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.journey-control button + button {
+  box-shadow: inset 1px 0 rgba(255, 255, 255, 0.055);
+}
+
+.journey-control__marker {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 50%;
+  transition:
+    background 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.journey-control button:hover:not(:disabled),
+.journey-control button:focus-visible {
+  color: rgba(255, 255, 255, 0.75);
+  border-color: rgba(242, 164, 92, 0.28);
+}
+
+.journey-control button:disabled {
+  cursor: wait;
+}
+
+.journey-control .journey-control__option--selected {
+  color: #ffc18a;
+  background: rgba(155, 72, 39, 0.18);
+  border-color: rgba(238, 133, 69, 0.62);
+  box-shadow:
+    inset 0 0 0 1px rgba(238, 133, 69, 0.46),
+    inset 0 0 18px rgba(172, 73, 34, 0.08),
+    0 0 18px rgba(187, 77, 36, 0.04);
+}
+
+.journey-control .journey-control__option--selected .journey-control__marker {
+  background: #f2a45c;
+  border-color: #ffc48c;
+  box-shadow: 0 0 7px rgba(232, 104, 48, 0.48);
+}
+
+.journey-control .journey-control__option--finished.journey-control__option--selected {
+  color: #f4cf83;
+  background: rgba(122, 84, 33, 0.18);
+  border-color: rgba(226, 168, 76, 0.54);
+}
+
+@media (max-width: 680px) {
+  .hearth-heading {
+    padding: 18px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .meeting-callout {
+    width: 100%;
+  }
+
+  .meeting-callout > span {
+    justify-content: flex-start;
+  }
+
+  .game-spotlight__art {
+    height: 240px;
+  }
+
+  .game-spotlight__details {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .personal-progress {
+    align-items: center;
+    gap: 12px;
+  }
+
+  .journey-control {
+    width: 100%;
+    max-width: 300px;
+    justify-self: center;
+    grid-template-columns: 1fr;
+  }
+
+  .journey-control button {
+    width: 100%;
+  }
+
+  .journey-control button + button {
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0.055);
+  }
+}
+
 .main-block {
   background: #18131c;
   border-radius: 4px;

--- a/client/src/components/CurrentGameHearth.vue
+++ b/client/src/components/CurrentGameHearth.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NIcon } from 'naive-ui'
+import { CalendarOutline, LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
+import type { Campaign, CampaignPlayer } from '@/types/Campaign'
+import type { Game } from '@/types/Game'
+import { formatDurationLabel, getGameCover } from '@/services/gameService'
+import { formatJourneyCount, getJourneyPlayers, type JourneyStatus } from '@/services/userService'
+
+type SaveState = 'idle' | 'saving' | 'saved'
+
+const props = defineProps<{
+  campaign: Campaign
+  game: Game
+  campaignUser: CampaignPlayer | null
+  journeyStatus: JourneyStatus
+  saveState: SaveState
+}>()
+
+const emit = defineEmits<{
+  changeJourney: [status: JourneyStatus]
+}>()
+
+const journeyOptions: Array<{ value: JourneyStatus; label: string }> = [
+  { value: 'not-started', label: 'Ainda não comecei' },
+  { value: 'playing', label: 'Em jornada' },
+  { value: 'finished', label: 'Concluí' },
+]
+
+const journeyPlayers = computed(() => {
+  return getJourneyPlayers(props.campaign.players ?? [])
+})
+
+const journeyHeading = computed(() => {
+  return formatJourneyCount(journeyPlayers.value.length)
+})
+
+const meeting = computed(() => {
+  if (!props.campaign.meetingAt) {
+    return null
+  }
+
+  const date = new Date(props.campaign.meetingAt)
+
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const day = new Intl.DateTimeFormat('pt-BR', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+  })
+    .format(date)
+    .replace(/\./g, '')
+
+  const time = new Intl.DateTimeFormat('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+
+  return { day, time }
+})
+
+const coverStyle = computed(() => {
+  const cover = getGameCover(props.game)
+  return cover ? { backgroundImage: `url('${cover}')` } : undefined
+})
+
+const durationLabel = computed(() => formatDurationLabel(props.game.durationLabel))
+
+const playerName = (campaignPlayer: CampaignPlayer) => {
+  return (
+    campaignPlayer.player.name?.trim() ||
+    campaignPlayer.player.discord?.globalName?.trim() ||
+    campaignPlayer.player.discord?.username?.trim() ||
+    'Participante'
+  )
+}
+
+const isCurrentPlayer = (campaignPlayer: CampaignPlayer) => {
+  return campaignPlayer.player.id === props.campaignUser?.player.id
+}
+</script>
+
+<template>
+  <section class="current-game-hearth" aria-labelledby="current-game-heading">
+    <header class="hearth-heading">
+      <div>
+        <p>Neste ciclo</p>
+        <h2 id="current-game-heading">{{ campaign.month }}</h2>
+      </div>
+
+      <component
+        :is="campaign.meetingUrl ? 'a' : 'div'"
+        v-if="meeting || campaign.meetingLocation"
+        class="meeting-callout"
+        :href="campaign.meetingUrl || undefined"
+        :target="campaign.meetingUrl ? '_blank' : undefined"
+        :rel="campaign.meetingUrl ? 'noopener noreferrer' : undefined"
+      >
+        <n-icon size="17"><CalendarOutline /></n-icon>
+        <span>
+          <small>Próximo encontro</small>
+          <strong v-if="meeting">{{ meeting.day }} · {{ meeting.time }}</strong>
+          <strong v-if="campaign.meetingLocation">{{ campaign.meetingLocation }}</strong>
+        </span>
+      </component>
+    </header>
+
+    <article class="game-spotlight">
+      <div class="game-spotlight__art" :style="coverStyle">
+        <div class="game-spotlight__shade"></div>
+      </div>
+
+      <div class="game-spotlight__details">
+        <div class="game-spotlight__copy">
+          <h3>{{ game.title }}</h3>
+          <p v-if="game.summary">{{ game.summary }}</p>
+        </div>
+
+        <nav class="game-links" aria-label="Links do jogo">
+          <a v-if="game.steam" :href="game.steam" target="_blank" rel="noopener noreferrer">
+            <n-icon size="17"><LogoSteam /></n-icon>
+            Steam
+          </a>
+          <a v-if="game.trailer" :href="game.trailer" target="_blank" rel="noopener noreferrer">
+            <n-icon size="18"><LogoYoutube /></n-icon>
+            Trailer
+          </a>
+          <a
+            v-if="game.howLongToBeatUrl"
+            :href="game.howLongToBeatUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <n-icon size="17"><TimeOutline /></n-icon>
+            {{ durationLabel || 'HowLongToBeat' }}
+          </a>
+        </nav>
+      </div>
+    </article>
+
+    <div v-if="campaignUser || journeyPlayers.length" class="hearth-community">
+      <header class="hearth-community__header">
+        <h3 id="progress-heading">
+          {{ campaignUser ? 'Sua jornada' : 'A jornada do grupo' }}
+        </h3>
+        <span v-if="journeyPlayers.length" id="group-progress-heading">
+          {{ journeyHeading }}
+        </span>
+      </header>
+
+      <div class="journey-shell">
+        <section v-if="campaignUser" class="personal-progress" aria-labelledby="progress-heading">
+          <div
+            class="journey-control"
+            aria-label="Seu progresso no jogo"
+            :aria-busy="saveState === 'saving'"
+          >
+            <button
+              v-for="option in journeyOptions"
+              :key="option.value"
+              type="button"
+              :class="[
+                `journey-control__option--${option.value}`,
+                { 'journey-control__option--selected': journeyStatus === option.value },
+              ]"
+              :aria-pressed="journeyStatus === option.value"
+              :disabled="saveState === 'saving'"
+              @click="emit('changeJourney', option.value)"
+            >
+              <span class="journey-control__marker" aria-hidden="true"></span>
+              <span>{{ option.label }}</span>
+            </button>
+          </div>
+        </section>
+
+        <section
+          v-if="journeyPlayers.length"
+          class="group-progress"
+          aria-labelledby="group-progress-heading"
+        >
+          <div class="journey-roster">
+            <div
+              v-for="campaignPlayer in journeyPlayers"
+              :key="campaignPlayer.id"
+              class="player-chip"
+              :class="{
+                'player-chip--current': isCurrentPlayer(campaignPlayer),
+                'player-chip--finished': campaignPlayer.finished_the_game,
+              }"
+              :title="`${playerName(campaignPlayer)} · ${campaignPlayer.finished_the_game ? 'Concluiu' : 'A caminho'}`"
+            >
+              <img
+                v-if="campaignPlayer.player.discord?.avatar"
+                :src="campaignPlayer.player.discord.avatar"
+                :alt="playerName(campaignPlayer)"
+              />
+              <span v-else class="player-chip__initial" aria-hidden="true">
+                {{ playerName(campaignPlayer).charAt(0).toUpperCase() }}
+              </span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+</template>

--- a/client/src/services/__tests__/gameService.spec.ts
+++ b/client/src/services/__tests__/gameService.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getGameCover } from '../gameService'
+import { formatDurationLabel, getGameCover } from '../gameService'
 import type { Game } from '@/types/Game'
 
 describe('getGameCover', () => {
@@ -24,5 +24,18 @@ describe('getGameCover', () => {
         suggestion: false,
       }),
     ).toBe('')
+  })
+})
+
+describe('formatDurationLabel', () => {
+  it('rounds half-hour estimates up to whole hours', () => {
+    expect(formatDurationLabel('8½–13½ h')).toBe('9–14 h')
+    expect(formatDurationLabel('8.5 a 13,5 horas')).toBe('9 a 14 horas')
+  })
+
+  it('preserves whole-hour estimates and empty values', () => {
+    expect(formatDurationLabel('11–18 h')).toBe('11–18 h')
+    expect(formatDurationLabel(null)).toBe('')
+    expect(formatDurationLabel()).toBe('')
   })
 })

--- a/client/src/services/__tests__/userService.spec.ts
+++ b/client/src/services/__tests__/userService.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { calculateUserTokens, getUserTokenBreakdown } from '../userService'
+import {
+  calculateUserTokens,
+  formatJourneyCount,
+  getJourneyFlags,
+  getJourneyPlayers,
+  getJourneyStatus,
+  getUserTokenBreakdown,
+} from '../userService'
 import type { CampaignPlayer } from '@/types/Campaign'
 
 const createCampaignPlayer = (overrides: Partial<CampaignPlayer> = {}): CampaignPlayer => ({
@@ -37,5 +44,64 @@ describe('user token breakdown', () => {
 
     expect(calculateUserTokens(player)).toBe(3)
     expect(getUserTokenBreakdown(player).map(({ value }) => value)).toEqual([1, 1, 1, 1, -1])
+  })
+})
+
+describe('campaign journey status', () => {
+  it.each([
+    [{ played_the_game: false, finished_the_game: false }, 'not-started'],
+    [{ played_the_game: true, finished_the_game: false }, 'playing'],
+    [{ played_the_game: true, finished_the_game: true }, 'finished'],
+  ] as const)('maps campaign flags to %s', (flags, expectedStatus) => {
+    expect(getJourneyStatus(createCampaignPlayer(flags))).toBe(expectedStatus)
+  })
+
+  it('maps each status back to a valid API payload', () => {
+    expect(getJourneyFlags('not-started')).toEqual({
+      played_the_game: false,
+      finished_the_game: false,
+    })
+    expect(getJourneyFlags('playing')).toEqual({
+      played_the_game: true,
+      finished_the_game: false,
+    })
+    expect(getJourneyFlags('finished')).toEqual({
+      played_the_game: true,
+      finished_the_game: true,
+    })
+  })
+
+  it.each([
+    [0, '0 pessoas na jornada'],
+    [1, '1 pessoa na jornada'],
+    [12, '12 pessoas na jornada'],
+  ])('formats a journey count of %i', (count, label) => {
+    expect(formatJourneyCount(count)).toBe(label)
+  })
+
+  it('keeps players ordered by stable player id when progress changes', () => {
+    const players = [
+      createCampaignPlayer({
+        id: 90,
+        player: { id: 9, name: 'Nove' },
+        played_the_game: true,
+        finished_the_game: true,
+      }),
+      createCampaignPlayer({
+        id: 20,
+        player: { id: 2, name: 'Dois' },
+        played_the_game: true,
+      }),
+      createCampaignPlayer({
+        id: 70,
+        player: { id: 7, name: 'Sete' },
+        played_the_game: true,
+      }),
+    ]
+
+    expect(getJourneyPlayers(players).map(({ player }) => player.id)).toEqual([2, 7, 9])
+
+    players[1]!.finished_the_game = true
+    expect(getJourneyPlayers(players).map(({ player }) => player.id)).toEqual([2, 7, 9])
   })
 })

--- a/client/src/services/gameService.ts
+++ b/client/src/services/gameService.ts
@@ -3,3 +3,13 @@
 export const getGameCover = (game?: Game | null): string => {
   return game?.cover || ''
 }
+
+export const formatDurationLabel = (label?: string | null): string => {
+  if (!label) {
+    return ''
+  }
+
+  return label.replace(/(\d+)\s*(?:[.,]5|½)/g, (_, hours: string) => {
+    return String(Number(hours) + 1)
+  })
+}

--- a/client/src/services/userService.ts
+++ b/client/src/services/userService.ts
@@ -7,6 +7,31 @@ export interface TokenBreakdownItem {
   applied: boolean
 }
 
+export type JourneyStatus = 'not-started' | 'playing' | 'finished'
+
+export const getJourneyStatus = (user: CampaignPlayer): JourneyStatus => {
+  if (user.finished_the_game) {
+    return 'finished'
+  }
+
+  return user.played_the_game ? 'playing' : 'not-started'
+}
+
+export const getJourneyFlags = (status: JourneyStatus) => ({
+  played_the_game: status !== 'not-started',
+  finished_the_game: status === 'finished',
+})
+
+export const formatJourneyCount = (count: number): string => {
+  return `${count} ${count === 1 ? 'pessoa' : 'pessoas'} na jornada`
+}
+
+export const getJourneyPlayers = (players: CampaignPlayer[]): CampaignPlayer[] => {
+  return players
+    .filter((player) => getJourneyStatus(player) !== 'not-started')
+    .sort((left, right) => left.player.id - right.player.id)
+}
+
 export const getUserTokenBreakdown = (user: CampaignPlayer): TokenBreakdownItem[] => [
   {
     key: 'base',

--- a/client/src/types/Campaign.ts
+++ b/client/src/types/Campaign.ts
@@ -29,6 +29,9 @@ export interface Campaign {
   year: string
   current: boolean
   description?: string | null
+  meetingAt?: string | null
+  meetingLocation?: string | null
+  meetingUrl?: string | null
   electionActive: boolean
   pool?: Pool | null
   game?: Game | null

--- a/client/src/types/Game.ts
+++ b/client/src/types/Game.ts
@@ -5,4 +5,7 @@
   steam?: string | null
   trailer?: string | null
   cover?: string | null
+  summary?: string | null
+  howLongToBeatUrl?: string | null
+  durationLabel?: string | null
 }

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,28 +1,22 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { NButton, NSpace, NSpin, NSwitch, useMessage } from 'naive-ui'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { useCampaignStore } from '@/stores/campaign.ts'
 import {
   recalculateElectionResult,
   updatePlayerGameInformation,
 } from '@/services/campaignService.ts'
-import { getGameCover } from '@/services/gameService.ts'
 import ElectionView from '@/components/ElectionView.vue'
-import VueMarkdown from 'vue-markdown-render'
+import CurrentGameHearth from '@/components/CurrentGameHearth.vue'
+import { getJourneyFlags, getJourneyStatus, type JourneyStatus } from '@/services/userService'
 
 const campaignStore = useCampaignStore()
 const { campaign, currentGame, campaignUser } = storeToRefs(campaignStore)
 
-const initialState = ref({
-  finished_the_game: false,
-  played_the_game: false,
-})
-
-const played_the_game = ref<boolean>(false)
-const finished_the_game = ref<boolean>(false)
-
-const saveInformationLoading = ref<boolean>(false)
+const journeyStatus = ref<JourneyStatus>('not-started')
+const saveState = ref<'idle' | 'saving' | 'saved'>('idle')
+let saveStateTimer: number | null = null
 const message = useMessage()
 
 onMounted(async () => {
@@ -33,12 +27,14 @@ onMounted(async () => {
     return
   }
 
-  played_the_game.value = Boolean(campaignUser.value?.played_the_game)
-  finished_the_game.value = Boolean(campaignUser.value?.finished_the_game)
+  if (campaignUser.value) {
+    journeyStatus.value = getJourneyStatus(campaignUser.value)
+  }
+})
 
-  initialState.value = {
-    finished_the_game: Boolean(campaignUser.value?.finished_the_game),
-    played_the_game: Boolean(campaignUser.value?.played_the_game),
+onBeforeUnmount(() => {
+  if (saveStateTimer !== null) {
+    window.clearTimeout(saveStateTimer)
   }
 })
 
@@ -52,42 +48,36 @@ if (params.get('authentication_error') === 'true') {
   history.replaceState({}, '', window.location.pathname)
 }
 
-const switchPlayedTheGame = (value: boolean) => {
-  played_the_game.value = value
-
-  if (!played_the_game.value) {
-    finished_the_game.value = false
+const changeJourney = async (status: JourneyStatus) => {
+  if (saveState.value === 'saving' || status === journeyStatus.value) {
+    return
   }
-}
 
-const formattedDescription = computed(() => {
-  return campaign.value?.description?.replace(/\\n/g, '\n') ?? ''
-})
+  const previousStatus = journeyStatus.value
+  journeyStatus.value = status
+  saveState.value = 'saving'
 
-const hasChanges = computed(() => {
-  return (
-    initialState.value.finished_the_game !== finished_the_game.value ||
-    initialState.value.played_the_game !== played_the_game.value
-  )
-})
-
-const saveInformation = async () => {
-  saveInformationLoading.value = true
+  if (saveStateTimer !== null) {
+    window.clearTimeout(saveStateTimer)
+  }
 
   try {
-    const newCampaignValue = await updatePlayerGameInformation({
-      played_the_game: played_the_game.value,
-      finished_the_game: finished_the_game.value,
-    })
-
-    initialState.value.played_the_game = played_the_game.value
-    initialState.value.finished_the_game = finished_the_game.value
-
+    const newCampaignValue = await updatePlayerGameInformation(getJourneyFlags(status))
     await campaignStore.init(newCampaignValue)
+
+    if (campaignUser.value) {
+      journeyStatus.value = getJourneyStatus(campaignUser.value)
+    }
+
+    saveState.value = 'saved'
+    saveStateTimer = window.setTimeout(() => {
+      saveState.value = 'idle'
+      saveStateTimer = null
+    }, 1800)
   } catch {
+    journeyStatus.value = previousStatus
+    saveState.value = 'idle'
     message.error('Não foi possível salvar a informação. Tente novamente.')
-  } finally {
-    saveInformationLoading.value = false
   }
 }
 
@@ -106,67 +96,15 @@ const recalculateElection = async () => {
 
     <ElectionView />
 
-    <div v-if="currentGame" class="home main-block">
-      <div class="main-block-cover">
-        <div
-          class="main-block-cover-bg"
-          :style="`background-image: url('${getGameCover(currentGame)}')`"
-        ></div>
-        <div class="main-block-cover-content">
-          <p v-if="campaign?.month">Jogo do mês de {{ campaign.month }}</p>
-          <h2>{{ currentGame.title }}</h2>
-        </div>
-      </div>
-      <div class="main-block-prepend" v-if="campaignUser">
-        <n-space class="main-block-prepend-actions">
-          <n-space>
-            <n-switch
-              :round="false"
-              :value="played_the_game"
-              @update:value="switchPlayedTheGame($event)"
-            />
-            <p>Iniciou sua jornada?</p>
-          </n-space>
+    <CurrentGameHearth
+      v-if="campaign && currentGame"
+      :campaign="campaign"
+      :game="currentGame"
+      :campaign-user="campaignUser"
+      :journey-status="journeyStatus"
+      :save-state="saveState"
+      @change-journey="changeJourney"
+    />
 
-          <n-space>
-            <n-switch
-              v-show="played_the_game"
-              :round="false"
-              :value="finished_the_game"
-              @update:value="finished_the_game = $event"
-            />
-            <p v-show="played_the_game">Chegou a concluí-la?</p>
-          </n-space>
-        </n-space>
-        <n-space>
-          <n-button
-            type="primary"
-            :disabled="!hasChanges || saveInformationLoading"
-            @click="saveInformation()"
-          >
-            <n-spin stroke="#18131C" size="small" v-show="saveInformationLoading" />
-            <span v-show="!saveInformationLoading">Salvar informação</span>
-          </n-button>
-        </n-space>
-      </div>
-      <div class="main-block-content" v-if="campaign">
-        <vue-markdown
-          :source="formattedDescription"
-          :options="{ breaks: true, html: true, linkify: true }"
-        />
-      </div>
-    </div>
-
-    <!--    <div style="padding-top: 100px">-->
-    <!--      <n-calendar-->
-    <!--        :value="lockedDate"-->
-    <!--        #="{ year, month, date }"-->
-    <!--        :on-update:value="onUpdateMonth"-->
-    <!--      >-->
-    <!--        <div v-if="targetDateString === `${year}-${month}-${date}`">-->
-    <!--          <p style="margin-top: 6px; text-align: center; color: var(&#45;&#45;color-accent)">Data do próximo encontro</p>-->
-    <!--        </div>-->
-    <!--      </n-calendar>-->
-    <!--    </div>-->
   </div>
 </template>

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -171,7 +171,7 @@ server.registerTool(
   {
     title: "Update campaign",
     description:
-      "Updates campaign metadata such as description, game, pool, electionActive, or current status.",
+      "Updates campaign metadata such as description, meeting details, game, pool, electionActive, or current status.",
     inputSchema: updateCampaignSchema.shape,
   },
   async ({ campaignId, ...body }) =>

--- a/mcp/src/schemas.ts
+++ b/mcp/src/schemas.ts
@@ -7,6 +7,9 @@ export const gameInputSchema = z.object({
   suggestion: z.boolean().optional(),
   steam: z.string().optional(),
   trailer: z.string().optional(),
+  summary: z.string().optional(),
+  howLongToBeatUrl: z.string().optional(),
+  durationLabel: z.string().optional(),
 });
 
 export const campaignInputSchema = z.object({
@@ -15,6 +18,9 @@ export const campaignInputSchema = z.object({
   month: z.string().min(1).optional(),
   year: z.string().min(1).optional(),
   description: z.string().optional(),
+  meetingAt: z.string().datetime({ offset: true }).optional(),
+  meetingLocation: z.string().optional(),
+  meetingUrl: z.string().optional(),
   electionActive: z.boolean().optional(),
   gameId: z.number().int().positive().optional(),
   gameTitle: z.string().min(1).optional(),

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -505,14 +505,44 @@ export class AdminService {
     }
 
     if (
-      Object.prototype.hasOwnProperty.call(input, 'description') &&
+      input.description !== undefined &&
       input.description !== campaign.description
     ) {
       changes.description = 'changed';
     }
 
     if (
-      Object.prototype.hasOwnProperty.call(input, 'electionActive') &&
+      input.meetingAt !== undefined &&
+      input.meetingAt !== campaign.meetingAt
+    ) {
+      changes.meetingAt = {
+        from: campaign.meetingAt ?? null,
+        to: input.meetingAt,
+      };
+    }
+
+    if (
+      input.meetingLocation !== undefined &&
+      input.meetingLocation !== campaign.meetingLocation
+    ) {
+      changes.meetingLocation = {
+        from: campaign.meetingLocation ?? null,
+        to: input.meetingLocation,
+      };
+    }
+
+    if (
+      input.meetingUrl !== undefined &&
+      input.meetingUrl !== campaign.meetingUrl
+    ) {
+      changes.meetingUrl = {
+        from: campaign.meetingUrl ?? null,
+        to: input.meetingUrl,
+      };
+    }
+
+    if (
+      input.electionActive !== undefined &&
       input.electionActive !== campaign.electionActive
     ) {
       changes.electionActive = {
@@ -763,20 +793,32 @@ export class AdminService {
         throw new BadRequestException('Cannot create a game without a title.');
       }
 
-      if (Object.prototype.hasOwnProperty.call(input, 'cover')) {
+      if (input.cover !== undefined) {
         game.cover = input.cover ?? null;
       }
 
-      if (Object.prototype.hasOwnProperty.call(input, 'suggestion')) {
+      if (input.suggestion !== undefined) {
         game.suggestion = input.suggestion ?? false;
       }
 
-      if (Object.prototype.hasOwnProperty.call(input, 'steam')) {
+      if (input.steam !== undefined) {
         game.steam = input.steam ?? null;
       }
 
-      if (Object.prototype.hasOwnProperty.call(input, 'trailer')) {
+      if (input.trailer !== undefined) {
         game.trailer = input.trailer ?? null;
+      }
+
+      if (input.summary !== undefined) {
+        game.summary = input.summary ?? null;
+      }
+
+      if (input.howLongToBeatUrl !== undefined) {
+        game.howLongToBeatUrl = input.howLongToBeatUrl ?? null;
+      }
+
+      if (input.durationLabel !== undefined) {
+        game.durationLabel = input.durationLabel ?? null;
       }
 
       const savedGame = await gameRepository.save(game);
@@ -810,6 +852,9 @@ export class AdminService {
       month: input.month,
       year: input.year,
       description: input.description,
+      meetingAt: input.meetingAt,
+      meetingLocation: input.meetingLocation,
+      meetingUrl: input.meetingUrl,
       current: input.current ?? input.setCurrent ?? true,
       electionActive: input.electionActive ?? false,
       players: [],
@@ -834,11 +879,23 @@ export class AdminService {
       campaign.year = input.year;
     }
 
-    if (Object.prototype.hasOwnProperty.call(input, 'description')) {
+    if (input.description !== undefined) {
       campaign.description = input.description ?? null;
     }
 
-    if (Object.prototype.hasOwnProperty.call(input, 'electionActive')) {
+    if (input.meetingAt !== undefined) {
+      campaign.meetingAt = input.meetingAt ?? null;
+    }
+
+    if (input.meetingLocation !== undefined) {
+      campaign.meetingLocation = input.meetingLocation ?? null;
+    }
+
+    if (input.meetingUrl !== undefined) {
+      campaign.meetingUrl = input.meetingUrl ?? null;
+    }
+
+    if (input.electionActive !== undefined) {
       campaign.electionActive = input.electionActive ?? false;
     }
 
@@ -1061,7 +1118,7 @@ export class AdminService {
       }
 
       for (const flag of participantFlags) {
-        if (Object.prototype.hasOwnProperty.call(participant, flag)) {
+        if (participant[flag] !== undefined) {
           campaignPlayer[flag] = participant[flag] ?? false;
         }
       }
@@ -1361,15 +1418,12 @@ export class AdminService {
       changes.title = { from: existingGame.title, to: input.title.trim() };
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(input, 'cover') &&
-      input.cover !== existingGame.cover
-    ) {
+    if (input.cover !== undefined && input.cover !== existingGame.cover) {
       changes.cover = { from: existingGame.cover ?? null, to: input.cover };
     }
 
     if (
-      Object.prototype.hasOwnProperty.call(input, 'suggestion') &&
+      input.suggestion !== undefined &&
       input.suggestion !== existingGame.suggestion
     ) {
       changes.suggestion = {
@@ -1378,20 +1432,41 @@ export class AdminService {
       };
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(input, 'steam') &&
-      input.steam !== existingGame.steam
-    ) {
+    if (input.steam !== undefined && input.steam !== existingGame.steam) {
       changes.steam = { from: existingGame.steam ?? null, to: input.steam };
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(input, 'trailer') &&
-      input.trailer !== existingGame.trailer
-    ) {
+    if (input.trailer !== undefined && input.trailer !== existingGame.trailer) {
       changes.trailer = {
         from: existingGame.trailer ?? null,
         to: input.trailer,
+      };
+    }
+
+    if (input.summary !== undefined && input.summary !== existingGame.summary) {
+      changes.summary = {
+        from: existingGame.summary ?? null,
+        to: input.summary,
+      };
+    }
+
+    if (
+      input.howLongToBeatUrl !== undefined &&
+      input.howLongToBeatUrl !== existingGame.howLongToBeatUrl
+    ) {
+      changes.howLongToBeatUrl = {
+        from: existingGame.howLongToBeatUrl ?? null,
+        to: input.howLongToBeatUrl,
+      };
+    }
+
+    if (
+      input.durationLabel !== undefined &&
+      input.durationLabel !== existingGame.durationLabel
+    ) {
+      changes.durationLabel = {
+        from: existingGame.durationLabel ?? null,
+        to: input.durationLabel,
       };
     }
 
@@ -1406,7 +1481,7 @@ export class AdminService {
 
     for (const flag of participantFlags) {
       if (
-        Object.prototype.hasOwnProperty.call(participant, flag) &&
+        participant[flag] !== undefined &&
         participant[flag] !== campaignPlayer[flag]
       ) {
         changes[flag] = {
@@ -1425,7 +1500,7 @@ export class AdminService {
     const flags: Record<string, boolean> = {};
 
     for (const flag of participantFlags) {
-      if (Object.prototype.hasOwnProperty.call(participant, flag)) {
+      if (participant[flag] !== undefined) {
         flags[flag] = participant[flag] ?? false;
       }
     }

--- a/server/src/admin/dto/monthly-plan.dto.ts
+++ b/server/src/admin/dto/monthly-plan.dto.ts
@@ -3,6 +3,7 @@ import {
   IsArray,
   IsBoolean,
   IsEmail,
+  IsISO8601,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -38,6 +39,18 @@ export class AdminGameInputDto {
   @IsOptional()
   @IsString()
   trailer?: string;
+
+  @IsOptional()
+  @IsString()
+  summary?: string;
+
+  @IsOptional()
+  @IsString()
+  howLongToBeatUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  durationLabel?: string;
 }
 
 export class AdminCampaignInputDto {
@@ -64,6 +77,18 @@ export class AdminCampaignInputDto {
   @IsOptional()
   @IsString()
   description?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  meetingAt?: string;
+
+  @IsOptional()
+  @IsString()
+  meetingLocation?: string;
+
+  @IsOptional()
+  @IsString()
+  meetingUrl?: string;
 
   @IsOptional()
   @IsBoolean()

--- a/server/src/campaign/dto/create-campaign.dto.ts
+++ b/server/src/campaign/dto/create-campaign.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsBoolean,
+  IsISO8601,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -45,6 +46,18 @@ export class CreateCampaignDto {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @IsISO8601()
+  @IsOptional()
+  meetingAt?: string;
+
+  @IsString()
+  @IsOptional()
+  meetingLocation?: string;
+
+  @IsString()
+  @IsOptional()
+  meetingUrl?: string;
 
   @IsOptional()
   @IsInt()

--- a/server/src/campaign/entities/campaign.entity.ts
+++ b/server/src/campaign/entities/campaign.entity.ts
@@ -27,6 +27,15 @@ export class Campaign {
   @Column({ type: 'varchar', nullable: true })
   description: string | null;
 
+  @Column({ name: 'meeting_at', type: 'varchar', nullable: true })
+  meetingAt: string | null;
+
+  @Column({ name: 'meeting_location', type: 'varchar', nullable: true })
+  meetingLocation: string | null;
+
+  @Column({ name: 'meeting_url', type: 'varchar', nullable: true })
+  meetingUrl: string | null;
+
   @ManyToOne(() => Game, { nullable: true, onDelete: 'SET NULL' })
   @JoinColumn({ name: 'game_id' })
   game?: Game | null;

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -2,11 +2,13 @@ import type { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import type { DataSourceOptions } from 'typeorm';
 import { AdminAutomation1763760000000 } from './migrations/1763760000000-AdminAutomation';
 import { SiteContent1785729600000 } from './migrations/1785729600000-SiteContent';
+import { CurrentGameDetails1785736800000 } from './migrations/1785736800000-CurrentGameDetails';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
 const safeRuntimeMigrations = [
   AdminAutomation1763760000000,
   SiteContent1785729600000,
+  CurrentGameDetails1785736800000,
 ];
 
 const getDatabasePort = (): number => {

--- a/server/src/db/migrations/1785736800000-CurrentGameDetails.ts
+++ b/server/src/db/migrations/1785736800000-CurrentGameDetails.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CurrentGameDetails1785736800000 implements MigrationInterface {
+  name = 'CurrentGameDetails1785736800000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "summary" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "how_long_to_beat_url" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "duration_label" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN "meeting_at" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN "meeting_location" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN "meeting_url" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" DROP COLUMN "meeting_url"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" DROP COLUMN "meeting_location"`,
+    );
+    await queryRunner.query(`ALTER TABLE "campaigns" DROP COLUMN "meeting_at"`);
+    await queryRunner.query(`ALTER TABLE "games" DROP COLUMN "duration_label"`);
+    await queryRunner.query(
+      `ALTER TABLE "games" DROP COLUMN "how_long_to_beat_url"`,
+    );
+    await queryRunner.query(`ALTER TABLE "games" DROP COLUMN "summary"`);
+  }
+}

--- a/server/src/games/dto/create-game.dto.ts
+++ b/server/src/games/dto/create-game.dto.ts
@@ -20,4 +20,16 @@ export class CreateGameDto {
   @IsString()
   @IsOptional()
   trailer?: string;
+
+  @IsString()
+  @IsOptional()
+  summary?: string;
+
+  @IsString()
+  @IsOptional()
+  howLongToBeatUrl?: string;
+
+  @IsString()
+  @IsOptional()
+  durationLabel?: string;
 }

--- a/server/src/games/entities/game.entity.ts
+++ b/server/src/games/entities/game.entity.ts
@@ -19,4 +19,13 @@ export class Game {
 
   @Column({ type: 'varchar', nullable: true })
   trailer: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  summary: string | null;
+
+  @Column({ name: 'how_long_to_beat_url', type: 'varchar', nullable: true })
+  howLongToBeatUrl: string | null;
+
+  @Column({ name: 'duration_label', type: 'varchar', nullable: true })
+  durationLabel: string | null;
 }


### PR DESCRIPTION
## Summary

- redesign the current-game area as a cohesive hearth with a wider game spotlight, clear meeting details, progress controls, and a stable participant roster
- add the campaign meeting and game-detail fields needed by the new presentation to the API, admin workflow, and MCP schemas
- add a production-safe migration with nullable columns and automatic runtime registration
- add duration formatting, journey-state helpers, stable participant ordering, and coverage for the new behavior

## Deployment

- the migration runs automatically when the production server starts
- all new columns are nullable, so existing campaign and game records remain valid
- no new environment variables or secrets are required
- Railway remains configured to deploy from `master`; this PR targets `develop` and will not change the production release flow

## Validation

- `pnpm run ci` under Node 22
- 14 client tests passed
- 10 server tests passed
- clean production server Docker build
- production `GET /campaign/current` currently returns 200
