### PR TITLE
Store Discord avatars in R2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
 
   server:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1102.0
+        version: 3.1102.0
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.23(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -306,6 +309,78 @@ packages:
 
   '@auth0/auth0-spa-js@2.20.0':
     resolution: {integrity: sha512-XKIfFgsz4M1h2qyGhxLb33k1i8eL7Nost+EmYIOY5givxZuzWOCmhzmwnXjprqYsT+dRGu6ORT29IuTd1rwDYQ==}
+
+  '@aws-sdk/checksums@3.1000.25':
+    resolution: {integrity: sha512-zUjEceMw6vhAxMayAlF/vkkKqP9gHbENqvz11t4FbfDlxB/WtW/Az1orJAQ00Pc/yORLQJXKE24w11Ktu/XBcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1102.0':
+    resolution: {integrity: sha512-VQL/oWlt0+Rj2QZcAnp3+hMHW/T01EmkPQXf9ise2gz6d95U82eVE1dPBpMlnv4aDiz99TrMR0DHmceCjCkCmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.5':
+    resolution: {integrity: sha512-O5otOc1c6UZh5HsHAaPdYBcUUR9HL6mtnKqvc8nxN/CKDGUBUpsdh0q8K04Uz/dd1i0TaGyIQuQNqoO7+ad2TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.66':
+    resolution: {integrity: sha512-bOzP2+zdJ0XrghywB4FaJXtGZCx9yS0AGps+VJ5yEgg30wVyHNmVDBwVDXcRypzQY5iLGCS3NSn0nsuISqjFCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.68':
+    resolution: {integrity: sha512-lkunS8X+H6V76WE+t/uGQm/U8v0JXK5mLfNFTUAMlE1kqaCjwlmqKJrgCVtqjK/vqnlrSWsLK4Lr4NANBWlfTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.11':
+    resolution: {integrity: sha512-KoDEolYtLHG/8C+IiZpXbJWyBOMkrHV+j66Kb9PBXmLv5euGb7aELvuCmLenoGAV6gBW2wM7TsG/1e5iulH4kA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.73':
+    resolution: {integrity: sha512-tjsxMkTAFkmiV9ycmymapb9nLECWVOwFs0bZMQ9gB9bnbY8/HwfukHZlWbXZZp7qkPU6EXAfOcMm3DioFFEywA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.77':
+    resolution: {integrity: sha512-l4nitYCN/Ls57vtUfdextCjTjW41JD7lQiAnuR0RTbdByFc/6OmEAzwGd+lrp6CUtiXGQL1FCaYiamfHASrwBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.66':
+    resolution: {integrity: sha512-YOnX6bIhdjx0QfaENu2PB0eFm5MEc9ft8XNGQ+NxMfeLSq9aE+XjWCwDupEnV4UWv5ZFpBLJbTREIx7KNOoqpQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.10':
+    resolution: {integrity: sha512-IsXnQ35j5VE+3ZK6aIhT5ypB+Jim3zRwVz0nYuVwyBKZyu/SYx+O2/LQpng8c2EiuwyqceabsDlYrICHDlJPsA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.72':
+    resolution: {integrity: sha512-nj9Zlsy7ya+fy+jhWTJwgfr7YdtDM4xHyZvgKuftuny0UgROVx9lxwvsWJSLvpKk4lig0m0tHng3k1fEnt0LeA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.71':
+    resolution: {integrity: sha512-5fpExT7JOIZSIWExXCgJVbZzbaOlNrS/rE5Eoesnp0ONMbnCtiyYsCkahNIdlXtKrO6XHqXI6ceqssVWMYKmWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.40':
+    resolution: {integrity: sha512-hEdHT0PBR4fkGxWhwKG5EtEYKnAM7HKkp0vD10ufk4YcXejH4r4q6G/XhPzjUc6Yxo5kBS2vHg7llj4ViR9VTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1102.0':
+    resolution: {integrity: sha512-Ua700vVvM1q105yABSUQWkCK6FeTrNfU6ORGetJe5BzkZWY7QhkF7SVTOlmDGWRDNd6jbyY0Dv5e+E4bMBEmLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1564,6 +1639,30 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
@@ -2217,6 +2316,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -5379,6 +5481,171 @@ snapshots:
       dpop: 2.1.1
       es-cookie: 1.3.2
 
+  '@aws-sdk/checksums@3.1000.25':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1102.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.25
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/credential-provider-node': 3.972.77
+      '@aws-sdk/middleware-sdk-s3': 3.972.71
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.5':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.11':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/credential-provider-env': 3.972.66
+      '@aws-sdk/credential-provider-http': 3.972.68
+      '@aws-sdk/credential-provider-login': 3.972.73
+      '@aws-sdk/credential-provider-process': 3.972.66
+      '@aws-sdk/credential-provider-sso': 3.973.10
+      '@aws-sdk/credential-provider-web-identity': 3.972.72
+      '@aws-sdk/nested-clients': 3.997.40
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/nested-clients': 3.997.40
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.77':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.66
+      '@aws-sdk/credential-provider-http': 3.972.68
+      '@aws-sdk/credential-provider-ini': 3.973.11
+      '@aws-sdk/credential-provider-process': 3.972.66
+      '@aws-sdk/credential-provider-sso': 3.973.10
+      '@aws-sdk/credential-provider-web-identity': 3.972.72
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/nested-clients': 3.997.40
+      '@aws-sdk/token-providers': 3.1102.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/nested-clients': 3.997.40
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.40':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1102.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.5
+      '@aws-sdk/nested-clients': 3.997.40
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -6584,6 +6851,39 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@sqltools/formatter@1.2.5': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -7425,6 +7725,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.14:
     dependencies:

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,3 +22,17 @@ JWT_SECRET=replace-with-a-long-random-secret
 DISCORD_CLIENT_ID=replace-with-discord-client-id
 DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
+
+# Cloudflare R2 media storage. Leave all five required values blank to use original media URLs locally.
+R2_ENDPOINT=https://account-id.r2.cloudflarestorage.com
+R2_BUCKET=sob-a-luz-do-bonfire
+R2_ACCESS_KEY_ID=replace-with-r2-access-key-id
+R2_SECRET_ACCESS_KEY=replace-with-r2-secret-access-key
+R2_PUBLIC_BASE_URL=https://pub-example.r2.dev
+R2_REGION=auto
+
+# Object key prefixes reserved for each kind of project media.
+R2_AVATAR_PREFIX=avatars
+R2_BANNER_PREFIX=banners
+R2_PICTURE_PREFIX=pictures
+R2_ASSET_PREFIX=assets

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "db:sync:prod": "ts-node -r tsconfig-paths/register src/db/sync-production-to-sqlite.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1102.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -8,11 +8,13 @@ import { AuthService } from './auth.service';
 import { DiscordStrategy } from './strategies/discord.strategy';
 import { PlayersModule } from '../players/players.module';
 import { JwtStrategy } from './strategies/jwt.strategy'; // assumes you have this
+import { MediaModule } from '../media/media.module';
 
 @Module({
   imports: [
     ConfigModule,
     PlayersModule,
+    MediaModule,
     PassportModule.register({ defaultStrategy: 'discord', session: false }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -2,6 +2,9 @@ import { JwtService } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
 import { PlayersService } from '../players/players.service';
 import { AuthService } from './auth.service';
+import { MediaStorageService } from '../media/media-storage.service';
+import type { Profile } from 'passport-discord';
+import { Player } from '../players/entities/player.entity';
 
 describe('AuthService', () => {
   it('does not include the Discord access token in the signed JWT payload', async () => {
@@ -13,6 +16,7 @@ describe('AuthService', () => {
         AuthService,
         { provide: PlayersService, useValue: {} },
         { provide: JwtService, useValue: { signAsync } },
+        { provide: MediaStorageService, useValue: {} },
       ],
     }).compile();
     const service = module.get(AuthService);
@@ -33,5 +37,49 @@ describe('AuthService', () => {
       discord: player.discord,
     });
     expect(signAsync.mock.calls[0][0]).not.toHaveProperty('accessToken');
+  });
+
+  it('persists the mirrored R2 avatar returned during Discord login', async () => {
+    const sourceUrl =
+      'https://cdn.discordapp.com/avatars/1234/abcdef123456.png';
+    const storedUrl =
+      'https://media.example.com/avatars/discord/1234/abcdef123456.png';
+    const create: jest.MockedFunction<PlayersService['create']> = jest.fn(
+      (dto) =>
+        Promise.resolve({ id: 1, ...dto, campaigns: [] } as unknown as Player),
+    );
+    const playersService = {
+      buildDiscordAvatarUrl: jest.fn().mockReturnValue(sourceUrl),
+      findByDiscordId: jest.fn().mockResolvedValue(null),
+      create,
+    };
+    const mediaStorageService = {
+      storeDiscordAvatar: jest.fn().mockResolvedValue(storedUrl),
+    };
+    const service = new AuthService(
+      playersService as unknown as PlayersService,
+      {} as JwtService,
+      mediaStorageService as unknown as MediaStorageService,
+    );
+    const profile = {
+      id: '1234',
+      username: 'ember',
+      global_name: 'Ember',
+      avatar: 'abcdef123456',
+    } as unknown as Profile;
+
+    const player = await service.validateDiscordUser(
+      profile,
+      'access-token',
+      'refresh-token',
+    );
+
+    expect(mediaStorageService.storeDiscordAvatar).toHaveBeenCalledWith(
+      '1234',
+      'abcdef123456',
+      sourceUrl,
+    );
+    expect(create.mock.calls[0][0].discord?.avatar).toBe(storedUrl);
+    expect(player.discord?.avatar).toBe(storedUrl);
   });
 });

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import type { Profile } from 'passport-discord';
 import { PlayersService } from '../players/players.service';
 import { Player } from '../players/entities/player.entity';
+import { MediaStorageService } from '../media/media-storage.service';
 
 export type AuthPlayer = Player & {
   accessToken: string;
@@ -16,9 +17,12 @@ type DiscordProfileDetails = Profile & {
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly playersService: PlayersService,
     private readonly jwtService: JwtService,
+    private readonly mediaStorageService: MediaStorageService,
   ) {}
 
   async validateDiscordUser(
@@ -29,6 +33,18 @@ export class AuthService {
     void refreshToken;
 
     const discordProfile = profile as DiscordProfileDetails;
+    let avatar: string | undefined;
+    if (discordProfile.avatar) {
+      const discordAvatarUrl = this.playersService.buildDiscordAvatarUrl(
+        discordProfile.id,
+        discordProfile.avatar,
+      );
+      avatar = await this.storeDiscordAvatar(
+        discordProfile.id,
+        discordProfile.avatar,
+        discordAvatarUrl,
+      );
+    }
     const dto = {
       email: discordProfile.email ?? undefined,
       name: discordProfile.global_name ?? discordProfile.username,
@@ -36,12 +52,7 @@ export class AuthService {
         id: discordProfile.id,
         username: discordProfile.username,
         globalName: discordProfile.global_name ?? null,
-        avatar: discordProfile.avatar
-          ? this.playersService.buildDiscordAvatarUrl(
-              discordProfile.id,
-              discordProfile.avatar,
-            )
-          : undefined,
+        avatar,
       },
     };
 
@@ -61,5 +72,25 @@ export class AuthService {
   async signToken(player: Player): Promise<string> {
     const { id, email, name, discord } = player;
     return this.jwtService.signAsync({ id, email, name, discord });
+  }
+
+  private async storeDiscordAvatar(
+    discordId: string,
+    avatarHash: string,
+    sourceUrl: string,
+  ): Promise<string> {
+    try {
+      return await this.mediaStorageService.storeDiscordAvatar(
+        discordId,
+        avatarHash,
+        sourceUrl,
+      );
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `Could not mirror Discord avatar to R2; using Discord instead. ${reason}`,
+      );
+      return sourceUrl;
+    }
   }
 }

--- a/server/src/media/media-storage.service.spec.ts
+++ b/server/src/media/media-storage.service.spec.ts
@@ -1,0 +1,97 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { ConfigService } from '@nestjs/config';
+import { MediaStorageService } from './media-storage.service';
+
+const storageConfig = {
+  R2_ENDPOINT: 'https://account-id.r2.cloudflarestorage.com',
+  R2_BUCKET: 'sob-a-luz-do-bonfire',
+  R2_ACCESS_KEY_ID: 'access-key',
+  R2_SECRET_ACCESS_KEY: 'secret-key',
+  R2_PUBLIC_BASE_URL: 'https://media.example.com/',
+};
+
+describe('MediaStorageService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the original avatar URL when R2 is not configured', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+    const service = new MediaStorageService(new ConfigService({}));
+    const sourceUrl =
+      'https://cdn.discordapp.com/avatars/1234/abcdef123456.png';
+
+    await expect(
+      service.storeDiscordAvatar('1234', 'abcdef123456', sourceUrl),
+    ).resolves.toBe(sourceUrl);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('stores a Discord avatar under its immutable R2 key', async () => {
+    const body = new Uint8Array([1, 2, 3, 4]);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      }),
+    );
+    const sendSpy = jest
+      .spyOn(S3Client.prototype, 'send')
+      .mockResolvedValue({} as never);
+    const service = new MediaStorageService(new ConfigService(storageConfig));
+    const sourceUrl =
+      'https://cdn.discordapp.com/avatars/1234/abcdef123456.png';
+
+    await expect(
+      service.storeDiscordAvatar('1234', 'abcdef123456', sourceUrl),
+    ).resolves.toBe(
+      'https://media.example.com/avatars/discord/1234/abcdef123456.png',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe(sourceUrl);
+    expect(fetchSpy.mock.calls[0][1]?.headers).toEqual({ Accept: 'image/*' });
+    expect(fetchSpy.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+    const command = sendSpy.mock.calls[0][0] as PutObjectCommand;
+    expect(command.input).toMatchObject({
+      Bucket: 'sob-a-luz-do-bonfire',
+      Key: 'avatars/discord/1234/abcdef123456.png',
+      ContentType: 'image/png',
+      CacheControl: 'public, max-age=31536000, immutable',
+    });
+    expect(command.input.Body).toEqual(body);
+  });
+
+  it('rejects avatar URLs that are not the expected Discord CDN object', async () => {
+    const service = new MediaStorageService(new ConfigService(storageConfig));
+
+    await expect(
+      service.storeDiscordAvatar(
+        '1234',
+        'abcdef123456',
+        'https://example.com/avatar.png',
+      ),
+    ).rejects.toThrow('Invalid Discord avatar source.');
+  });
+
+  it('rejects remote responses that exceed the image limit', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array(), {
+        status: 200,
+        headers: {
+          'content-type': 'image/png',
+          'content-length': String(8 * 1024 * 1024 + 1),
+        },
+      }),
+    );
+    const sendSpy = jest.spyOn(S3Client.prototype, 'send');
+    const service = new MediaStorageService(new ConfigService(storageConfig));
+    const sourceUrl =
+      'https://cdn.discordapp.com/avatars/1234/abcdef123456.png';
+
+    await expect(
+      service.storeDiscordAvatar('1234', 'abcdef123456', sourceUrl),
+    ).rejects.toThrow('Discord avatar is larger than the storage limit.');
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/media/media-storage.service.ts
+++ b/server/src/media/media-storage.service.ts
@@ -1,0 +1,218 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+export type MediaCategory = 'avatars' | 'banners' | 'pictures' | 'assets';
+
+type UploadMediaObject = {
+  category: MediaCategory;
+  objectName: string;
+  body: Uint8Array;
+  contentType: string;
+  cacheControl?: string;
+};
+
+type StorageConfiguration = {
+  bucket: string;
+  publicBaseUrl: string;
+};
+
+const MAX_REMOTE_IMAGE_BYTES = 8 * 1024 * 1024;
+const REMOTE_IMAGE_TIMEOUT_MS = 10_000;
+const ALLOWED_IMAGE_TYPES = new Set([
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+@Injectable()
+export class MediaStorageService {
+  private readonly logger = new Logger(MediaStorageService.name);
+  private readonly client: S3Client | null;
+  private readonly storage: StorageConfiguration | null;
+  private readonly prefixes: Record<MediaCategory, string>;
+
+  constructor(private readonly config: ConfigService) {
+    this.prefixes = {
+      avatars: this.readPrefix('R2_AVATAR_PREFIX', 'avatars'),
+      banners: this.readPrefix('R2_BANNER_PREFIX', 'banners'),
+      pictures: this.readPrefix('R2_PICTURE_PREFIX', 'pictures'),
+      assets: this.readPrefix('R2_ASSET_PREFIX', 'assets'),
+    };
+
+    const endpoint = this.readOptional('R2_ENDPOINT');
+    const bucket = this.readOptional('R2_BUCKET');
+    const accessKeyId = this.readOptional('R2_ACCESS_KEY_ID');
+    const secretAccessKey = this.readOptional('R2_SECRET_ACCESS_KEY');
+    const publicBaseUrl = this.readOptional('R2_PUBLIC_BASE_URL');
+    const values = [
+      endpoint,
+      bucket,
+      accessKeyId,
+      secretAccessKey,
+      publicBaseUrl,
+    ];
+
+    if (values.every((value) => !value)) {
+      this.client = null;
+      this.storage = null;
+      return;
+    }
+
+    if (
+      !endpoint ||
+      !bucket ||
+      !accessKeyId ||
+      !secretAccessKey ||
+      !publicBaseUrl
+    ) {
+      this.logger.warn(
+        'R2 media storage is disabled because its configuration is incomplete.',
+      );
+      this.client = null;
+      this.storage = null;
+      return;
+    }
+
+    this.client = new S3Client({
+      region: this.readOptional('R2_REGION') ?? 'auto',
+      endpoint,
+      credentials: { accessKeyId, secretAccessKey },
+    });
+    this.storage = {
+      bucket,
+      publicBaseUrl: publicBaseUrl.replace(/\/+$/, ''),
+    };
+  }
+
+  isConfigured(): boolean {
+    return this.client !== null && this.storage !== null;
+  }
+
+  async storeDiscordAvatar(
+    discordId: string,
+    avatarHash: string,
+    sourceUrl: string,
+  ): Promise<string> {
+    if (!this.isConfigured()) {
+      return sourceUrl;
+    }
+
+    this.assertDiscordAvatarSource(discordId, avatarHash, sourceUrl);
+
+    const response = await fetch(sourceUrl, {
+      headers: { Accept: 'image/*' },
+      signal: AbortSignal.timeout(REMOTE_IMAGE_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Discord returned HTTP ${response.status} for an avatar.`,
+      );
+    }
+
+    const contentType = response.headers
+      .get('content-type')
+      ?.split(';', 1)[0]
+      .trim()
+      .toLowerCase();
+
+    if (!contentType || !ALLOWED_IMAGE_TYPES.has(contentType)) {
+      throw new Error('Discord returned an unsupported avatar format.');
+    }
+
+    const declaredLength = Number(response.headers.get('content-length'));
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > MAX_REMOTE_IMAGE_BYTES
+    ) {
+      throw new Error('Discord avatar is larger than the storage limit.');
+    }
+
+    const body = new Uint8Array(await response.arrayBuffer());
+    if (body.byteLength > MAX_REMOTE_IMAGE_BYTES) {
+      throw new Error('Discord avatar is larger than the storage limit.');
+    }
+
+    const extension = avatarHash.startsWith('a_') ? 'gif' : 'png';
+    return this.upload({
+      category: 'avatars',
+      objectName: `discord/${discordId}/${avatarHash}.${extension}`,
+      body,
+      contentType,
+      cacheControl: 'public, max-age=31536000, immutable',
+    });
+  }
+
+  async upload(object: UploadMediaObject): Promise<string> {
+    if (!this.client || !this.storage) {
+      throw new Error('R2 media storage is not configured.');
+    }
+
+    const objectName = this.normalizeObjectName(object.objectName);
+    const key = `${this.prefixes[object.category]}/${objectName}`;
+
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.storage.bucket,
+        Key: key,
+        Body: object.body,
+        ContentType: object.contentType,
+        CacheControl: object.cacheControl,
+      }),
+    );
+
+    return `${this.storage.publicBaseUrl}/${key
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/')}`;
+  }
+
+  private assertDiscordAvatarSource(
+    discordId: string,
+    avatarHash: string,
+    sourceUrl: string,
+  ): void {
+    if (!/^\d+$/.test(discordId)) {
+      throw new Error('Invalid Discord user ID.');
+    }
+
+    if (!/^(?:a_)?[a-f\d]+$/i.test(avatarHash)) {
+      throw new Error('Invalid Discord avatar hash.');
+    }
+
+    const extension = avatarHash.startsWith('a_') ? 'gif' : 'png';
+    const expectedUrl = `https://cdn.discordapp.com/avatars/${discordId}/${avatarHash}.${extension}`;
+
+    if (sourceUrl !== expectedUrl) {
+      throw new Error('Invalid Discord avatar source.');
+    }
+  }
+
+  private normalizeObjectName(objectName: string): string {
+    const normalized = objectName.replace(/^\/+|\/+$/g, '');
+
+    if (
+      !normalized ||
+      normalized
+        .split('/')
+        .some((part) => !part || part === '.' || part === '..') ||
+      !/^[a-zA-Z0-9._/-]+$/.test(normalized)
+    ) {
+      throw new Error('Invalid media object name.');
+    }
+
+    return normalized;
+  }
+
+  private readPrefix(name: string, fallback: string): string {
+    const prefix = this.readOptional(name) ?? fallback;
+    return this.normalizeObjectName(prefix);
+  }
+
+  private readOptional(name: string): string | undefined {
+    const value = this.config.get<string>(name)?.trim();
+    return value || undefined;
+  }
+}

--- a/server/src/media/media.module.ts
+++ b/server/src/media/media.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MediaStorageService } from './media-storage.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [MediaStorageService],
+  exports: [MediaStorageService],
+})
+export class MediaModule {}


### PR DESCRIPTION
## Summary
- add reusable Cloudflare R2 media storage with dedicated avatar, banner, picture, and asset prefixes
- mirror Discord avatars to the project bucket during login and persist the R2 public URL
- keep Discord as a login-safe fallback when storage is unavailable
- document the required storage configuration and add focused coverage

## Validation
- `pnpm run ci`
- `docker build -f server/Dockerfile server`
- verified the production Railway service has all required R2 variables without triggering an early deploy
- verified bucket upload, browser-style public read, and cleanup with a disposable object