### PR TITLE
Make public pages discoverable by search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A full-stack web app for managing the **Sob a Luz do Bonfire** game club: current campaigns, past campaigns, game information, Discord login, player progress, and voting/election flow for upcoming games.
 
+Live site: [sob-a-luz-do-bonfire.onrender.com](https://sob-a-luz-do-bonfire.onrender.com)
+
 The repository is split into three workspace packages:
 
 - `client/` — Vue 3 + Vite + TypeScript frontend.

--- a/client/index.html
+++ b/client/index.html
@@ -1,20 +1,95 @@
-<!DOCTYPE html>
-<html lang="">
-<head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#18131c" />
+    <meta
+      name="description"
+      content="Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire."
+    />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sob-a-luz-do-bonfire.onrender.com/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="pt_BR" />
+    <meta property="og:site_name" content="Sob a Luz do Bonfire" />
+    <meta property="og:title" content="Sob a Luz do Bonfire" />
+    <meta
+      property="og:description"
+      content="Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire."
+    />
+    <meta property="og:url" content="https://sob-a-luz-do-bonfire.onrender.com/" />
+    <meta
+      property="og:image"
+      content="https://sob-a-luz-do-bonfire.onrender.com/src/assets/bonfire.png"
+    />
+    <meta property="og:image:alt" content="Fogueira do Sob a Luz do Bonfire" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Sob a Luz do Bonfire" />
+    <meta
+      name="twitter:description"
+      content="Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire."
+    />
+    <meta
+      name="twitter:image"
+      content="https://sob-a-luz-do-bonfire.onrender.com/src/assets/bonfire.png"
+    />
     <title>Sob a Luz do Bonfire</title>
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Mulish:wght@300;500;600;700&display=swap" rel="stylesheet">
+    <script id="structured-data" type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Sob a Luz do Bonfire",
+        "url": "https://sob-a-luz-do-bonfire.onrender.com/",
+        "inLanguage": "pt-BR"
+      }
+    </script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@400;700;900&family=Mulish:wght@300;500;600;700&display=swap"
+      rel="stylesheet"
+    />
 
     <style>
+      .seo-fallback {
+        box-sizing: border-box;
+        max-width: 760px;
+        margin: 10vh auto;
+        padding: 32px;
+        color: #f7ded0;
+        font-family: Mulish, sans-serif;
+      }
+      .seo-fallback a {
+        color: #e7a06c;
+      }
     </style>
-</head>
-<body>
-    <div id="app"></div>
+  </head>
+  <body>
+    <div id="app">
+      <!-- SEO_FALLBACK_START -->
+      <main class="seo-fallback">
+        <h1>Sob a Luz do Bonfire</h1>
+        <p>
+          Um clube de jogos reunido ao redor da fogueira. Acompanhe a campanha atual e a jornada da
+          comunidade.
+        </p>
+        <nav aria-label="Páginas do Sob a Luz do Bonfire">
+          <ul>
+            <li><a href="/">Sob a Luz do Bonfire</a></li>
+            <li><a href="/campanhas">Campanhas</a></li>
+            <li><a href="/regras">Regras</a></li>
+            <li><a href="/brasas">Brasas</a></li>
+          </ul>
+        </nav>
+      </main>
+      <!-- SEO_FALLBACK_END -->
+    </div>
     <script type="module" src="/src/main.ts"></script>
-</body>
+  </body>
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build-with-type-check": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
-    "build": "vite build",
+    "build": "vite build && node scripts/generate-static-pages.mjs",
     "type-check": "vue-tsc --build",
     "test": "vitest",
     "test:run": "vitest run",

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /auth/callback
+
+Sitemap: https://sob-a-luz-do-bonfire.onrender.com/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://sob-a-luz-do-bonfire.onrender.com/</loc>
+  </url>
+  <url>
+    <loc>https://sob-a-luz-do-bonfire.onrender.com/campanhas/</loc>
+  </url>
+  <url>
+    <loc>https://sob-a-luz-do-bonfire.onrender.com/regras/</loc>
+  </url>
+  <url>
+    <loc>https://sob-a-luz-do-bonfire.onrender.com/brasas/</loc>
+  </url>
+</urlset>

--- a/client/scripts/generate-static-pages.mjs
+++ b/client/scripts/generate-static-pages.mjs
@@ -1,0 +1,166 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const clientRoot = fileURLToPath(new URL('..', import.meta.url))
+const distDirectory = path.join(clientRoot, 'dist')
+const config = JSON.parse(await readFile(path.join(clientRoot, 'seo-pages.json'), 'utf8'))
+const siteUrl = (process.env.VITE_SITE_URL || config.siteUrl).replace(/\/$/, '')
+const template = await readFile(path.join(distDirectory, 'index.html'), 'utf8')
+
+const assets = await readdir(path.join(distDirectory, 'assets'))
+const bonfireImage = assets.find((asset) => /^bonfire-[\w-]+\.png$/.test(asset))
+
+if (!bonfireImage) {
+  throw new Error('Could not find the built bonfire image used by SEO metadata.')
+}
+
+const imageUrl = `${siteUrl}/assets/${bonfireImage}`
+const indexablePages = config.pages.filter((page) => page.indexable)
+
+const escapeHtml = (value) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;')
+
+const replaceTag = (html, pattern, replacement, label) => {
+  if (!pattern.test(html)) {
+    throw new Error(`Could not find ${label} in the built index.html.`)
+  }
+
+  return html.replace(pattern, replacement)
+}
+
+const metaTagPattern = (attribute, key) =>
+  new RegExp(`<meta\\s+(?=[^>]*\\b${attribute}="${key}")[^>]*>`)
+
+const buildStructuredData = (page, canonicalUrl) => ({
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': `${siteUrl}/#organization`,
+      name: config.siteName,
+      url: `${siteUrl}/`,
+      logo: {
+        '@type': 'ImageObject',
+        url: imageUrl,
+        width: 320,
+        height: 332,
+      },
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${siteUrl}/#website`,
+      url: `${siteUrl}/`,
+      name: config.siteName,
+      description: config.pages[0].description,
+      inLanguage: config.language,
+      publisher: { '@id': `${siteUrl}/#organization` },
+    },
+    {
+      '@type': 'WebPage',
+      '@id': `${canonicalUrl}#webpage`,
+      url: canonicalUrl,
+      name: page.title,
+      description: page.description,
+      inLanguage: config.language,
+      isPartOf: { '@id': `${siteUrl}/#website` },
+    },
+  ],
+})
+
+const buildFallback = (page) => {
+  const navigation = indexablePages
+    .map(
+      (navigationPage) =>
+        `<li><a href="${navigationPage.canonicalPath}">${escapeHtml(navigationPage.heading)}</a></li>`,
+    )
+    .join('')
+
+  return `<!-- SEO_FALLBACK_START -->
+      <main class="seo-fallback">
+        <h1>${escapeHtml(page.heading)}</h1>
+        <p>${escapeHtml(page.summary)}</p>
+        <nav aria-label="Páginas do Sob a Luz do Bonfire"><ul>${navigation}</ul></nav>
+      </main>
+    <!-- SEO_FALLBACK_END -->`
+}
+
+const renderPage = (page) => {
+  const canonicalUrl = `${siteUrl}${page.canonicalPath}`
+  const robots = page.indexable ? 'index, follow' : 'noindex, nofollow'
+  let html = template
+
+  html = replaceTag(
+    html,
+    /<title>[^<]*<\/title>/,
+    `<title>${escapeHtml(page.title)}</title>`,
+    'title',
+  )
+  html = replaceTag(
+    html,
+    metaTagPattern('name', 'description'),
+    `<meta name="description" content="${escapeHtml(page.description)}">`,
+    'meta description',
+  )
+  html = replaceTag(
+    html,
+    metaTagPattern('name', 'robots'),
+    `<meta name="robots" content="${robots}">`,
+    'robots metadata',
+  )
+  html = replaceTag(
+    html,
+    /<link\s+(?=[^>]*\brel="canonical")[^>]*>/,
+    `<link rel="canonical" href="${canonicalUrl}">`,
+    'canonical URL',
+  )
+
+  const metaValues = {
+    'og:title': page.title,
+    'og:description': page.description,
+    'og:url': canonicalUrl,
+    'og:image': imageUrl,
+    'twitter:title': page.title,
+    'twitter:description': page.description,
+    'twitter:image': imageUrl,
+  }
+
+  for (const [key, value] of Object.entries(metaValues)) {
+    const attribute = key.startsWith('og:') ? 'property' : 'name'
+    html = replaceTag(
+      html,
+      metaTagPattern(attribute, key),
+      `<meta ${attribute}="${key}" content="${escapeHtml(value)}">`,
+      key,
+    )
+  }
+
+  html = replaceTag(
+    html,
+    /<script id="structured-data" type="application\/ld\+json">[\s\S]*?<\/script>/,
+    `<script id="structured-data" type="application/ld+json">${JSON.stringify(buildStructuredData(page, canonicalUrl)).replaceAll('<', '\\u003c')}</script>`,
+    'structured data',
+  )
+  html = replaceTag(
+    html,
+    /<!-- SEO_FALLBACK_START -->[\s\S]*?<!-- SEO_FALLBACK_END -->/,
+    buildFallback(page),
+    'SEO fallback content',
+  )
+
+  return html
+}
+
+for (const page of config.pages) {
+  const outputDirectory =
+    page.path === '/' ? distDirectory : path.join(distDirectory, page.path.slice(1))
+  await mkdir(outputDirectory, { recursive: true })
+  await writeFile(path.join(outputDirectory, 'index.html'), renderPage(page))
+}
+
+console.log(`Generated ${config.pages.length} static route pages with canonical SEO metadata.`)

--- a/client/seo-pages.json
+++ b/client/seo-pages.json
@@ -1,0 +1,53 @@
+{
+  "siteName": "Sob a Luz do Bonfire",
+  "siteUrl": "https://sob-a-luz-do-bonfire.onrender.com",
+  "locale": "pt_BR",
+  "language": "pt-BR",
+  "pages": [
+    {
+      "path": "/",
+      "canonicalPath": "/",
+      "title": "Sob a Luz do Bonfire",
+      "description": "Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire.",
+      "heading": "Sob a Luz do Bonfire",
+      "summary": "Um clube de jogos reunido ao redor da fogueira. Acompanhe a campanha atual e a jornada da comunidade.",
+      "indexable": true
+    },
+    {
+      "path": "/campanhas",
+      "canonicalPath": "/campanhas/",
+      "title": "Campanhas | Sob a Luz do Bonfire",
+      "description": "Conheça o histórico de campanhas e os jogos que a comunidade viveu ao redor da fogueira.",
+      "heading": "Campanhas",
+      "summary": "Histórias, jogos e jornadas compartilhadas nas campanhas anteriores do clube.",
+      "indexable": true
+    },
+    {
+      "path": "/regras",
+      "canonicalPath": "/regras/",
+      "title": "Regras | Sob a Luz do Bonfire",
+      "description": "Veja como funcionam as recomendações, eleições, campanhas e a participação no Sob a Luz do Bonfire.",
+      "heading": "Regras",
+      "summary": "Como escolhemos jogos, organizamos campanhas e jogamos juntos.",
+      "indexable": true
+    },
+    {
+      "path": "/brasas",
+      "canonicalPath": "/brasas/",
+      "title": "Brasas | Sob a Luz do Bonfire",
+      "description": "Explore os jogos recomendados que ainda podem ser escolhidos para uma próxima campanha do clube.",
+      "heading": "Brasas",
+      "summary": "Jogos recomendados pela comunidade que ainda podem acender a próxima fogueira.",
+      "indexable": true
+    },
+    {
+      "path": "/auth/callback",
+      "canonicalPath": "/auth/callback/",
+      "title": "Autenticação | Sob a Luz do Bonfire",
+      "description": "Conclusão da autenticação do Sob a Luz do Bonfire.",
+      "heading": "Autenticação",
+      "summary": "Concluindo a entrada no Sob a Luz do Bonfire.",
+      "indexable": false
+    }
+  ]
+}

--- a/client/src/__tests__/seo.spec.ts
+++ b/client/src/__tests__/seo.spec.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { applySeo, siteUrl } from '@/seo'
+
+describe('SEO metadata', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  it('publishes indexable route metadata and a canonical URL', () => {
+    applySeo('/campanhas')
+
+    expect(document.title).toBe('Campanhas | Sob a Luz do Bonfire')
+    expect(document.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe(
+      'index, follow',
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      `${siteUrl}/campanhas/`,
+    )
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      `${siteUrl}/campanhas/`,
+    )
+  })
+
+  it('marks unknown routes as noindex', () => {
+    applySeo('/uma-pagina-que-nao-existe')
+
+    expect(document.title).toBe('Página não encontrada | Sob a Luz do Bonfire')
+    expect(document.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe(
+      'noindex, nofollow',
+    )
+  })
+
+  it('emits valid WebPage structured data', () => {
+    applySeo('/regras')
+
+    const structuredData = JSON.parse(
+      document.querySelector('#structured-data')?.textContent ?? '{}',
+    )
+
+    expect(structuredData).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      url: `${siteUrl}/regras/`,
+      inLanguage: 'pt-BR',
+    })
+  })
+})

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,12 +6,14 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import authPlugin from './plugins/auth'
+import { installSeo } from './seo'
 
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(authPlugin)
 app.use(router)
+installSeo(router)
 
 router.isReady().then(() => {
   app.mount('#app')

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -47,6 +47,15 @@ const router = createRouter({
       name: 'auth-callback',
       component: AuthCallbackPage,
     },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'not-found',
+      component: () => import('../views/NotFound.vue'),
+      meta: {
+        pageTitle: 'Página não encontrada',
+        pageKicker: 'Nem toda brasa continua acesa',
+      },
+    },
   ],
 })
 

--- a/client/src/seo.ts
+++ b/client/src/seo.ts
@@ -1,0 +1,126 @@
+import type { Router } from 'vue-router'
+import seoConfig from '../seo-pages.json'
+
+interface SeoPage {
+  path: string
+  canonicalPath: string
+  title: string
+  description: string
+  heading: string
+  summary: string
+  indexable: boolean
+}
+
+const configuredSiteUrl = import.meta.env.VITE_SITE_URL || seoConfig.siteUrl
+export const siteUrl = configuredSiteUrl.replace(/\/$/, '')
+
+const fallbackPage: SeoPage = {
+  path: '',
+  canonicalPath: '',
+  title: `Página não encontrada | ${seoConfig.siteName}`,
+  description: 'A página procurada não existe no Sob a Luz do Bonfire.',
+  heading: 'Página não encontrada',
+  summary: 'A página procurada não existe.',
+  indexable: false,
+}
+
+const upsertMeta = (selector: string, attributes: Record<string, string>) => {
+  let element = document.head.querySelector<HTMLMetaElement>(selector)
+
+  if (!element) {
+    element = document.createElement('meta')
+    document.head.appendChild(element)
+  }
+
+  for (const [name, value] of Object.entries(attributes)) {
+    element.setAttribute(name, value)
+  }
+}
+
+const upsertCanonical = (canonicalUrl: string) => {
+  let canonical = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+
+  if (!canonical) {
+    canonical = document.createElement('link')
+    canonical.rel = 'canonical'
+    document.head.appendChild(canonical)
+  }
+
+  canonical.href = canonicalUrl
+}
+
+const normalizedPath = (routePath: string) =>
+  routePath.length > 1 ? routePath.replace(/\/+$/, '') : routePath
+
+const findPage = (routePath: string): SeoPage =>
+  (seoConfig.pages.find((page) => page.path === normalizedPath(routePath)) as
+    | SeoPage
+    | undefined) ?? {
+    ...fallbackPage,
+    path: routePath,
+    canonicalPath: routePath,
+  }
+
+const currentImageUrl = () =>
+  document.head.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content ||
+  `${siteUrl}/src/assets/bonfire.png`
+
+const updateStructuredData = (page: SeoPage, canonicalUrl: string) => {
+  let script = document.head.querySelector<HTMLScriptElement>('#structured-data')
+
+  if (!script) {
+    script = document.createElement('script')
+    script.id = 'structured-data'
+    script.type = 'application/ld+json'
+    document.head.appendChild(script)
+  }
+
+  script.textContent = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': `${canonicalUrl}#webpage`,
+    url: canonicalUrl,
+    name: page.title,
+    description: page.description,
+    inLanguage: seoConfig.language,
+    isPartOf: { '@id': `${siteUrl}/#website` },
+    primaryImageOfPage: {
+      '@type': 'ImageObject',
+      url: currentImageUrl(),
+    },
+  })
+}
+
+export const applySeo = (routePath: string) => {
+  const page = findPage(routePath)
+  const canonicalUrl = `${siteUrl}${page.canonicalPath || routePath}`
+  const robots = page.indexable ? 'index, follow' : 'noindex, nofollow'
+  const imageUrl = currentImageUrl()
+
+  document.title = page.title
+  upsertMeta('meta[name="description"]', { name: 'description', content: page.description })
+  upsertMeta('meta[name="robots"]', { name: 'robots', content: robots })
+  upsertCanonical(canonicalUrl)
+
+  const metadata = [
+    ['meta[property="og:title"]', 'property', 'og:title', page.title],
+    ['meta[property="og:description"]', 'property', 'og:description', page.description],
+    ['meta[property="og:url"]', 'property', 'og:url', canonicalUrl],
+    ['meta[property="og:image"]', 'property', 'og:image', imageUrl],
+    ['meta[name="twitter:title"]', 'name', 'twitter:title', page.title],
+    ['meta[name="twitter:description"]', 'name', 'twitter:description', page.description],
+    ['meta[name="twitter:image"]', 'name', 'twitter:image', imageUrl],
+  ] as const
+
+  for (const [selector, attribute, key, value] of metadata) {
+    upsertMeta(selector, { [attribute]: key, content: value })
+  }
+
+  updateStructuredData(page, canonicalUrl)
+}
+
+export const installSeo = (router: Router) => {
+  router.afterEach((route) => {
+    applySeo(route.path)
+  })
+}

--- a/client/src/views/NotFound.vue
+++ b/client/src/views/NotFound.vue
@@ -1,0 +1,9 @@
+<template>
+  <section class="main-block" aria-labelledby="not-found-title">
+    <div class="main-block-content">
+      <h2 id="not-found-title">Esta brasa se apagou</h2>
+      <p>A página que você procurou não existe.</p>
+      <RouterLink to="/">Voltar para a fogueira</RouterLink>
+    </div>
+  </section>
+</template>


### PR DESCRIPTION
## What changed
- generate static, route-specific HTML for every public page
- add canonical, description, Open Graph, Twitter, and JSON-LD metadata
- publish robots.txt and an XML sitemap
- keep auth callbacks and unknown routes out of the index
- link the live site from the public repository

## Validation
- `pnpm run ci`
- built artifact HTTP checks for all canonical routes, robots.txt, and sitemap.xml
- sitemap XML and JSON-LD parsing
- headless Chrome checks for public and not-found routes