### PR TITLE
Release canonical domain correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A full-stack web app for managing the **Sob a Luz do Bonfire** game club: current campaigns, past campaigns, game information, Discord login, player progress, and voting/election flow for upcoming games.
 
-Live site: [sob-a-luz-do-bonfire.onrender.com](https://sob-a-luz-do-bonfire.onrender.com)
+Live site: [sobaluzdobonfire.com.br](https://sobaluzdobonfire.com.br)
 
 The repository is split into three workspace packages:
 

--- a/client/index.html
+++ b/client/index.html
@@ -10,7 +10,7 @@
       content="Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire."
     />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://sob-a-luz-do-bonfire.onrender.com/" />
+    <link rel="canonical" href="https://sobaluzdobonfire.com.br/" />
 
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="pt_BR" />
@@ -20,10 +20,10 @@
       property="og:description"
       content="Acompanhe o jogo do mês, as campanhas, as regras e os próximos jogos do clube Sob a Luz do Bonfire."
     />
-    <meta property="og:url" content="https://sob-a-luz-do-bonfire.onrender.com/" />
+    <meta property="og:url" content="https://sobaluzdobonfire.com.br/" />
     <meta
       property="og:image"
-      content="https://sob-a-luz-do-bonfire.onrender.com/src/assets/bonfire.png"
+      content="https://sobaluzdobonfire.com.br/src/assets/bonfire.png"
     />
     <meta property="og:image:alt" content="Fogueira do Sob a Luz do Bonfire" />
 
@@ -35,7 +35,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://sob-a-luz-do-bonfire.onrender.com/src/assets/bonfire.png"
+      content="https://sobaluzdobonfire.com.br/src/assets/bonfire.png"
     />
     <title>Sob a Luz do Bonfire</title>
 
@@ -44,8 +44,17 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Sob a Luz do Bonfire",
-        "url": "https://sob-a-luz-do-bonfire.onrender.com/",
+        "url": "https://sobaluzdobonfire.com.br/",
         "inLanguage": "pt-BR"
+      }
+    </script>
+
+    <script>
+      if (window.location.hostname === 'sob-a-luz-do-bonfire.onrender.com') {
+        const canonicalUrl = new URL(window.location.href)
+        canonicalUrl.protocol = 'https:'
+        canonicalUrl.host = 'sobaluzdobonfire.com.br'
+        window.location.replace(canonicalUrl.toString())
       }
     </script>
 

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /auth/callback
 
-Sitemap: https://sob-a-luz-do-bonfire.onrender.com/sitemap.xml
+Sitemap: https://sobaluzdobonfire.com.br/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://sob-a-luz-do-bonfire.onrender.com/</loc>
+    <loc>https://sobaluzdobonfire.com.br/</loc>
   </url>
   <url>
-    <loc>https://sob-a-luz-do-bonfire.onrender.com/campanhas/</loc>
+    <loc>https://sobaluzdobonfire.com.br/campanhas/</loc>
   </url>
   <url>
-    <loc>https://sob-a-luz-do-bonfire.onrender.com/regras/</loc>
+    <loc>https://sobaluzdobonfire.com.br/regras/</loc>
   </url>
   <url>
-    <loc>https://sob-a-luz-do-bonfire.onrender.com/brasas/</loc>
+    <loc>https://sobaluzdobonfire.com.br/brasas/</loc>
   </url>
 </urlset>

--- a/client/seo-pages.json
+++ b/client/seo-pages.json
@@ -1,6 +1,6 @@
 {
   "siteName": "Sob a Luz do Bonfire",
-  "siteUrl": "https://sob-a-luz-do-bonfire.onrender.com",
+  "siteUrl": "https://sobaluzdobonfire.com.br",
   "locale": "pt_BR",
   "language": "pt-BR",
   "pages": [


### PR DESCRIPTION
Correct production SEO and discovery URLs to `https://sobaluzdobonfire.com.br` and stop treating the Render hostname as canonical.

Validated in PR #28 and full monorepo CI.