### PR TITLE
feat: add Brasas game catalog

### DIFF
--- a/.agents/skills/manage-bonfire-cycle/SKILL.md
+++ b/.agents/skills/manage-bonfire-cycle/SKILL.md
@@ -36,7 +36,9 @@ Use the narrower MCP tools only for isolated operations. Still read state first 
 - A backlog game is eligible when it has never won and has appeared in fewer than three prior election pools.
 - After three unsuccessful appearances, exclude it until a participant explicitly recommends it again in a later meeting.
 - A game that already won a campaign is not backlog-eligible.
-- Mark only actual recommenders with `suggested_a_game: true` and only actual attendees with `partook_in_the_meeting: true`.
+- Mark only actual recommenders with `suggested_a_game: true`. When the game is known, also provide exactly one of `suggestedGameId` or `suggestedGameTitle`; the game reference automatically implies the boolean. Preserve legacy boolean-only records when the title is unknown.
+- Use top-level `recommendations` for verified historical game-to-person provenance when the original campaign is unknown. Do not invent a campaign association merely to populate a game's recommender list.
+- Mark only actual attendees with `partook_in_the_meeting: true`.
 - Preserve unrelated participant flags by omitting them from updates.
 - Use Portuguese for campaign announcements unless the user requests another language.
 

--- a/.agents/skills/manage-bonfire-cycle/references/workflows.md
+++ b/.agents/skills/manage-bonfire-cycle/references/workflows.md
@@ -47,13 +47,21 @@
     {
       "player": { "name": "Existing Player" },
       "partook_in_the_meeting": true,
-      "suggested_a_game": true
+      "suggestedGameTitle": "Example Game"
+    }
+  ],
+  "recommendations": [
+    {
+      "player": { "name": "Existing Player" },
+      "gameTitle": "Older Recommendation"
     }
   ]
 }
 ```
 
-Omit fields that should remain unchanged. Use IDs after resolution when names are ambiguous.
+Omit fields that should remain unchanged. Use IDs after resolution when names are ambiguous. `suggestedGameId` or `suggestedGameTitle` automatically sets `suggested_a_game: true`; use the boolean alone only when the historical game is unknown.
+
+Top-level `recommendations` records verified game-to-person provenance without claiming it happened in the selected campaign. Use this for historical backfills whose original meeting is unknown.
 
 ## Start an election
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -72,7 +72,11 @@ const themeOverrides: GlobalThemeOverrides = {
       <RouterView v-slot="{ Component, route: activeRoute }">
         <div class="route-viewport">
           <Transition name="route-page" mode="out-in">
-            <div :key="activeRoute.path" class="route-stage">
+            <div
+              :key="activeRoute.path"
+              class="route-stage"
+              :class="{ 'route-stage--grounded': activeRoute.name === 'brasas' }"
+            >
               <section v-if="activeRoute.meta.pageTitle" class="page-intro">
                 <p v-if="activeRoute.meta.pageKicker" class="page-intro__kicker">
                   {{ activeRoute.meta.pageKicker }}
@@ -84,7 +88,7 @@ const themeOverrides: GlobalThemeOverrides = {
 
               <main :class="{ 'main--inner-page': Boolean(activeRoute.meta.pageTitle) }">
                 <component :is="Component" />
-                <p>&nbsp;</p>
+                <p v-if="activeRoute.name !== 'brasas'">&nbsp;</p>
               </main>
             </div>
           </Transition>

--- a/client/src/assets/ash-color-dither.svg
+++ b/client/src/assets/ash-color-dither.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 640" fill="#090a0d" shape-rendering="crispEdges">
+  <defs>
+    <pattern id="p1" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0z" /></pattern>
+    <pattern id="p2" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 2h1v1H2z" /></pattern>
+    <pattern id="p3" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM2 2h1v1H2z" /></pattern>
+    <pattern id="p4" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM0 2h1v1H0zM2 2h1v1H2z" /></pattern>
+    <pattern id="p5" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM1 1h1v1H1zM0 2h1v1H0zM2 2h1v1H2z" /></pattern>
+    <pattern id="p6" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM1 1h1v1H1zM0 2h1v1H0zM2 2h1v1H2zM3 3h1v1H3z" /></pattern>
+    <pattern id="p7" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM2 2h1v1H2zM3 3h1v1H3z" /></pattern>
+    <pattern id="p8" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM2 0h1v1H2zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM2 2h1v1H2zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p9" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM2 2h1v1H2zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p10" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p11" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM3 0h1v1H3zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p12" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM3 0h1v1H3zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM1 2h1v1H1zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p13" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM3 0h1v1H3zM0 1h1v1H0zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM1 2h1v1H1zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM3 3h1v1H3z" /></pattern>
+    <pattern id="p14" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM3 0h1v1H3zM0 1h1v1H0zM1 1h1v1H1zM3 1h1v1H3zM0 2h1v1H0zM1 2h1v1H1zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM2 3h1v1H2zM3 3h1v1H3z" /></pattern>
+    <pattern id="p15" width="4" height="4" patternUnits="userSpaceOnUse"><path d="M0 0h1v1H0zM1 0h1v1H1zM2 0h1v1H2zM3 0h1v1H3zM0 1h1v1H0zM1 1h1v1H1zM2 1h1v1H2zM3 1h1v1H3zM0 2h1v1H0zM1 2h1v1H1zM2 2h1v1H2zM3 2h1v1H3zM1 3h1v1H1zM2 3h1v1H2zM3 3h1v1H3z" /></pattern>
+  </defs>
+  <path d="M0 40h4v40H0z" fill="url(#p1)" />
+  <path d="M0 80h4v40H0z" fill="url(#p2)" />
+  <path d="M0 120h4v40H0z" fill="url(#p3)" />
+  <path d="M0 160h4v40H0z" fill="url(#p4)" />
+  <path d="M0 200h4v40H0z" fill="url(#p5)" />
+  <path d="M0 240h4v40H0z" fill="url(#p6)" />
+  <path d="M0 280h4v40H0z" fill="url(#p7)" />
+  <path d="M0 320h4v40H0z" fill="url(#p8)" />
+  <path d="M0 360h4v40H0z" fill="url(#p9)" />
+  <path d="M0 400h4v40H0z" fill="url(#p10)" />
+  <path d="M0 440h4v40H0z" fill="url(#p11)" />
+  <path d="M0 480h4v40H0z" fill="url(#p12)" />
+  <path d="M0 520h4v40H0z" fill="url(#p13)" />
+  <path d="M0 560h4v40H0z" fill="url(#p14)" />
+  <path d="M0 600h4v40H0z" fill="url(#p15)" />
+</svg>

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -67,6 +67,18 @@ body.bonfire-inner-page {
   position: relative;
 }
 
+.route-stage--grounded {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.route-stage--grounded main {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+}
+
 .route-page-enter-active,
 .route-page-leave-active {
   transition: opacity 160ms ease;
@@ -1822,5 +1834,686 @@ a.meeting-callout:focus-visible {
     right: 12px;
     max-width: calc(100% - 24px);
     gap: 6px;
+  }
+}
+
+.backlog-page {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  padding-bottom: 0;
+}
+
+.backlog-loading,
+.backlog-empty {
+  display: flex;
+  min-height: 310px;
+  padding: 40px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 16px;
+  text-align: center;
+}
+
+.backlog-loading {
+  color: rgba(255, 241, 231, 0.62);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.backlog-overview {
+  position: relative;
+  display: flex;
+  min-height: 210px;
+  margin-bottom: 42px;
+  padding: 38px 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 68% 210px at 50% -22px, rgba(186, 79, 43, 0.17), transparent 72%),
+    linear-gradient(155deg, rgba(29, 21, 29, 0.985), rgba(17, 14, 21, 0.99));
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top-color: rgba(238, 160, 105, 0.5);
+  border-bottom-color: rgba(0, 0, 0, 0.78);
+  border-radius: 9px;
+  box-shadow:
+    0 -14px 38px rgba(174, 65, 32, 0.07),
+    0 18px 46px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 222, 190, 0.05);
+}
+
+.backlog-overview::before {
+  position: absolute;
+  top: -1px;
+  left: 23%;
+  z-index: 2;
+  width: 54%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 200, 146, 0.72), transparent);
+  content: '';
+  pointer-events: none;
+}
+
+.backlog-overview__copy {
+  position: relative;
+  z-index: 1;
+  max-width: 650px;
+}
+
+.backlog-eyebrow {
+  display: block;
+  margin-bottom: 8px;
+  color: rgba(242, 164, 92, 0.72);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.backlog-overview h2,
+.backlog-empty h2 {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Mulish', sans-serif;
+  font-size: clamp(27px, 4vw, 39px);
+  font-weight: 850;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+
+.backlog-overview p,
+.backlog-empty p {
+  max-width: 610px;
+  margin: 15px 0 0;
+  color: rgba(255, 255, 255, 0.53);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.backlog-limit {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-width: 150px;
+  padding-left: 26px;
+  align-items: center;
+  gap: 13px;
+  border-left: 1px solid rgba(242, 164, 92, 0.22);
+}
+
+.backlog-limit strong {
+  color: #f2a45c;
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: 51px;
+  font-weight: 500;
+  line-height: 1;
+  text-shadow: 0 5px 20px rgba(182, 65, 30, 0.26);
+}
+
+.backlog-limit span {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+  text-transform: uppercase;
+}
+
+.backlog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.backlog-card {
+  min-width: 0;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(29, 21, 28, 0.98), rgba(13, 11, 16, 0.99));
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top: 2px solid rgba(242, 164, 92, 0.52);
+  border-radius: 8px;
+  box-shadow:
+    0 -10px 28px rgba(174, 65, 32, 0.07),
+    0 13px 28px rgba(0, 0, 0, 0.22),
+    inset 0 1px rgba(255, 220, 190, 0.05);
+}
+
+.backlog-card__art {
+  position: relative;
+  height: 170px;
+  background-color: #2d2543;
+  background-position: center;
+  background-size: cover;
+}
+
+.backlog-card__shade {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(12, 10, 15, 0.12), transparent 42%),
+    linear-gradient(0deg, rgba(9, 7, 11, 0.95), transparent 66%);
+}
+
+.backlog-card__count {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 1;
+  padding: 6px 9px;
+  color: rgba(255, 255, 255, 0.54);
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  background: rgba(9, 7, 11, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(6px);
+}
+
+.backlog-card__count strong {
+  color: #f2a45c;
+  font-size: 12px;
+}
+
+.backlog-card__title {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  padding: 24px 17px 15px;
+}
+
+.backlog-card__title h3 {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Mulish', sans-serif;
+  font-size: 18px;
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+  text-shadow: 0 3px 10px rgba(0, 0, 0, 0.85);
+}
+
+.backlog-card__footer {
+  display: flex;
+  min-height: 62px;
+  padding: 13px 14px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.045);
+}
+
+.backlog-card__history {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.backlog-card__history > span {
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 9px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backlog-embers {
+  display: flex;
+  gap: 5px;
+}
+
+.backlog-embers span {
+  width: 18px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+}
+
+.backlog-embers .backlog-ember--lit {
+  background: linear-gradient(90deg, #bd572f, #f2a45c);
+  box-shadow: 0 0 8px rgba(225, 91, 43, 0.34);
+}
+
+.backlog-card__recommenders {
+  display: flex;
+  margin-left: auto;
+  align-items: center;
+  flex: 0 0 auto;
+  padding-left: 3px;
+}
+
+.backlog-recommender {
+  position: relative;
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  margin-left: -7px;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: rgba(255, 229, 211, 0.78);
+  font-size: 9px;
+  font-weight: 800;
+  background: #21171d;
+  border: 2px solid #151118;
+  border-radius: 50%;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.28);
+  cursor: default;
+  user-select: none;
+}
+
+.backlog-recommender:first-child {
+  margin-left: 0;
+}
+
+.backlog-recommender:focus-visible {
+  z-index: 2;
+  border-color: rgba(242, 164, 92, 0.56);
+  outline: none;
+}
+
+.backlog-recommender:focus-visible {
+  box-shadow: 0 0 0 2px rgba(242, 164, 92, 0.26);
+}
+
+.backlog-recommender img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.backlog-recommender--more {
+  color: rgba(255, 255, 255, 0.54);
+  font-size: 8px;
+  background: #171319;
+}
+
+.backlog-card__links {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+}
+
+.backlog-card__links a {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 5px;
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
+}
+
+.backlog-card__links a:hover,
+.backlog-card__links a:focus-visible {
+  color: #f4b184;
+  background: rgba(242, 164, 92, 0.055);
+  border-color: rgba(242, 164, 92, 0.34);
+}
+
+.backlog-card__links a:focus-visible {
+  outline: 2px solid rgba(242, 164, 92, 0.5);
+  outline-offset: 2px;
+}
+
+.backlog-empty h2 {
+  font-size: clamp(24px, 3vw, 32px);
+}
+
+.backlog-retry {
+  min-height: 36px;
+  margin-top: 8px;
+  padding: 8px 14px;
+  color: #f4b184;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(242, 164, 92, 0.055);
+  border: 1px solid rgba(242, 164, 92, 0.3);
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
+}
+
+.backlog-retry:hover,
+.backlog-retry:focus-visible {
+  color: #ffd0a8;
+  background: rgba(242, 164, 92, 0.11);
+  border-color: rgba(242, 164, 92, 0.52);
+}
+
+.backlog-retry:focus-visible {
+  outline: 2px solid rgba(242, 164, 92, 0.48);
+  outline-offset: 3px;
+}
+
+.backlog-rubble {
+  position: relative;
+  display: flex;
+  width: var(--rubble-viewport-width);
+  margin-left: calc((100% - var(--rubble-viewport-width)) / 2);
+  margin-top: clamp(420px, 52vh, 620px);
+  flex: 1 0 auto;
+  flex-direction: column;
+}
+
+.backlog-rubble::before {
+  position: absolute;
+  inset: -96px 0 0;
+  z-index: 0;
+  background:
+    url('./ash-color-dither.svg') repeat-x top / 4px 640px,
+    linear-gradient(#090a0d 0 0) 0 640px / 100% calc(100% - 640px) no-repeat;
+  content: '';
+  pointer-events: none;
+}
+
+.backlog-rubble::after {
+  content: none;
+}
+
+.backlog-rubble__title {
+  position: relative;
+  z-index: 50;
+  margin: 0;
+  color: rgba(185, 184, 188, 0.38);
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-align: center;
+  text-shadow: 0 12px 28px rgba(0, 0, 0, 0.78);
+  text-transform: uppercase;
+}
+
+.backlog-rubble__pile {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: auto;
+  min-height: var(--rubble-pile-height);
+  margin-top: 0;
+  flex: 1 0 var(--rubble-pile-height);
+  overflow: hidden;
+  isolation: isolate;
+  background: transparent;
+  opacity: 1;
+  transition: opacity 180ms ease;
+}
+
+.backlog-rubble__pile--shuffling {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.backlog-rubble__piece {
+  position: absolute;
+  z-index: var(--rubble-layer);
+  display: flex;
+  padding: 16px 17px;
+  align-items: flex-start;
+  justify-content: flex-end;
+  flex-direction: column;
+  gap: 3px;
+  overflow: hidden;
+  color: rgba(205, 202, 201, 0.58);
+  font: inherit;
+  text-align: left;
+  background-color: #19191c;
+  background-position: center;
+  background-size: cover;
+  border: 0;
+  cursor: pointer;
+  filter: grayscale(0.88) saturate(var(--rubble-saturation)) brightness(var(--rubble-brightness))
+    drop-shadow(0 14px 16px rgba(0, 0, 0, 0.46));
+  text-decoration: none;
+  transform: translateX(-50%) rotate(var(--rubble-rotation));
+  transform-origin: 50% 90%;
+  transition:
+    opacity 240ms ease,
+    filter 240ms ease,
+    transform 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.backlog-rubble__piece::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(
+      circle at var(--rubble-scar-x) var(--rubble-scar-y),
+      rgba(3, 3, 5, 0.9),
+      transparent 27%
+    ),
+    repeating-linear-gradient(
+      var(--rubble-scar-angle),
+      transparent 0 14px,
+      rgba(5, 4, 6, 0.74) 15px 17px,
+      transparent 18px 35px
+    ),
+    linear-gradient(0deg, rgba(8, 7, 10, 0.95), transparent 74%),
+    linear-gradient(145deg, rgba(48, 48, 52, 0.18), rgba(8, 8, 10, 0.42));
+  content: '';
+  opacity: var(--rubble-damage-opacity);
+}
+
+.backlog-rubble__piece::after {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: linear-gradient(
+      calc(var(--rubble-scar-angle) + 31deg),
+      transparent 46%,
+      rgba(4, 3, 5, 0.82) 47% 49%,
+      transparent 50%
+    )
+    var(--rubble-scar-x) var(--rubble-scar-y) / 58% 72% no-repeat;
+  content: '';
+  opacity: var(--rubble-damage-opacity);
+  pointer-events: none;
+}
+
+.backlog-rubble__piece span,
+.backlog-rubble__piece strong {
+  position: relative;
+  z-index: 2;
+  text-shadow: 0 3px 8px rgba(0, 0, 0, 0.95);
+}
+
+.backlog-rubble__piece span {
+  color: rgba(188, 184, 182, 0.44);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.backlog-rubble__piece strong {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backlog-rubble__piece:hover,
+.backlog-rubble__piece:focus-visible {
+  z-index: 100;
+  color: rgba(231, 228, 226, 0.82);
+  filter: grayscale(0.58) saturate(0.38) brightness(0.65)
+    drop-shadow(0 18px 24px rgba(0, 0, 0, 0.58));
+  outline: none;
+  transform: translateX(-50%) translateY(-18px) rotate(0deg) scale(1.035);
+}
+
+.backlog-rubble__piece:focus-visible {
+  outline: 2px solid rgba(242, 164, 92, 0.62);
+  outline-offset: -7px;
+}
+
+.backlog-rubble__piece.backlog-rubble__piece--extracted {
+  z-index: 150;
+  opacity: 0;
+  pointer-events: none;
+  filter: grayscale(1) saturate(0) brightness(0.3) blur(0.7px);
+  transform: translateX(-50%) translateY(-76px) rotate(var(--rubble-rotation));
+}
+
+.rubble-memory-position {
+  width: min(360px, calc(100vw - 36px));
+}
+
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-enter-active {
+  transition:
+    opacity 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-leave-active {
+  transition:
+    opacity 200ms ease-in,
+    transform 240ms ease-in;
+}
+
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-enter-from,
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-leave-to {
+  opacity: 0;
+  transform: translateY(58px);
+}
+
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-enter-to,
+.rubble-memory-position.n-modal.fade-in-scale-up-transition-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.rubble-memory-card {
+  width: 100%;
+  overflow: hidden;
+  filter: grayscale(0.44) saturate(0.58) brightness(0.82);
+  box-shadow: 0 30px 82px rgba(0, 0, 0, 0.66);
+  transform: translateY(-32px);
+}
+
+.rubble-memory-card .backlog-card__art {
+  height: 190px;
+}
+
+@media (max-width: 820px) {
+  .backlog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .backlog-overview {
+    padding: 34px;
+  }
+}
+
+@media (max-width: 640px) {
+  .top-navigation__links {
+    gap: 14px;
+  }
+
+  .top-navigation__account {
+    margin-left: 12px;
+    padding-left: 12px;
+  }
+
+  .backlog-overview {
+    margin-bottom: 52px;
+    padding: 29px 25px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .backlog-limit {
+    min-width: 0;
+    padding: 16px 0 0;
+    border-top: 1px solid rgba(242, 164, 92, 0.18);
+    border-left: 0;
+  }
+
+  .backlog-limit strong {
+    font-size: 42px;
+  }
+
+  .backlog-rubble {
+    margin-top: 320px;
+  }
+
+  .backlog-rubble__pile {
+    margin-top: 140px;
+  }
+
+  .backlog-rubble__piece {
+    padding: 11px;
+  }
+
+  .backlog-rubble__piece span {
+    font-size: 7px;
+  }
+
+  .backlog-rubble__piece strong {
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 500px) {
+  .backlog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .backlog-card__art {
+    height: 185px;
+  }
+
+  .backlog-loading,
+  .backlog-empty {
+    min-height: 260px;
+    padding: 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backlog-card,
+  .backlog-rubble__pile,
+  .backlog-rubble__piece {
+    transition: none;
+  }
+
+  .rubble-memory-position.n-modal.fade-in-scale-up-transition-enter-active,
+  .rubble-memory-position.n-modal.fade-in-scale-up-transition-leave-active {
+    transition: none;
+  }
+
+  .backlog-rubble__piece:hover,
+  .backlog-rubble__piece:focus-visible {
+    transform: translateX(-50%) rotate(var(--rubble-rotation));
   }
 }

--- a/client/src/components/TopNavigation.vue
+++ b/client/src/components/TopNavigation.vue
@@ -51,6 +51,7 @@ const logout = async () => {
       <div class="top-navigation__links">
         <RouterLink to="/" class="top-navigation__link">Início</RouterLink>
         <RouterLink to="/campanhas" class="top-navigation__link">Campanhas</RouterLink>
+        <RouterLink to="/brasas" class="top-navigation__link">Brasas</RouterLink>
         <RouterLink to="/regras" class="top-navigation__link">Regras</RouterLink>
       </div>
 

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -30,6 +30,19 @@ const router = createRouter({
       },
     },
     {
+      path: '/brasas',
+      name: 'brasas',
+      component: () => import('../views/Backlog.vue'),
+      meta: {
+        pageTitle: 'Brasas',
+        pageKicker: 'Jogos que ainda podem acender a fogueira',
+      },
+    },
+    {
+      path: '/lenha',
+      redirect: '/brasas',
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: AuthCallbackPage,

--- a/client/src/services/gameService.ts
+++ b/client/src/services/gameService.ts
@@ -1,4 +1,10 @@
-﻿import type { Game } from '@/types/Game'
+﻿import api from './api'
+import type { Game, GameBacklog } from '@/types/Game'
+
+export const getGameBacklog = async (): Promise<GameBacklog> => {
+  const { data } = await api.get<GameBacklog>('/games/backlog')
+  return data
+}
 
 export const getGameCover = (game?: Game | null): string => {
   return game?.cover || ''

--- a/client/src/types/Campaign.ts
+++ b/client/src/types/Campaign.ts
@@ -19,6 +19,7 @@ export interface CampaignPlayer {
   played_the_game: boolean
   finished_the_game: boolean
   suggested_a_game: boolean
+  suggestedGame?: Game | null
   partook_in_the_meeting: boolean
   tokens: number
 }

--- a/client/src/types/Game.ts
+++ b/client/src/types/Game.ts
@@ -8,4 +8,22 @@
   summary?: string | null
   howLongToBeatUrl?: string | null
   durationLabel?: string | null
+  recommendedBy?: GameRecommender[]
+}
+
+export interface GameRecommender {
+  id: number
+  name: string
+  avatar?: string | null
+}
+
+export interface BacklogGame extends Game {
+  electionAppearances: number
+  recommendedBy: GameRecommender[]
+}
+
+export interface GameBacklog {
+  games: BacklogGame[]
+  rubble: BacklogGame[]
+  retirementThreshold: number
 }

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -1,0 +1,617 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
+import { NIcon, NModal, NSpin, NTooltip } from 'naive-ui'
+import { formatDurationLabel, getGameBacklog, getGameCover } from '@/services/gameService'
+import type { BacklogGame, GameBacklog, GameRecommender } from '@/types/Game'
+
+const backlog = ref<GameBacklog | null>(null)
+const loading = ref(true)
+const loadFailed = ref(false)
+const rubbleShuffling = ref(false)
+const extractedRubbleIndex = ref<number | null>(null)
+const selectedRubbleGame = ref<BacklogGame | null>(null)
+const rubbleModalOpen = ref(false)
+const failedRecommenderAvatars = ref(new Set<string>())
+
+const backlogCountLabel = computed(() => {
+  const count = backlog.value?.games.length ?? 0
+  return `${count} ${count === 1 ? 'jogo' : 'jogos'} à espera da fogueira`
+})
+
+const appearanceLabel = (count: number) => {
+  if (count === 0) return 'Ainda não passou'
+  return `${count} ${count === 1 ? 'passagem' : 'passagens'}`
+}
+
+const coverStyle = (game: BacklogGame) => ({
+  backgroundImage: getGameCover(game) ? `url('${getGameCover(game)}')` : undefined,
+})
+
+const recommenderAvatarKey = (gameId: number, recommenderId: number) => `${gameId}:${recommenderId}`
+
+const hasRecommenderAvatar = (game: BacklogGame, recommender: GameRecommender) =>
+  Boolean(recommender.avatar) &&
+  !failedRecommenderAvatars.value.has(recommenderAvatarKey(game.id, recommender.id))
+
+const markRecommenderAvatarFailed = (game: BacklogGame, recommender: GameRecommender) => {
+  failedRecommenderAvatars.value = new Set(failedRecommenderAvatars.value).add(
+    recommenderAvatarKey(game.id, recommender.id),
+  )
+}
+
+const recommenderInitial = (recommender: GameRecommender) =>
+  recommender.name.trim().charAt(0).toLocaleUpperCase('pt-BR') || '?'
+
+const visibleRecommenders = (game: BacklogGame) => (game.recommendedBy ?? []).slice(0, 3)
+
+const hiddenRecommenderNames = (game: BacklogGame) =>
+  (game.recommendedBy ?? [])
+    .slice(3)
+    .map((recommender) => recommender.name)
+    .join(', ')
+
+interface RubblePieceLayout {
+  style: Record<string, string>
+  top: number
+}
+
+interface RubblePileLayout {
+  height: number
+  pieces: RubblePieceLayout[]
+}
+
+const viewportWidth = ref(1280)
+const rubbleLayoutWidth = ref(1280)
+const rubbleSeed = Math.floor(Math.random() * 0xffffffff)
+let resizeFrame: number | undefined
+let resizeTimer: number | undefined
+let extractionTimer: number | undefined
+
+const createSeededRandom = (seed: number) => {
+  let state = seed >>> 0
+
+  return () => {
+    state += 0x6d2b79f5
+    let value = state
+    value = Math.imul(value ^ (value >>> 15), value | 1)
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61)
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(maximum, Math.max(minimum, value))
+
+const createDamageMask = (random: () => number, damage: number) => {
+  const tear = (minimum: number, range: number) => minimum + random() * range * damage
+
+  return `polygon(
+    ${tear(0, 10)}% ${tear(0, 17)}%,
+    ${tear(19, 13)}% ${tear(0, 8)}%,
+    ${tear(48, 12)}% ${tear(0, 14)}%,
+    ${tear(76, 12)}% ${tear(0, 10)}%,
+    ${100 - tear(0, 9)}% ${tear(1, 22)}%,
+    ${100 - tear(0, 12)}% ${tear(65, 20)}%,
+    ${100 - tear(4, 20)}% ${100 - tear(0, 14)}%,
+    ${tear(53, 17)}% ${100 - tear(0, 12)}%,
+    ${tear(20, 20)}% ${100 - tear(0, 17)}%,
+    ${tear(0, 12)}% ${100 - tear(5, 22)}%
+  )`
+}
+
+const createRubbleLayout = (total: number, availableWidth: number): RubblePileLayout => {
+  if (!total) return { height: 360, pieces: [] }
+
+  const width = Math.max(320, availableWidth)
+  const mobile = width < 640
+  const random = createSeededRandom(rubbleSeed + (mobile ? 1 : 0))
+  const baseWidth = mobile ? clamp(width * 0.78, 258, 310) : clamp(width * 0.215, 285, 320)
+  const groundCount = Math.min(total, Math.max(2, Math.round(width / (baseWidth * 0.92))))
+  const surfaceBinCount = Math.max(18, Math.ceil(width / (mobile ? 18 : 24)))
+  const surface = Array.from<number>({ length: surfaceBinCount }).fill(0)
+  const pieces: RubblePieceLayout[] = []
+
+  const surfaceRange = (left: number, pieceWidth: number) => {
+    const first = clamp(
+      Math.floor(((left - pieceWidth * 0.38) / width) * (surfaceBinCount - 1)),
+      0,
+      surfaceBinCount - 1,
+    )
+    const last = clamp(
+      Math.ceil(((left + pieceWidth * 0.38) / width) * (surfaceBinCount - 1)),
+      first,
+      surfaceBinCount - 1,
+    )
+
+    return { first, last }
+  }
+
+  const getSupport = (left: number, pieceWidth: number) => {
+    const { first, last } = surfaceRange(left, pieceWidth)
+    const values = surface.slice(first, last + 1).sort((a, b) => a - b)
+    const support = values[Math.floor((values.length - 1) * 0.56)] ?? 0
+
+    return { first, last, support }
+  }
+
+  const updateSurface = (first: number, last: number, bottom: number, pieceHeight: number) => {
+    const middle = (first + last) / 2
+    const radius = Math.max(1, (last - first) / 2)
+
+    for (let bin = first; bin <= last; bin += 1) {
+      const distance = Math.min(1, Math.abs(bin - middle) / radius)
+      const top = bottom + pieceHeight * (0.79 + Math.cos(distance * Math.PI * 0.5) * 0.21)
+      surface[bin] = Math.max(surface[bin] ?? 0, top)
+    }
+  }
+
+  for (let index = 0; index < total; index += 1) {
+    const groundPiece = index < groundCount
+    const damage = 0.2 + random() * 0.8
+    const pieceWidth = clamp(
+      baseWidth * (0.92 + random() * 0.16),
+      mobile ? 250 : 275,
+      mobile ? Math.min(325, width * 0.88) : 340,
+    )
+    const pieceHeight = clamp(pieceWidth * (0.56 + random() * 0.1), 158, mobile ? 218 : 225)
+    let left: number
+    let supportData: ReturnType<typeof getSupport>
+
+    if (groundPiece) {
+      const slotWidth = width / groundCount
+      left = slotWidth * (index + 0.5) + (random() - 0.5) * slotWidth * 0.12
+      supportData = getSupport(left, Math.max(pieceWidth, slotWidth * 1.12))
+    } else {
+      const progress = (index - groundCount) / Math.max(1, total - groundCount - 1)
+      const spread = 1 - progress * 0.18
+      let bestCandidate = width / 2
+      let bestScore = Number.NEGATIVE_INFINITY
+
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        const triangular = random() + random() - 1
+        const candidate = clamp(width / 2 + triangular * width * 0.57 * spread, 0, width)
+        const candidateSupport = getSupport(candidate, pieceWidth).support
+        const centrality = 1 - Math.abs(candidate - width / 2) / (width / 2)
+        const score =
+          centrality * baseWidth * (0.28 + progress * 0.18) -
+          candidateSupport * 0.58 +
+          random() * 36
+
+        if (score > bestScore) {
+          bestScore = score
+          bestCandidate = candidate
+        }
+      }
+
+      left = bestCandidate
+      supportData = getSupport(left, pieceWidth)
+    }
+
+    const bottom = groundPiece
+      ? -16 + random() * 18
+      : Math.max(8, supportData.support - pieceHeight * (0.4 + random() * 0.1))
+    const leftSupport = surface[supportData.first] ?? 0
+    const rightSupport = surface[supportData.last] ?? 0
+    const surfaceAngle = Math.atan2(rightSupport - leftSupport, pieceWidth) * (180 / Math.PI)
+    const rotation = surfaceAngle * 0.45 + (random() - 0.5) * (damage > 0.76 ? 13 : 7)
+    const top = bottom + pieceHeight
+
+    pieces.push({
+      top,
+      style: {
+        left: `${(left / width) * 100}%`,
+        bottom: `${bottom}px`,
+        width: `${pieceWidth}px`,
+        height: `${pieceHeight}px`,
+        clipPath: createDamageMask(random, damage),
+        '--rubble-rotation': `${rotation}deg`,
+        '--rubble-layer': String(10 + index),
+        '--rubble-brightness': String(0.34 + (1 - damage) * 0.18 + random() * 0.06),
+        '--rubble-saturation': String(0.08 + (1 - damage) * 0.18),
+        '--rubble-damage-opacity': String(0.2 + damage * 0.68),
+        '--rubble-scar-angle': `${18 + random() * 125}deg`,
+        '--rubble-scar-x': `${15 + random() * 70}%`,
+        '--rubble-scar-y': `${12 + random() * 64}%`,
+      },
+    })
+
+    updateSurface(supportData.first, supportData.last, bottom, pieceHeight)
+  }
+
+  const pileHeight = Math.max(360, ...pieces.map((piece) => piece.top + 34))
+
+  return { height: pileHeight, pieces }
+}
+
+const displayedRubbleCount = computed(() => (backlog.value?.rubble.length ?? 0) * 3)
+const rubbleLayout = computed(() =>
+  createRubbleLayout(displayedRubbleCount.value, rubbleLayoutWidth.value),
+)
+
+const rubblePileStyle = computed(() => ({
+  '--rubble-pile-height': `${rubbleLayout.value.height}px`,
+}))
+
+const rubbleSectionStyle = computed(() => ({
+  '--rubble-viewport-width': `${viewportWidth.value}px`,
+}))
+
+const rubblePlacement = (game: BacklogGame, index: number): Record<string, string> => ({
+  backgroundImage: getGameCover(game) ? `url('${getGameCover(game)}')` : 'none',
+  ...rubbleLayout.value.pieces[index]?.style,
+})
+
+const openRubbleGame = (game: BacklogGame, index: number) => {
+  if (extractedRubbleIndex.value !== null) return
+
+  extractedRubbleIndex.value = index
+  selectedRubbleGame.value = game
+  extractionTimer = window.setTimeout(() => {
+    rubbleModalOpen.value = true
+    extractionTimer = undefined
+  }, 220)
+}
+
+const restoreRubbleGame = () => {
+  extractedRubbleIndex.value = null
+  selectedRubbleGame.value = null
+}
+
+const updateViewportWidth = () => {
+  if (resizeFrame) window.cancelAnimationFrame(resizeFrame)
+  resizeFrame = window.requestAnimationFrame(() => {
+    const nextWidth = document.documentElement.clientWidth
+    const crossedMobileBreakpoint =
+      (rubbleLayoutWidth.value < 640 && nextWidth >= 640) ||
+      (rubbleLayoutWidth.value >= 640 && nextWidth < 640)
+
+    viewportWidth.value = nextWidth
+
+    const requiresReshuffle =
+      crossedMobileBreakpoint || Math.abs(nextWidth - rubbleLayoutWidth.value) > 220
+
+    if (requiresReshuffle) {
+      rubbleShuffling.value = true
+      if (resizeTimer) window.clearTimeout(resizeTimer)
+      resizeTimer = window.setTimeout(async () => {
+        rubbleLayoutWidth.value = document.documentElement.clientWidth
+        resizeTimer = undefined
+        await nextTick()
+        window.requestAnimationFrame(() => {
+          rubbleShuffling.value = false
+        })
+      }, 240)
+    } else if (resizeTimer) {
+      window.clearTimeout(resizeTimer)
+      resizeTimer = undefined
+      rubbleShuffling.value = false
+    }
+  })
+}
+
+const loadBacklog = async () => {
+  loading.value = true
+  loadFailed.value = false
+
+  try {
+    backlog.value = await getGameBacklog()
+  } catch {
+    loadFailed.value = true
+  } finally {
+    loading.value = false
+    updateViewportWidth()
+  }
+}
+
+onMounted(() => {
+  const initialWidth = document.documentElement.clientWidth
+  viewportWidth.value = initialWidth
+  rubbleLayoutWidth.value = initialWidth
+  window.addEventListener('resize', updateViewportWidth, { passive: true })
+  void loadBacklog()
+})
+
+onBeforeUnmount(() => {
+  if (resizeFrame) window.cancelAnimationFrame(resizeFrame)
+  if (resizeTimer) window.clearTimeout(resizeTimer)
+  if (extractionTimer) window.clearTimeout(extractionTimer)
+  window.removeEventListener('resize', updateViewportWidth)
+})
+</script>
+
+<template>
+  <section class="backlog-page" aria-label="Brasas">
+    <n-modal
+      v-model:show="rubbleModalOpen"
+      :block-scroll="false"
+      :mask-closable="true"
+      transform-origin="center"
+      @after-leave="restoreRubbleGame"
+    >
+      <div v-if="selectedRubbleGame && backlog" class="rubble-memory-position">
+        <article
+          class="backlog-card rubble-memory-card"
+          :aria-label="`Lembrança de ${selectedRubbleGame.title}`"
+        >
+          <div class="backlog-card__art" :style="coverStyle(selectedRubbleGame)">
+            <div class="backlog-card__shade"></div>
+
+            <span class="backlog-card__count">
+              <strong>{{ selectedRubbleGame.electionAppearances }}</strong>
+              / {{ backlog.retirementThreshold }}
+            </span>
+
+            <header class="backlog-card__title">
+              <h3>{{ selectedRubbleGame.title }}</h3>
+            </header>
+          </div>
+
+          <footer class="backlog-card__footer">
+            <div class="backlog-card__history">
+              <div
+                class="backlog-embers"
+                :aria-label="appearanceLabel(selectedRubbleGame.electionAppearances)"
+              >
+                <span
+                  v-for="position in backlog.retirementThreshold"
+                  :key="position"
+                  :class="{
+                    'backlog-ember--lit': position <= selectedRubbleGame.electionAppearances,
+                  }"
+                  aria-hidden="true"
+                ></span>
+              </div>
+              <span>{{ appearanceLabel(selectedRubbleGame.electionAppearances) }}</span>
+            </div>
+
+            <div
+              v-if="selectedRubbleGame.recommendedBy?.length"
+              class="backlog-card__recommenders"
+              aria-label="Pessoas que apresentaram este jogo ao grupo"
+            >
+              <n-tooltip
+                v-for="recommender in visibleRecommenders(selectedRubbleGame)"
+                :key="recommender.id"
+                placement="top"
+              >
+                <template #trigger>
+                  <span
+                    class="backlog-recommender"
+                    tabindex="0"
+                    :aria-label="`Apresentado por ${recommender.name}`"
+                  >
+                    <img
+                      v-if="hasRecommenderAvatar(selectedRubbleGame, recommender)"
+                      :src="recommender.avatar ?? undefined"
+                      alt=""
+                      @error="markRecommenderAvatarFailed(selectedRubbleGame, recommender)"
+                    />
+                    <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
+                  </span>
+                </template>
+                Apresentado por {{ recommender.name }}
+              </n-tooltip>
+
+              <n-tooltip v-if="selectedRubbleGame.recommendedBy.length > 3" placement="top">
+                <template #trigger>
+                  <span
+                    class="backlog-recommender backlog-recommender--more"
+                    tabindex="0"
+                    :aria-label="`Mais ${selectedRubbleGame.recommendedBy.length - 3} pessoas apresentaram este jogo`"
+                  >
+                    +{{ selectedRubbleGame.recommendedBy.length - 3 }}
+                  </span>
+                </template>
+                Também apresentado por {{ hiddenRecommenderNames(selectedRubbleGame) }}
+              </n-tooltip>
+            </div>
+
+            <nav class="backlog-card__links" :aria-label="`Links de ${selectedRubbleGame.title}`">
+              <a
+                v-if="selectedRubbleGame.steam"
+                :href="selectedRubbleGame.steam"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Abrir na Steam"
+              >
+                <n-icon size="17"><LogoSteam /></n-icon>
+              </a>
+              <a
+                v-if="selectedRubbleGame.trailer"
+                :href="selectedRubbleGame.trailer"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Assistir ao trailer"
+              >
+                <n-icon size="17"><LogoYoutube /></n-icon>
+              </a>
+              <a
+                v-if="selectedRubbleGame.howLongToBeatUrl"
+                :href="selectedRubbleGame.howLongToBeatUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                :aria-label="`Ver duração${formatDurationLabel(selectedRubbleGame.durationLabel) ? `: ${formatDurationLabel(selectedRubbleGame.durationLabel)}` : ''}`"
+              >
+                <n-icon size="17"><TimeOutline /></n-icon>
+              </a>
+            </nav>
+          </footer>
+        </article>
+      </div>
+    </n-modal>
+
+    <div v-if="loading" class="main-block backlog-loading" role="status" aria-live="polite">
+      <n-spin :size="34" :stroke-width="12" stroke="#e7a06c" />
+      <span>Avivando as brasas…</span>
+    </div>
+
+    <div v-else-if="loadFailed" class="main-block backlog-empty backlog-empty--error">
+      <span class="backlog-eyebrow">A chama baixou</span>
+      <h2>Não conseguimos carregar as Brasas</h2>
+      <p>Podemos tentar reunir os jogos novamente.</p>
+      <button type="button" class="backlog-retry" @click="loadBacklog">Tentar novamente</button>
+    </div>
+
+    <template v-else-if="backlog && (backlog.games.length || backlog.rubble.length)">
+      <header class="backlog-overview">
+        <div class="backlog-overview__copy">
+          <span class="backlog-eyebrow">Ainda há calor</span>
+          <h2 id="backlog-heading">{{ backlogCountLabel }}</h2>
+          <p>
+            Jogos sugeridos que ainda podem ser escolhidos para uma jornada. Cada um ainda guarda a
+            chance de ganhar um lugar junto à fogueira.
+          </p>
+        </div>
+
+        <div class="backlog-limit" aria-label="Limite de passagens antes de virar cinza">
+          <strong>{{ backlog.retirementThreshold }}</strong>
+          <span>passagens<br />até as cinzas</span>
+        </div>
+      </header>
+
+      <div class="backlog-grid" aria-label="Jogos que ainda guardam calor">
+        <article v-for="game in backlog.games" :key="game.id" class="backlog-card">
+          <div class="backlog-card__art" :style="coverStyle(game)">
+            <div class="backlog-card__shade"></div>
+
+            <span class="backlog-card__count">
+              <strong>{{ game.electionAppearances }}</strong>
+              / {{ backlog.retirementThreshold }}
+            </span>
+
+            <header class="backlog-card__title">
+              <h3>{{ game.title }}</h3>
+            </header>
+          </div>
+
+          <footer class="backlog-card__footer">
+            <div class="backlog-card__history">
+              <div
+                class="backlog-embers"
+                :aria-label="`${appearanceLabel(game.electionAppearances)} de ${backlog.retirementThreshold} antes de virar cinza`"
+              >
+                <span
+                  v-for="position in backlog.retirementThreshold"
+                  :key="position"
+                  :class="{ 'backlog-ember--lit': position <= game.electionAppearances }"
+                  aria-hidden="true"
+                ></span>
+              </div>
+              <span>{{ appearanceLabel(game.electionAppearances) }}</span>
+            </div>
+
+            <div
+              v-if="game.recommendedBy?.length"
+              class="backlog-card__recommenders"
+              aria-label="Pessoas que apresentaram este jogo ao grupo"
+            >
+              <n-tooltip
+                v-for="recommender in visibleRecommenders(game)"
+                :key="recommender.id"
+                placement="top"
+              >
+                <template #trigger>
+                  <span
+                    class="backlog-recommender"
+                    tabindex="0"
+                    :aria-label="`Apresentado por ${recommender.name}`"
+                  >
+                    <img
+                      v-if="hasRecommenderAvatar(game, recommender)"
+                      :src="recommender.avatar ?? undefined"
+                      alt=""
+                      @error="markRecommenderAvatarFailed(game, recommender)"
+                    />
+                    <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
+                  </span>
+                </template>
+                Apresentado por {{ recommender.name }}
+              </n-tooltip>
+
+              <n-tooltip v-if="game.recommendedBy.length > 3" placement="top">
+                <template #trigger>
+                  <span
+                    class="backlog-recommender backlog-recommender--more"
+                    tabindex="0"
+                    :aria-label="`Mais ${game.recommendedBy.length - 3} pessoas apresentaram este jogo`"
+                  >
+                    +{{ game.recommendedBy.length - 3 }}
+                  </span>
+                </template>
+                Também apresentado por {{ hiddenRecommenderNames(game) }}
+              </n-tooltip>
+            </div>
+
+            <nav class="backlog-card__links" :aria-label="`Links de ${game.title}`">
+              <a
+                v-if="game.steam"
+                :href="game.steam"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Abrir na Steam"
+              >
+                <n-icon size="17"><LogoSteam /></n-icon>
+              </a>
+              <a
+                v-if="game.trailer"
+                :href="game.trailer"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Assistir ao trailer"
+              >
+                <n-icon size="17"><LogoYoutube /></n-icon>
+              </a>
+              <a
+                v-if="game.howLongToBeatUrl"
+                :href="game.howLongToBeatUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                :aria-label="`Ver duração${formatDurationLabel(game.durationLabel) ? `: ${formatDurationLabel(game.durationLabel)}` : ''}`"
+              >
+                <n-icon size="17"><TimeOutline /></n-icon>
+              </a>
+            </nav>
+          </footer>
+        </article>
+      </div>
+
+      <section
+        v-if="backlog.rubble.length"
+        class="backlog-rubble"
+        aria-label="Jogos que viraram cinza"
+        :style="rubbleSectionStyle"
+      >
+        <h2 class="backlog-rubble__title">Cinzas</h2>
+
+        <div
+          class="backlog-rubble__pile"
+          :class="{ 'backlog-rubble__pile--shuffling': rubbleShuffling }"
+          :style="rubblePileStyle"
+        >
+          <button
+            v-for="(game, index) in backlog.rubble"
+            :key="`${game.id}-${index}`"
+            type="button"
+            class="backlog-rubble__piece"
+            :class="{
+              'backlog-rubble__piece--extracted': extractedRubbleIndex === index,
+            }"
+            :style="rubblePlacement(game, index)"
+            :aria-label="`${game.title}, ${game.electionAppearances} passagens sem ser escolhido. Ver lembrança`"
+            @click="openRubbleGame(game, index)"
+          >
+            <span>{{ game.electionAppearances }} passagens</span>
+            <strong>{{ game.title }}</strong>
+          </button>
+        </div>
+      </section>
+    </template>
+
+    <div v-else class="main-block backlog-empty">
+      <span class="backlog-eyebrow">Nenhuma brasa por aqui</span>
+      <h2>Nenhum jogo está esperando</h2>
+      <p>As próximas sugestões vão aparecer aqui quando chegarem à fogueira.</p>
+    </div>
+  </section>
+</template>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -81,8 +81,16 @@ pnpm run build:mcp
       "partook_in_the_meeting": true,
       "played_the_game": true,
       "finished_the_game": false,
-      "suggested_a_game": false
+      "suggestedGameTitle": "Hades"
+    }
+  ],
+  "recommendations": [
+    {
+      "player": { "playerId": 3 },
+      "gameTitle": "Outer Wilds"
     }
   ]
 }
 ```
+
+Use `recommendations` for verified historical game-to-person provenance when the original campaign is unknown. It updates the game's recommender registry without inventing a campaign participation.

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -111,7 +111,7 @@ server.registerTool(
   {
     title: "Preview monthly plan",
     description:
-      "Validates a full monthly campaign update and returns a safe diff plus confirmation token. This does not modify data.",
+      "Validates a full monthly campaign update, including historical game recommender provenance, and returns a safe diff plus confirmation token. This does not modify data.",
     inputSchema: monthlyPlanSchema.shape,
   },
   async (input) =>
@@ -183,7 +183,7 @@ server.registerTool(
   {
     title: "Bulk update campaign participants",
     description:
-      "Adds or updates campaign participant flags: meeting attendance, played, finished, and suggested game.",
+      "Adds or updates campaign participant flags and optionally records the exact suggested game by ID or title.",
     inputSchema: bulkParticipantsSchema.shape,
   },
   async ({ campaignId, participants }) =>

--- a/mcp/src/schemas.ts
+++ b/mcp/src/schemas.ts
@@ -50,6 +50,14 @@ export const participantInputSchema = z.object({
   finished_the_game: z.boolean().optional(),
   partook_in_the_meeting: z.boolean().optional(),
   suggested_a_game: z.boolean().optional(),
+  suggestedGameId: z.number().int().positive().optional(),
+  suggestedGameTitle: z.string().min(1).optional(),
+});
+
+export const gameRecommendationInputSchema = z.object({
+  player: playerReferenceSchema,
+  gameId: z.number().int().positive().optional(),
+  gameTitle: z.string().min(1).optional(),
 });
 
 export const monthlyPlanSchema = z.object({
@@ -57,6 +65,7 @@ export const monthlyPlanSchema = z.object({
   games: z.array(gameInputSchema).optional(),
   pool: poolInputSchema.optional(),
   participants: z.array(participantInputSchema).optional(),
+  recommendations: z.array(gameRecommendationInputSchema).optional(),
 });
 
 export const applyMonthlyPlanSchema = monthlyPlanSchema.extend({

--- a/server/src/admin/admin.module.ts
+++ b/server/src/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { ContentModule } from '../content/content.module';
 import { Game } from '../games/entities/game.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -21,6 +22,7 @@ import { AdminApiKeyGuard } from './guards/admin-api-key.guard';
       Campaign,
       CampaignPlayer,
       Game,
+      GameRecommendation,
       Player,
       Pool,
       PoolOption,

--- a/server/src/admin/admin.service.spec.ts
+++ b/server/src/admin/admin.service.spec.ts
@@ -1,0 +1,188 @@
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { ContentService } from '../content/content.service';
+import { Game } from '../games/entities/game.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
+import { Player } from '../players/entities/player.entity';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Pool } from '../pool/entities/pool.entity';
+import { AdminService } from './admin.service';
+import { AdminAuditLog } from './entities/admin-audit-log.entity';
+
+describe('AdminService game recommendations', () => {
+  let dataSource: DataSource;
+  let service: AdminService;
+  let campaign: Campaign;
+  let player: Player;
+  let game: Game;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqljs',
+      entities: [
+        AdminAuditLog,
+        Campaign,
+        CampaignPlayer,
+        Game,
+        GameRecommendation,
+        Player,
+        Pool,
+        PoolOption,
+      ],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+
+    service = new AdminService(
+      dataSource.getRepository(Campaign),
+      dataSource.getRepository(CampaignPlayer),
+      dataSource.getRepository(Game),
+      dataSource.getRepository(GameRecommendation),
+      dataSource.getRepository(Player),
+      dataSource.getRepository(Pool),
+      dataSource,
+      new ConfigService({ MCP_ADMIN_TOKEN: 'test-token' }),
+      {} as ContentService,
+    );
+
+    campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Player' }));
+    game = await dataSource.getRepository(Game).save(
+      dataSource.getRepository(Game).create({
+        title: 'Known recommendation',
+        suggestion: true,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('derives the boolean from a game ID and clears both fields explicitly', async () => {
+    const updated = await service.bulkUpdateCampaignParticipants(campaign.id, {
+      participants: [
+        {
+          player: { playerId: player.id },
+          suggestedGameId: game.id,
+        },
+      ],
+    });
+
+    expect(updated.players[0]).toMatchObject({
+      suggested_a_game: true,
+      suggestedGame: { id: game.id, title: game.title },
+    });
+    await expect(
+      dataSource.getRepository(GameRecommendation).findOne({
+        where: { game: { id: game.id }, player: { id: player.id } },
+      }),
+    ).resolves.toBeTruthy();
+
+    const cleared = await service.bulkUpdateCampaignParticipants(campaign.id, {
+      participants: [
+        {
+          player: { playerId: player.id },
+          suggested_a_game: false,
+        },
+      ],
+    });
+
+    expect(cleared.players[0].suggested_a_game).toBe(false);
+    expect(cleared.players[0].suggestedGame).toBeNull();
+  });
+
+  it('links a newly created game by title through the previewed monthly plan', async () => {
+    const plan = {
+      campaign: { id: campaign.id },
+      games: [{ title: 'New recommendation', suggestion: true }],
+      participants: [
+        {
+          player: { playerId: player.id },
+          suggestedGameTitle: 'New recommendation',
+        },
+      ],
+    };
+    const preview = await service.previewMonthlyPlan(plan);
+    const participantAction = preview.actions.find(
+      (action) => action.entity === 'campaign_player',
+    );
+
+    expect(preview.valid).toBe(true);
+    expect(participantAction?.details).toMatchObject({
+      suggested_a_game: true,
+      suggestedGame: { title: 'New recommendation' },
+    });
+
+    const result = await service.applyMonthlyPlan({
+      ...plan,
+      confirm: true,
+      confirmationToken: preview.confirmationToken ?? '',
+    });
+
+    expect(result.campaign.players[0]).toMatchObject({
+      suggested_a_game: true,
+      suggestedGame: { title: 'New recommendation' },
+    });
+  });
+
+  it('rejects a game reference combined with a false suggestion flag', async () => {
+    const preview = await service.previewMonthlyPlan({
+      campaign: { id: campaign.id },
+      participants: [
+        {
+          player: { playerId: player.id },
+          suggested_a_game: false,
+          suggestedGameId: game.id,
+        },
+      ],
+    });
+
+    expect(preview.valid).toBe(false);
+    expect(preview.errors).toContain(
+      'A suggested game cannot be attached when suggested_a_game is false.',
+    );
+  });
+
+  it('records historical provenance without inventing a campaign suggestion', async () => {
+    const plan = {
+      campaign: { id: campaign.id },
+      recommendations: [{ player: { playerId: player.id }, gameId: game.id }],
+    };
+    const preview = await service.previewMonthlyPlan(plan);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.actions).toContainEqual(
+      expect.objectContaining({
+        type: 'create',
+        entity: 'game_recommendation',
+      }),
+    );
+
+    await service.applyMonthlyPlan({
+      ...plan,
+      confirm: true,
+      confirmationToken: preview.confirmationToken ?? '',
+    });
+
+    await expect(
+      dataSource.getRepository(GameRecommendation).findOne({
+        where: { game: { id: game.id }, player: { id: player.id } },
+      }),
+    ).resolves.toBeTruthy();
+    await expect(
+      dataSource.getRepository(CampaignPlayer).count(),
+    ).resolves.toBe(0);
+  });
+});

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -12,6 +12,7 @@ import { Campaign } from '../campaign/entities/campaign.entity';
 import { ContentService } from '../content/content.service';
 import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -25,6 +26,7 @@ import {
 } from './dto/admin-operations.dto';
 import {
   AdminCampaignInputDto,
+  AdminGameRecommendationInputDto,
   AdminGameInputDto,
   AdminParticipantInputDto,
   AdminPlayerReferenceDto,
@@ -66,10 +68,16 @@ export interface ElectionResultOption {
   voters: string[];
 }
 
+interface SuggestedGameReference {
+  id?: number;
+  title: string;
+}
+
 const campaignRelations = [
   'game',
   'players',
   'players.player',
+  'players.suggestedGame',
   'pool',
   'pool.options',
   'pool.options.game',
@@ -121,6 +129,8 @@ export class AdminService {
     private readonly campaignPlayerRepository: Repository<CampaignPlayer>,
     @InjectRepository(Game)
     private readonly gameRepository: Repository<Game>,
+    @InjectRepository(GameRecommendation)
+    private readonly gameRecommendationRepository: Repository<GameRecommendation>,
     @InjectRepository(Player)
     private readonly playerRepository: Repository<Player>,
     @InjectRepository(Pool)
@@ -212,6 +222,7 @@ export class AdminService {
     await this.previewGames(plan.games ?? [], actions, warnings, errors);
     await this.previewPool(plan, actions, warnings, errors);
     await this.previewParticipants(plan, actions, warnings, errors);
+    await this.previewRecommendations(plan, actions, warnings, errors);
 
     return {
       valid: errors.length === 0,
@@ -290,6 +301,13 @@ export class AdminService {
         manager,
         savedCampaign,
         plan.participants ?? [],
+        savedGames,
+      );
+
+      await this.applyRecommendations(
+        manager,
+        plan.recommendations ?? [],
+        savedGames,
       );
 
       await this.writeAuditLog(manager, 'monthly_plan_applied', plan, {
@@ -700,6 +718,15 @@ export class AdminService {
     const campaign = await this.resolveCampaignForPreview(plan.campaign);
 
     for (const participant of plan.participants ?? []) {
+      const suggestedGame = await this.resolveSuggestedGameForPreview(
+        participant,
+        plan.games ?? [],
+        errors,
+      );
+      const providedDetails = this.getProvidedParticipantDetails(
+        participant,
+        suggestedGame,
+      );
       const player = await this.resolvePlayerForPreview(
         participant.player,
         warnings,
@@ -714,7 +741,7 @@ export class AdminService {
             type: 'create',
             entity: 'campaign_player',
             label,
-            details: this.getProvidedParticipantFlags(participant),
+            details: providedDetails,
           });
         }
         continue;
@@ -725,7 +752,7 @@ export class AdminService {
           type: 'update',
           entity: 'campaign_player',
           label,
-          details: this.getProvidedParticipantFlags(participant),
+          details: providedDetails,
         });
         continue;
       }
@@ -735,6 +762,7 @@ export class AdminService {
           campaign: { id: campaign.id },
           player: { id: player.id },
         },
+        relations: ['suggestedGame'],
       });
 
       if (!campaignPlayer) {
@@ -742,7 +770,7 @@ export class AdminService {
           type: 'create',
           entity: 'campaign_player',
           label,
-          details: this.getProvidedParticipantFlags(participant),
+          details: providedDetails,
         });
         continue;
       }
@@ -750,6 +778,7 @@ export class AdminService {
       const changes = this.describeParticipantChanges(
         campaignPlayer,
         participant,
+        suggestedGame,
       );
 
       actions.push(
@@ -765,6 +794,58 @@ export class AdminService {
               entity: 'campaign_player',
               label,
               details: { reason: 'already up to date' },
+            },
+      );
+    }
+  }
+
+  private async previewRecommendations(
+    plan: MonthlyPlanDto,
+    actions: PreviewAction[],
+    warnings: string[],
+    errors: string[],
+  ): Promise<void> {
+    for (const recommendation of plan.recommendations ?? []) {
+      const game = await this.resolveRecommendationGameForPreview(
+        recommendation,
+        plan.games ?? [],
+        errors,
+      );
+      const player = await this.resolvePlayerForPreview(
+        recommendation.player,
+        warnings,
+        errors,
+      );
+
+      if (!game || !player) {
+        continue;
+      }
+
+      const label = `${game.title} — ${this.describePlayerRef(
+        recommendation.player,
+        player,
+      )}`;
+      const existing = game.id
+        ? await this.gameRecommendationRepository.findOne({
+            where: {
+              game: { id: game.id },
+              player: { id: player.id },
+            },
+          })
+        : null;
+
+      actions.push(
+        existing
+          ? {
+              type: 'skip',
+              entity: 'game_recommendation',
+              label,
+              details: { reason: 'already recorded' },
+            }
+          : {
+              type: 'create',
+              entity: 'game_recommendation',
+              label,
             },
       );
     }
@@ -1089,21 +1170,139 @@ export class AdminService {
     return compact(planGames.map((game) => game.title));
   }
 
+  private async resolveSuggestedGameForPreview(
+    participant: AdminParticipantInputDto,
+    planGames: AdminGameInputDto[],
+    errors: string[],
+  ): Promise<SuggestedGameReference | undefined> {
+    try {
+      this.validateSuggestedGameInput(participant);
+    } catch (error: unknown) {
+      errors.push(
+        error instanceof Error ? error.message : 'Invalid suggested game.',
+      );
+      return undefined;
+    }
+
+    if (participant.suggestedGameId) {
+      const game = await this.gameRepository.findOneBy({
+        id: participant.suggestedGameId,
+      });
+
+      if (!game) {
+        errors.push(
+          `Could not find suggested game #${participant.suggestedGameId}.`,
+        );
+        return undefined;
+      }
+
+      return game;
+    }
+
+    if (!participant.suggestedGameTitle) {
+      return undefined;
+    }
+
+    const existingGame = await this.findGameByTitle(
+      this.dataSource.manager,
+      participant.suggestedGameTitle,
+    );
+
+    if (existingGame) {
+      return existingGame;
+    }
+
+    const plannedGame = planGames.find(
+      (game) =>
+        game.title &&
+        normalizeText(game.title) ===
+          normalizeText(participant.suggestedGameTitle ?? ''),
+    );
+
+    if (plannedGame?.title) {
+      return { id: plannedGame.id, title: plannedGame.title };
+    }
+
+    errors.push(
+      `Could not find suggested game '${participant.suggestedGameTitle}'.`,
+    );
+    return undefined;
+  }
+
+  private async resolveRecommendationGameForPreview(
+    recommendation: AdminGameRecommendationInputDto,
+    planGames: AdminGameInputDto[],
+    errors: string[],
+  ): Promise<SuggestedGameReference | undefined> {
+    const hasGameId = recommendation.gameId !== undefined;
+    const hasGameTitle = recommendation.gameTitle !== undefined;
+
+    if (hasGameId === hasGameTitle) {
+      errors.push(
+        'Every recommendation must provide exactly one of gameId or gameTitle.',
+      );
+      return undefined;
+    }
+
+    if (recommendation.gameId) {
+      const game = await this.gameRepository.findOneBy({
+        id: recommendation.gameId,
+      });
+
+      if (!game) {
+        errors.push(
+          `Could not find recommended game #${recommendation.gameId}.`,
+        );
+      }
+
+      return game ?? undefined;
+    }
+
+    const title = recommendation.gameTitle ?? '';
+    const existingGame = await this.findGameByTitle(
+      this.dataSource.manager,
+      title,
+    );
+
+    if (existingGame) {
+      return existingGame;
+    }
+
+    const plannedGame = planGames.find(
+      (game) =>
+        game.title && normalizeText(game.title) === normalizeText(title),
+    );
+
+    if (plannedGame?.title) {
+      return { id: plannedGame.id, title: plannedGame.title };
+    }
+
+    errors.push(`Could not find recommended game '${title}'.`);
+    return undefined;
+  }
+
   private async applyParticipants(
     manager: EntityManager,
     campaign: Campaign,
     participants: AdminParticipantInputDto[],
+    savedGames: Map<string, Game> = new Map(),
   ): Promise<void> {
     const campaignPlayerRepository = manager.getRepository(CampaignPlayer);
 
     for (const participant of participants) {
       const player = await this.resolvePlayer(manager, participant.player);
+      const suggestedGame = await this.resolveSuggestedGame(
+        manager,
+        participant,
+        savedGames,
+      );
 
       let campaignPlayer = await campaignPlayerRepository.findOne({
         where: {
           campaign: { id: campaign.id },
           player: { id: player.id },
         },
+        relations: ['suggestedGame'],
       });
 
       if (!campaignPlayer) {
@@ -1114,6 +1313,7 @@ export class AdminService {
           finished_the_game: false,
           partook_in_the_meeting: false,
           suggested_a_game: false,
+          suggestedGame: null,
         });
       }
 
@@ -1123,7 +1323,135 @@ export class AdminService {
         }
       }
 
+      if (suggestedGame) {
+        campaignPlayer.suggestedGame = suggestedGame;
+        campaignPlayer.suggested_a_game = true;
+        await this.ensureGameRecommendation(manager, suggestedGame, player);
+      } else if (participant.suggested_a_game === false) {
+        campaignPlayer.suggestedGame = null;
+      }
+
       await campaignPlayerRepository.save(campaignPlayer);
+    }
+  }
+
+  private async applyRecommendations(
+    manager: EntityManager,
+    recommendations: AdminGameRecommendationInputDto[],
+    savedGames: Map<string, Game>,
+  ): Promise<void> {
+    for (const recommendation of recommendations) {
+      const player = await this.resolvePlayer(manager, recommendation.player);
+      const game = await this.resolveRecommendationGame(
+        manager,
+        recommendation,
+        savedGames,
+      );
+      await this.ensureGameRecommendation(manager, game, player);
+    }
+  }
+
+  private async ensureGameRecommendation(
+    manager: EntityManager,
+    game: Game,
+    player: Player,
+  ): Promise<void> {
+    const repository = manager.getRepository(GameRecommendation);
+    const existing = await repository.findOne({
+      where: { game: { id: game.id }, player: { id: player.id } },
+    });
+
+    if (!existing) {
+      await repository.save(repository.create({ game, player }));
+    }
+  }
+
+  private async resolveSuggestedGame(
+    manager: EntityManager,
+    participant: AdminParticipantInputDto,
+    savedGames: Map<string, Game>,
+  ): Promise<Game | undefined> {
+    this.validateSuggestedGameInput(participant);
+
+    if (participant.suggestedGameId) {
+      const game = await manager.getRepository(Game).findOneBy({
+        id: participant.suggestedGameId,
+      });
+
+      if (!game) {
+        throw new BadRequestException(
+          `Could not find suggested game #${participant.suggestedGameId}.`,
+        );
+      }
+
+      return game;
+    }
+
+    if (participant.suggestedGameTitle) {
+      const game =
+        savedGames.get(normalizeText(participant.suggestedGameTitle)) ??
+        (await this.findGameByTitle(manager, participant.suggestedGameTitle));
+
+      if (!game) {
+        throw new BadRequestException(
+          `Could not find suggested game '${participant.suggestedGameTitle}'.`,
+        );
+      }
+
+      return game;
+    }
+
+    return undefined;
+  }
+
+  private async resolveRecommendationGame(
+    manager: EntityManager,
+    recommendation: AdminGameRecommendationInputDto,
+    savedGames: Map<string, Game>,
+  ): Promise<Game> {
+    const hasGameId = recommendation.gameId !== undefined;
+    const hasGameTitle = recommendation.gameTitle !== undefined;
+
+    if (hasGameId === hasGameTitle) {
+      throw new BadRequestException(
+        'Every recommendation must provide exactly one of gameId or gameTitle.',
+      );
+    }
+
+    const game = recommendation.gameId
+      ? await manager
+          .getRepository(Game)
+          .findOneBy({ id: recommendation.gameId })
+      : (savedGames.get(normalizeText(recommendation.gameTitle ?? '')) ??
+        (await this.findGameByTitle(manager, recommendation.gameTitle ?? '')));
+
+    if (!game) {
+      throw new BadRequestException(
+        recommendation.gameId
+          ? `Could not find recommended game #${recommendation.gameId}.`
+          : `Could not find recommended game '${recommendation.gameTitle}'.`,
+      );
+    }
+
+    return game;
+  }
+
+  private validateSuggestedGameInput(
+    participant: AdminParticipantInputDto,
+  ): void {
+    const hasGameId = participant.suggestedGameId !== undefined;
+    const hasGameTitle = participant.suggestedGameTitle !== undefined;
+
+    if (hasGameId && hasGameTitle) {
+      throw new BadRequestException(
+        'Provide either suggestedGameId or suggestedGameTitle, not both.',
+      );
+    }
+
+    if ((hasGameId || hasGameTitle) && participant.suggested_a_game === false) {
+      throw new BadRequestException(
+        'A suggested game cannot be attached when suggested_a_game is false.',
+      );
     }
   }
 
@@ -1476,36 +1804,73 @@ export class AdminService {
   private describeParticipantChanges(
     campaignPlayer: CampaignPlayer,
     participant: AdminParticipantInputDto,
+    suggestedGame?: SuggestedGameReference,
   ): Record<string, unknown> {
     const changes: Record<string, unknown> = {};
 
     for (const flag of participantFlags) {
-      if (
-        participant[flag] !== undefined &&
-        participant[flag] !== campaignPlayer[flag]
-      ) {
+      const targetValue =
+        flag === 'suggested_a_game' && suggestedGame ? true : participant[flag];
+
+      if (targetValue !== undefined && targetValue !== campaignPlayer[flag]) {
         changes[flag] = {
           from: campaignPlayer[flag],
-          to: participant[flag],
+          to: targetValue,
         };
       }
+    }
+
+    if (suggestedGame) {
+      const currentGame = campaignPlayer.suggestedGame;
+      const isSameGame = suggestedGame.id
+        ? currentGame?.id === suggestedGame.id
+        : currentGame
+          ? normalizeText(currentGame.title) ===
+            normalizeText(suggestedGame.title)
+          : false;
+
+      if (!isSameGame) {
+        changes.suggestedGame = {
+          from: currentGame
+            ? { id: currentGame.id, title: currentGame.title }
+            : null,
+          to: suggestedGame,
+        };
+      }
+    } else if (
+      participant.suggested_a_game === false &&
+      campaignPlayer.suggestedGame
+    ) {
+      changes.suggestedGame = {
+        from: {
+          id: campaignPlayer.suggestedGame.id,
+          title: campaignPlayer.suggestedGame.title,
+        },
+        to: null,
+      };
     }
 
     return changes;
   }
 
-  private getProvidedParticipantFlags(
+  private getProvidedParticipantDetails(
     participant: AdminParticipantInputDto,
-  ): Record<string, boolean> {
-    const flags: Record<string, boolean> = {};
+    suggestedGame?: SuggestedGameReference,
+  ): Record<string, unknown> {
+    const details: Record<string, unknown> = {};
 
     for (const flag of participantFlags) {
       if (participant[flag] !== undefined) {
-        flags[flag] = participant[flag] ?? false;
+        details[flag] = participant[flag] ?? false;
       }
     }
 
-    return flags;
+    if (suggestedGame) {
+      details.suggested_a_game = true;
+      details.suggestedGame = suggestedGame;
+    }
+
+    return details;
   }
 
   private describePlayerRef(
@@ -1553,6 +1918,7 @@ export class AdminService {
       games: dto.games,
       pool: dto.pool,
       participants: dto.participants,
+      recommendations: dto.recommendations,
     };
   }
 

--- a/server/src/admin/dto/monthly-plan.dto.ts
+++ b/server/src/admin/dto/monthly-plan.dto.ts
@@ -189,6 +189,34 @@ export class AdminParticipantInputDto {
   @IsOptional()
   @IsBoolean()
   suggested_a_game?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  suggestedGameId?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  suggestedGameTitle?: string;
+}
+
+export class AdminGameRecommendationInputDto {
+  @ValidateNested()
+  @Type(() => AdminPlayerReferenceDto)
+  player!: AdminPlayerReferenceDto;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  gameId?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  gameTitle?: string;
 }
 
 export class MonthlyPlanDto {
@@ -213,6 +241,12 @@ export class MonthlyPlanDto {
   @ValidateNested({ each: true })
   @Type(() => AdminParticipantInputDto)
   participants?: AdminParticipantInputDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AdminGameRecommendationInputDto)
+  recommendations?: AdminGameRecommendationInputDto[];
 }
 
 export class ApplyMonthlyPlanDto extends MonthlyPlanDto {

--- a/server/src/campaign/campaign.service.ts
+++ b/server/src/campaign/campaign.service.ts
@@ -83,6 +83,7 @@ export class CampaignService {
     'game',
     'players',
     'players.player',
+    'players.suggestedGame',
     'pool',
     'pool.options',
     'pool.options.game',
@@ -106,7 +107,7 @@ export class CampaignService {
 
   async findAllHistory(): Promise<Campaign[]> {
     const campaigns = await this.campaignRepository.find({
-      relations: ['game', 'players', 'players.player'],
+      relations: ['game', 'players', 'players.player', 'players.suggestedGame'],
     });
 
     return sortCampaigns(campaigns);
@@ -173,6 +174,7 @@ export class CampaignService {
         finished_the_game: false,
         partook_in_the_meeting: false,
         suggested_a_game: false,
+        suggestedGame: null,
       },
     );
 

--- a/server/src/campaign/entities/campaign-player.entity.ts
+++ b/server/src/campaign/entities/campaign-player.entity.ts
@@ -1,6 +1,7 @@
 ﻿import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -9,6 +10,7 @@
 import { Campaign } from './campaign.entity';
 import { Player } from '../../players/entities/player.entity';
 import { Expose } from 'class-transformer';
+import { Game } from '../../games/entities/game.entity';
 
 @Entity('campaign_players')
 @Unique(['campaign', 'player'])
@@ -35,6 +37,11 @@ export class CampaignPlayer {
 
   @Column({ default: false })
   suggested_a_game: boolean;
+
+  @ManyToOne(() => Game, { nullable: true, onDelete: 'SET NULL' })
+  @Index('IDX_campaign_players_suggested_game')
+  @JoinColumn({ name: 'suggested_game_id' })
+  suggestedGame?: Game | null;
 
   @Expose()
   get tokens(): number {

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -3,12 +3,16 @@ import type { DataSourceOptions } from 'typeorm';
 import { AdminAutomation1763760000000 } from './migrations/1763760000000-AdminAutomation';
 import { SiteContent1785729600000 } from './migrations/1785729600000-SiteContent';
 import { CurrentGameDetails1785736800000 } from './migrations/1785736800000-CurrentGameDetails';
+import { GameRecommendations1785795104186 } from './migrations/1785795104186-GameRecommendations';
+import { GameRecommendationRegistry1785796200000 } from './migrations/1785796200000-GameRecommendationRegistry';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
 const safeRuntimeMigrations = [
   AdminAutomation1763760000000,
   SiteContent1785729600000,
   CurrentGameDetails1785736800000,
+  GameRecommendations1785795104186,
+  GameRecommendationRegistry1785796200000,
 ];
 
 const getDatabasePort = (): number => {

--- a/server/src/db/migrations/1785795104186-GameRecommendations.ts
+++ b/server/src/db/migrations/1785795104186-GameRecommendations.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class GameRecommendations1785795104186 implements MigrationInterface {
+  name = 'GameRecommendations1785795104186';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "campaign_players" ADD COLUMN "suggested_game_id" integer`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_campaign_players_suggested_game" ON "campaign_players" ("suggested_game_id")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaign_players" ADD CONSTRAINT "FK_campaign_players_suggested_game" FOREIGN KEY ("suggested_game_id") REFERENCES "games"("id") ON DELETE SET NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "campaign_players" DROP CONSTRAINT "FK_campaign_players_suggested_game"`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_campaign_players_suggested_game"`);
+    await queryRunner.query(
+      `ALTER TABLE "campaign_players" DROP COLUMN "suggested_game_id"`,
+    );
+  }
+}

--- a/server/src/db/migrations/1785796200000-GameRecommendationRegistry.ts
+++ b/server/src/db/migrations/1785796200000-GameRecommendationRegistry.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class GameRecommendationRegistry1785796200000
+  implements MigrationInterface
+{
+  name = 'GameRecommendationRegistry1785796200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "game_recommendations" (
+        "id" SERIAL NOT NULL,
+        "game_id" integer NOT NULL,
+        "player_id" integer NOT NULL,
+        CONSTRAINT "UQ_game_recommendations_game_player" UNIQUE ("game_id", "player_id"),
+        CONSTRAINT "PK_game_recommendations" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_game_recommendations_game" FOREIGN KEY ("game_id") REFERENCES "games"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_game_recommendations_player" FOREIGN KEY ("player_id") REFERENCES "players"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "game_recommendations" ("game_id", "player_id")
+      SELECT DISTINCT "suggested_game_id", "player_id"
+      FROM "campaign_players"
+      WHERE "suggested_game_id" IS NOT NULL
+      ON CONFLICT ("game_id", "player_id") DO NOTHING
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "game_recommendations"`);
+  }
+}

--- a/server/src/games/entities/game-recommendation.entity.ts
+++ b/server/src/games/entities/game-recommendation.entity.ts
@@ -1,0 +1,24 @@
+import {
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { Player } from '../../players/entities/player.entity';
+import { Game } from './game.entity';
+
+@Entity('game_recommendations')
+@Unique('UQ_game_recommendations_game_player', ['game', 'player'])
+export class GameRecommendation {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Game, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'game_id' })
+  game!: Game;
+
+  @ManyToOne(() => Player, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'player_id' })
+  player!: Player;
+}

--- a/server/src/games/games.controller.ts
+++ b/server/src/games/games.controller.ts
@@ -14,6 +14,7 @@ import { UpdateGameDto } from './dto/update-game.dto';
 import { Game } from './entities/game.entity';
 import { DeleteResult } from 'typeorm';
 import { ApiTags } from '@nestjs/swagger';
+import { GameBacklog, GameWithRecommenders } from './games.service';
 
 @ApiTags('games')
 @Controller('games')
@@ -30,8 +31,15 @@ export class GamesController {
     return this.gamesService.findAll();
   }
 
+  @Get('backlog')
+  findBacklog(): Promise<GameBacklog> {
+    return this.gamesService.findBacklog();
+  }
+
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Game | null> {
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<GameWithRecommenders | null> {
     return this.gamesService.findOne(id);
   }
 

--- a/server/src/games/games.module.ts
+++ b/server/src/games/games.module.ts
@@ -3,9 +3,14 @@ import { GamesService } from './games.service';
 import { GamesController } from './games.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Game } from './entities/game.entity';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { GameRecommendation } from './entities/game-recommendation.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Game])],
+  imports: [
+    TypeOrmModule.forFeature([Game, PoolOption, Campaign, GameRecommendation]),
+  ],
   controllers: [GamesController],
   providers: [GamesService],
   exports: [TypeOrmModule],

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -1,0 +1,187 @@
+import { DataSource } from 'typeorm';
+import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { Player } from '../players/entities/player.entity';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Pool } from '../pool/entities/pool.entity';
+import { Game } from './entities/game.entity';
+import { GameRecommendation } from './entities/game-recommendation.entity';
+import { GamesService } from './games.service';
+
+describe('GamesService backlog', () => {
+  let dataSource: DataSource;
+  let service: GamesService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqljs',
+      entities: [
+        Campaign,
+        CampaignPlayer,
+        Game,
+        GameRecommendation,
+        Player,
+        Pool,
+        PoolOption,
+      ],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+
+    service = new GamesService(
+      dataSource.getRepository(Game),
+      dataSource.getRepository(PoolOption),
+      dataSource.getRepository(Campaign),
+      dataSource.getRepository(GameRecommendation),
+    );
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('returns unwon suggestions ordered by distinct election appearances', async () => {
+    const games = await saveGames([
+      { title: 'Third chance', suggestion: true },
+      { title: 'Second chance', suggestion: true },
+      { title: 'First chance', suggestion: true },
+      { title: 'Fresh suggestion', suggestion: true },
+      { title: 'Fourth appearance', suggestion: true },
+      { title: 'Already won', suggestion: true },
+      { title: 'Not suggested', suggestion: false },
+    ]);
+
+    await addAppearances(games[0], 3);
+    await addAppearances(games[1], 2);
+    await addAppearances(games[2], 1);
+    await addAppearances(games[4], 4);
+    await addAppearances(games[5], 1);
+    await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        game: games[5],
+      }),
+    );
+
+    const backlog = await service.findBacklog();
+
+    expect(backlog.retirementThreshold).toBe(3);
+    expect(
+      backlog.games.map(({ title, electionAppearances }) => [
+        title,
+        electionAppearances,
+      ]),
+    ).toEqual([
+      ['First chance', 1],
+      ['Second chance', 2],
+      ['Fresh suggestion', 0],
+    ]);
+    expect(
+      backlog.rubble.map(({ title, electionAppearances }) => [
+        title,
+        electionAppearances,
+      ]),
+    ).toEqual([
+      ['Fourth appearance', 4],
+      ['Third chance', 3],
+    ]);
+  });
+
+  it('collapses duplicate records and combines their pool appearances', async () => {
+    const [first, duplicate] = await saveGames([
+      {
+        title: 'The Same Game',
+        suggestion: true,
+        steam: 'https://store.steampowered.com/app/123/The_Same_Game/',
+      },
+      {
+        title: 'The Same Game',
+        suggestion: true,
+        steam: 'https://store.steampowered.com/app/123/The_Same_Game/',
+        cover: 'https://example.com/cover.jpg',
+      },
+    ]);
+    await addAppearances(first, 1);
+    await addAppearances(duplicate, 1);
+
+    const backlog = await service.findBacklog();
+
+    expect(backlog.games).toHaveLength(1);
+    expect(backlog.rubble).toHaveLength(0);
+    expect(backlog.games[0]).toMatchObject({
+      id: duplicate.id,
+      electionAppearances: 2,
+      cover: 'https://example.com/cover.jpg',
+    });
+  });
+
+  it('returns distinct public recommenders across campaigns and duplicate game records', async () => {
+    const [game, duplicate] = await saveGames([
+      {
+        title: 'Shared suggestion',
+        suggestion: true,
+        steam: 'https://store.steampowered.com/app/456/shared/',
+      },
+      {
+        title: 'Shared suggestion',
+        suggestion: true,
+        steam: 'https://store.steampowered.com/app/456/shared/',
+      },
+    ]);
+    const playerRepository = dataSource.getRepository(Player);
+    const [ana, bia] = await playerRepository.save([
+      playerRepository.create({
+        name: 'Ana',
+        email: 'private@example.com',
+        discord: { avatar: 'https://example.com/ana.png' },
+      }),
+      playerRepository.create({ name: 'Bia' }),
+    ]);
+    const recommendationRepository =
+      dataSource.getRepository(GameRecommendation);
+    await recommendationRepository.save([
+      recommendationRepository.create({
+        player: ana,
+        game,
+      }),
+      recommendationRepository.create({
+        player: ana,
+        game: duplicate,
+      }),
+      recommendationRepository.create({
+        player: bia,
+        game,
+      }),
+    ]);
+
+    const backlog = await service.findBacklog();
+    const details = await service.findOne(game.id);
+
+    expect(backlog.games).toHaveLength(1);
+    expect(backlog.games[0].recommendedBy).toEqual([
+      { id: ana.id, name: 'Ana', avatar: 'https://example.com/ana.png' },
+      { id: bia.id, name: 'Bia', avatar: null },
+    ]);
+    expect(details?.recommendedBy).toEqual(backlog.games[0].recommendedBy);
+    expect(backlog.games[0].recommendedBy[0]).not.toHaveProperty('email');
+  });
+
+  const saveGames = (games: Array<Partial<Game> & Pick<Game, 'title'>>) => {
+    const repository = dataSource.getRepository(Game);
+    return repository.save(games.map((game) => repository.create(game)));
+  };
+
+  const addAppearances = async (game: Game, count: number) => {
+    const poolRepository = dataSource.getRepository(Pool);
+    const optionRepository = dataSource.getRepository(PoolOption);
+
+    for (let index = 0; index < count; index += 1) {
+      await poolRepository.save(
+        poolRepository.create({
+          options: [optionRepository.create({ game, players: [] })],
+        }),
+      );
+    }
+  };
+});

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -4,12 +4,66 @@ import { UpdateGameDto } from './dto/update-game.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Game } from './entities/game.entity';
 import { DeleteResult, Repository } from 'typeorm';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { GameRecommendation } from './entities/game-recommendation.entity';
+
+const MAX_BACKLOG_APPEARANCES = 3;
+
+export interface GameRecommender {
+  id: number;
+  name: string;
+  avatar: string | null;
+}
+
+export interface GameWithRecommenders extends Game {
+  recommendedBy: GameRecommender[];
+}
+
+export interface BacklogGame extends GameWithRecommenders {
+  electionAppearances: number;
+}
+
+export interface GameBacklog {
+  games: BacklogGame[];
+  rubble: BacklogGame[];
+  retirementThreshold: number;
+}
+
+const normalizeGameIdentity = (game: Game): string => {
+  const steamUrl = game.steam
+    ?.trim()
+    .replace(/[/?#]+$/, '')
+    .toLocaleLowerCase('en-US');
+
+  if (steamUrl) {
+    return `steam:${steamUrl}`;
+  }
+
+  return `title:${game.title.trim().replace(/\s+/g, ' ').toLocaleLowerCase('pt-BR')}`;
+};
+
+const gameCompleteness = (game: Game): number =>
+  [
+    game.cover,
+    game.steam,
+    game.trailer,
+    game.summary,
+    game.howLongToBeatUrl,
+    game.durationLabel,
+  ].filter(Boolean).length;
 
 @Injectable()
 export class GamesService {
   constructor(
     @InjectRepository(Game)
     private gameRepository: Repository<Game>,
+    @InjectRepository(PoolOption)
+    private poolOptionRepository: Repository<PoolOption>,
+    @InjectRepository(Campaign)
+    private campaignRepository: Repository<Campaign>,
+    @InjectRepository(GameRecommendation)
+    private gameRecommendationRepository: Repository<GameRecommendation>,
   ) {}
 
   create(createGameDto: CreateGameDto): Promise<Game> {
@@ -21,8 +75,141 @@ export class GamesService {
     return this.gameRepository.find();
   }
 
-  findOne(id: number): Promise<Game | null> {
-    return this.gameRepository.findOneBy({ id });
+  async findBacklog(): Promise<GameBacklog> {
+    const [games, poolOptions, campaigns, recommendersByIdentity] =
+      await Promise.all([
+        this.gameRepository.find({ order: { id: 'ASC' } }),
+        this.poolOptionRepository.find({ relations: ['game', 'pool'] }),
+        this.campaignRepository.find({ relations: ['game'] }),
+        this.findRecommendersByIdentity(),
+      ]);
+
+    const gamesByIdentity = new Map<string, Game[]>();
+    for (const game of games) {
+      const identity = normalizeGameIdentity(game);
+      gamesByIdentity.set(identity, [
+        ...(gamesByIdentity.get(identity) ?? []),
+        game,
+      ]);
+    }
+
+    const winningIdentities = new Set(
+      campaigns
+        .map((campaign) => campaign.game)
+        .filter((game): game is Game => Boolean(game))
+        .map(normalizeGameIdentity),
+    );
+
+    const appearancesByIdentity = new Map<string, Set<number>>();
+    for (const option of poolOptions) {
+      const identity = normalizeGameIdentity(option.game);
+      const poolIds = appearancesByIdentity.get(identity) ?? new Set<number>();
+      poolIds.add(option.pool.id);
+      appearancesByIdentity.set(identity, poolIds);
+    }
+
+    const backlogGames: BacklogGame[] = [];
+    const rubbleGames: BacklogGame[] = [];
+    for (const [identity, matchingGames] of gamesByIdentity) {
+      if (
+        !matchingGames.some((game) => game.suggestion) ||
+        winningIdentities.has(identity)
+      ) {
+        continue;
+      }
+
+      const electionAppearances =
+        appearancesByIdentity.get(identity)?.size ?? 0;
+      const game = [...matchingGames].sort(
+        (left, right) =>
+          gameCompleteness(right) - gameCompleteness(left) ||
+          left.id - right.id,
+      )[0];
+
+      const backlogGame = {
+        ...game,
+        electionAppearances,
+        recommendedBy: recommendersByIdentity.get(identity) ?? [],
+      };
+      if (electionAppearances >= MAX_BACKLOG_APPEARANCES) {
+        rubbleGames.push(backlogGame);
+      } else {
+        backlogGames.push(backlogGame);
+      }
+    }
+
+    backlogGames.sort(
+      (left, right) =>
+        (left.electionAppearances || Number.MAX_SAFE_INTEGER) -
+          (right.electionAppearances || Number.MAX_SAFE_INTEGER) ||
+        left.title.localeCompare(right.title, 'pt-BR'),
+    );
+
+    rubbleGames.sort(
+      (left, right) =>
+        right.electionAppearances - left.electionAppearances ||
+        left.title.localeCompare(right.title, 'pt-BR'),
+    );
+
+    return {
+      games: backlogGames,
+      rubble: rubbleGames,
+      retirementThreshold: MAX_BACKLOG_APPEARANCES,
+    };
+  }
+
+  async findOne(id: number): Promise<GameWithRecommenders | null> {
+    const game = await this.gameRepository.findOneBy({ id });
+
+    if (!game) {
+      return null;
+    }
+
+    const recommendersByIdentity = await this.findRecommendersByIdentity();
+    return {
+      ...game,
+      recommendedBy:
+        recommendersByIdentity.get(normalizeGameIdentity(game)) ?? [],
+    };
+  }
+
+  private async findRecommendersByIdentity(): Promise<
+    Map<string, GameRecommender[]>
+  > {
+    const recommendations = await this.gameRecommendationRepository.find({
+      relations: ['game', 'player'],
+    });
+    const recommendersByIdentity = new Map<
+      string,
+      Map<number, GameRecommender>
+    >();
+
+    for (const recommendation of recommendations) {
+      const identity = normalizeGameIdentity(recommendation.game);
+      const recommenders =
+        recommendersByIdentity.get(identity) ??
+        new Map<number, GameRecommender>();
+      const player = recommendation.player;
+      recommenders.set(player.id, {
+        id: player.id,
+        name:
+          player.discord?.globalName ??
+          player.name ??
+          player.discord?.username ??
+          'Participante',
+        avatar: player.discord?.avatar ?? null,
+      });
+      recommendersByIdentity.set(identity, recommenders);
+    }
+
+    return new Map(
+      Array.from(recommendersByIdentity, ([identity, recommenders]) => [
+        identity,
+        Array.from(recommenders.values()).sort((left, right) =>
+          left.name.localeCompare(right.name, 'pt-BR'),
+        ),
+      ]),
+    );
   }
 
   async update(id: number, updateGameDto: UpdateGameDto): Promise<Game> {


### PR DESCRIPTION
## Summary

- add the themed Brasas catalog, ordered by election appearances, with discarded games forming the interactive Cinzas ground
- add responsive rubble extraction, modal presentation, stable reshuffling, subtle ordered color dithering, themed tooltips, and recommender faces
- record exact campaign suggestions while preserving the legacy boolean behavior
- add a separate game-to-player provenance registry for historical recommendations without inventing campaign dates
- extend the admin preview/apply flow and MCP contracts for safe recommendation updates
- add registered PostgreSQL migrations and focused server coverage

## Validation

- `pnpm run ci`
- 18 client tests and 19 server tests
- `docker build -f server/Dockerfile -t bonfire-server:backlog-catalog-pr .`
- responsive full-page visual verification
