### PR TITLE
feat: automate game recommendations

### DIFF
--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -1948,9 +1948,9 @@ a.meeting-callout:focus-visible {
 
 .backlog-limit strong {
   color: #f2a45c;
-  font-family: 'Cinzel Decorative', cursive;
+  font-family: 'Mulish', sans-serif;
   font-size: 51px;
-  font-weight: 500;
+  font-weight: 800;
   line-height: 1;
   text-shadow: 0 5px 20px rgba(182, 65, 30, 0.26);
 }
@@ -1962,6 +1962,59 @@ a.meeting-callout:focus-visible {
   letter-spacing: 0.1em;
   line-height: 1.5;
   text-transform: uppercase;
+}
+
+.backlog-shelf {
+  min-width: 0;
+}
+
+.backlog-shelf + .backlog-shelf {
+  margin-top: 66px;
+}
+
+.backlog-shelf--next-vote {
+  position: relative;
+  padding: 27px;
+  background:
+    radial-gradient(ellipse 68% 190px at 50% 0, rgba(192, 91, 47, 0.11), transparent 76%),
+    rgba(16, 13, 19, 0.58);
+  border: 1px solid rgba(242, 164, 92, 0.14);
+  border-radius: 9px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.16);
+}
+
+.backlog-shelf__heading {
+  display: flex;
+  margin-bottom: 22px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.backlog-shelf__heading > div {
+  flex: 0 0 auto;
+}
+
+.backlog-shelf__heading h2,
+.backlog-shelf__heading p {
+  margin: 0;
+}
+
+.backlog-shelf__heading h2 {
+  color: rgba(255, 255, 255, 0.91);
+  font-family: 'Mulish', sans-serif;
+  font-size: clamp(21px, 2.6vw, 28px);
+  font-weight: 820;
+  letter-spacing: -0.035em;
+  white-space: nowrap;
+}
+
+.backlog-shelf__heading p {
+  max-width: 520px;
+  color: rgba(255, 255, 255, 0.44);
+  font-size: 12px;
+  line-height: 1.55;
+  text-align: right;
 }
 
 .backlog-grid {
@@ -1981,6 +2034,54 @@ a.meeting-callout:focus-visible {
     0 -10px 28px rgba(174, 65, 32, 0.07),
     0 13px 28px rgba(0, 0, 0, 0.22),
     inset 0 1px rgba(255, 220, 190, 0.05);
+}
+
+.backlog-card--next-vote {
+  border-top-color: rgba(245, 181, 117, 0.26);
+  box-shadow:
+    0 15px 30px rgba(0, 0, 0, 0.24),
+    inset 0 1px rgba(255, 224, 194, 0.035);
+}
+
+.next-vote-fill-card {
+  display: flex;
+  min-height: 234px;
+  padding: 24px;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: rgba(255, 255, 255, 0.5);
+  background:
+    linear-gradient(180deg, rgba(242, 164, 92, 0.035), transparent 58%), rgba(8, 7, 10, 0.28);
+  border: 1px dashed rgba(242, 164, 92, 0.22);
+  border-radius: 8px;
+}
+
+.next-vote-fill-card__count {
+  color: #f2a45c;
+  font-family: 'Mulish', sans-serif;
+  font-size: 39px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.next-vote-fill-card h3,
+.next-vote-fill-card p {
+  margin: 0;
+}
+
+.next-vote-fill-card h3 {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.next-vote-fill-card p {
+  max-width: 190px;
+  margin-top: 5px;
+  color: rgba(255, 255, 255, 0.36);
+  font-size: 10px;
+  line-height: 1.5;
 }
 
 .backlog-card__art {
@@ -2019,6 +2120,33 @@ a.meeting-callout:focus-visible {
 .backlog-card__count strong {
   color: #f2a45c;
   font-size: 12px;
+}
+
+.backlog-card__count--aside {
+  right: 12px;
+  left: auto;
+}
+
+.backlog-card__next-vote {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 1;
+  display: inline-flex;
+  min-height: 29px;
+  padding: 6px 9px;
+  align-items: center;
+  gap: 5px;
+  color: #f5b575;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  background: rgba(24, 14, 13, 0.86);
+  border: 1px solid rgba(245, 181, 117, 0.28);
+  border-radius: 5px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.28);
+  text-transform: uppercase;
+  backdrop-filter: blur(6px);
 }
 
 .backlog-card__title {
@@ -2461,6 +2589,24 @@ a.meeting-callout:focus-visible {
 
   .backlog-limit strong {
     font-size: 42px;
+  }
+
+  .backlog-shelf--next-vote {
+    padding: 21px;
+  }
+
+  .backlog-shelf__heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  .backlog-shelf__heading p {
+    text-align: left;
+  }
+
+  .backlog-shelf__heading h2 {
+    white-space: normal;
   }
 
   .backlog-rubble {

--- a/client/src/components/BacklogGameCard.vue
+++ b/client/src/components/BacklogGameCard.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { CheckmarkCircle, LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
+import { NIcon, NTooltip } from 'naive-ui'
+import { formatDurationLabel, getGameCover } from '@/services/gameService'
+import type { BacklogGame, GameRecommender } from '@/types/Game'
+
+const props = withDefaults(
+  defineProps<{
+    game: BacklogGame
+    retirementThreshold: number
+    nextVote?: boolean
+  }>(),
+  { nextVote: false },
+)
+
+const failedRecommenderAvatars = ref(new Set<number>())
+
+const appearanceLabel = (count: number) => {
+  if (count === 0) return 'Ainda não passou'
+  return `${count} ${count === 1 ? 'passagem' : 'passagens'}`
+}
+
+const coverStyle = () => ({
+  backgroundImage: getGameCover(props.game) ? `url('${getGameCover(props.game)}')` : undefined,
+})
+
+const hasRecommenderAvatar = (recommender: GameRecommender) =>
+  Boolean(recommender.avatar) && !failedRecommenderAvatars.value.has(recommender.id)
+
+const markRecommenderAvatarFailed = (recommender: GameRecommender) => {
+  failedRecommenderAvatars.value = new Set(failedRecommenderAvatars.value).add(recommender.id)
+}
+
+const recommenderInitial = (recommender: GameRecommender) =>
+  recommender.name.trim().charAt(0).toLocaleUpperCase('pt-BR') || '?'
+
+const visibleRecommenders = () => (props.game.recommendedBy ?? []).slice(0, 3)
+
+const hiddenRecommenderNames = () =>
+  (props.game.recommendedBy ?? [])
+    .slice(3)
+    .map((recommender) => recommender.name)
+    .join(', ')
+</script>
+
+<template>
+  <article class="backlog-card" :class="{ 'backlog-card--next-vote': nextVote }">
+    <div class="backlog-card__art" :style="coverStyle()">
+      <div class="backlog-card__shade"></div>
+
+      <span v-if="nextVote" class="backlog-card__next-vote">
+        <n-icon size="14"><CheckmarkCircle /></n-icon>
+        Próxima votação
+      </span>
+
+      <span class="backlog-card__count" :class="{ 'backlog-card__count--aside': nextVote }">
+        <strong>{{ game.electionAppearances }}</strong>
+        / {{ retirementThreshold }}
+      </span>
+
+      <header class="backlog-card__title">
+        <h3>{{ game.title }}</h3>
+      </header>
+    </div>
+
+    <footer class="backlog-card__footer">
+      <div class="backlog-card__history">
+        <div
+          class="backlog-embers"
+          :aria-label="`${appearanceLabel(game.electionAppearances)} de ${retirementThreshold} antes de virar cinza`"
+        >
+          <span
+            v-for="position in retirementThreshold"
+            :key="position"
+            :class="{ 'backlog-ember--lit': position <= game.electionAppearances }"
+            aria-hidden="true"
+          ></span>
+        </div>
+        <span v-if="!nextVote">{{ appearanceLabel(game.electionAppearances) }}</span>
+      </div>
+
+      <div
+        v-if="game.recommendedBy?.length"
+        class="backlog-card__recommenders"
+        aria-label="Pessoas que apresentaram este jogo ao grupo"
+      >
+        <n-tooltip
+          v-for="recommender in visibleRecommenders()"
+          :key="recommender.id"
+          placement="top"
+        >
+          <template #trigger>
+            <span
+              class="backlog-recommender"
+              tabindex="0"
+              :aria-label="`Apresentado por ${recommender.name}`"
+            >
+              <img
+                v-if="hasRecommenderAvatar(recommender)"
+                :src="recommender.avatar ?? undefined"
+                alt=""
+                @error="markRecommenderAvatarFailed(recommender)"
+              />
+              <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
+            </span>
+          </template>
+          Apresentado por {{ recommender.name }}
+        </n-tooltip>
+
+        <n-tooltip v-if="game.recommendedBy.length > 3" placement="top">
+          <template #trigger>
+            <span
+              class="backlog-recommender backlog-recommender--more"
+              tabindex="0"
+              :aria-label="`Mais ${game.recommendedBy.length - 3} pessoas apresentaram este jogo`"
+            >
+              +{{ game.recommendedBy.length - 3 }}
+            </span>
+          </template>
+          Também apresentado por {{ hiddenRecommenderNames() }}
+        </n-tooltip>
+      </div>
+
+      <nav class="backlog-card__links" :aria-label="`Links de ${game.title}`">
+        <a
+          v-if="game.steam"
+          :href="game.steam"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Abrir na Steam"
+        >
+          <n-icon size="17"><LogoSteam /></n-icon>
+        </a>
+        <a
+          v-if="game.trailer"
+          :href="game.trailer"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Assistir ao trailer"
+        >
+          <n-icon size="17"><LogoYoutube /></n-icon>
+        </a>
+        <a
+          v-if="game.howLongToBeatUrl"
+          :href="game.howLongToBeatUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          :aria-label="`Ver duração${formatDurationLabel(game.durationLabel) ? `: ${formatDurationLabel(game.durationLabel)}` : ''}`"
+        >
+          <n-icon size="17"><TimeOutline /></n-icon>
+        </a>
+      </nav>
+    </footer>
+  </article>
+</template>

--- a/client/src/components/GameRecommendation.vue
+++ b/client/src/components/GameRecommendation.vue
@@ -1,0 +1,758 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import {
+  CheckmarkCircle,
+  FlameOutline,
+  SearchOutline,
+  TimeOutline,
+  TrashOutline,
+} from '@vicons/ionicons5'
+import { NIcon, NSpin } from 'naive-ui'
+import axios from 'axios'
+import { useCampaignStore } from '@/stores/campaign'
+import type { CampaignPlayer } from '@/types/Campaign'
+import type {
+  CreatedGameRecommendation,
+  GameRecommendationAssessment,
+  SteamGameSearchResult,
+} from '@/types/Game'
+import {
+  assessGameRecommendation,
+  createGameRecommendation,
+  deleteGameRecommendation,
+  searchGameRecommendations,
+} from '@/services/gameService'
+
+const props = defineProps<{
+  campaignUser: CampaignPlayer | null
+}>()
+
+type RecommendationState =
+  | 'idle'
+  | 'empty'
+  | 'searching'
+  | 'assessing'
+  | 'assessed'
+  | 'submitting'
+  | 'success'
+  | 'error'
+
+const campaignStore = useCampaignStore()
+const query = ref('')
+const results = ref<SteamGameSearchResult[]>([])
+const selectedGame = ref<SteamGameSearchResult | null>(null)
+const assessment = ref<GameRecommendationAssessment | null>(null)
+const recommendation = ref<CreatedGameRecommendation | null>(null)
+const state = ref<RecommendationState>('idle')
+const errorMessage = ref('')
+const removingSuggestion = ref(false)
+let searchTimer: number | undefined
+let searchController: AbortController | null = null
+let searchSequence = 0
+
+const existingSuggestion = computed(
+  () => props.campaignUser?.suggestedGame ?? recommendation.value?.game ?? null,
+)
+
+const statusMessage = computed(() => {
+  if (state.value === 'assessing') {
+    return 'Conferindo o tempo no HowLongToBeat e reunindo os detalhes…'
+  }
+
+  if (state.value === 'submitting') {
+    return 'Guardando esta sugestão nas Brasas…'
+  }
+
+  if (!assessment.value) return ''
+
+  switch (assessment.value.reason) {
+    case 'too_long':
+      return `${assessment.value.game.title} leva cerca de ${formatHours(assessment.value.game.mainExtraHours)} na campanha com extras. O limite do grupo é ${assessment.value.limitHours} h.`
+    case 'duration_unavailable':
+      return 'Não encontramos uma estimativa confiável para a campanha com extras. Por segurança, este jogo não pode ser sugerido agora.'
+    case 'not_a_game':
+      return 'Este item da Steam não é um jogo completo.'
+    case 'already_played':
+      return 'Este jogo já foi escolhido pelo grupo em uma campanha anterior.'
+    case 'already_suggested':
+      return `Você já sugeriu ${assessment.value.existingSuggestion?.title ?? 'outro jogo'} neste ciclo.`
+    default:
+      return `Cerca de ${formatHours(assessment.value.game.mainExtraHours)} na campanha com extras. Está dentro do limite do grupo.`
+  }
+})
+
+const formatHours = (hours?: number | null) => {
+  if (hours === null || hours === undefined) return 'tempo indisponível'
+  const rounded = Math.round(hours * 2) / 2
+  return `${new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 1 }).format(rounded)} h`
+}
+
+const clearSearch = () => {
+  if (searchTimer) window.clearTimeout(searchTimer)
+  searchController?.abort()
+  searchController = null
+  results.value = []
+}
+
+watch(query, (value) => {
+  if (selectedGame.value?.title === value) return
+
+  selectedGame.value = null
+  assessment.value = null
+  recommendation.value = null
+  errorMessage.value = ''
+  clearSearch()
+
+  const normalized = value.trim().replace(/\s+/g, ' ')
+  if (normalized.length < 2) {
+    state.value = 'idle'
+    return
+  }
+
+  const sequence = ++searchSequence
+  state.value = 'searching'
+  searchTimer = window.setTimeout(async () => {
+    searchController = new AbortController()
+
+    try {
+      const matches = await searchGameRecommendations(normalized, searchController.signal)
+      if (sequence !== searchSequence) return
+      results.value = matches
+      state.value = matches.length ? 'idle' : 'empty'
+    } catch (error: unknown) {
+      if (axios.isCancel(error) || sequence !== searchSequence) return
+      state.value = 'error'
+      errorMessage.value = 'Não foi possível pesquisar na Steam agora. Tente novamente.'
+    }
+  }, 350)
+})
+
+const selectGame = async (game: SteamGameSearchResult) => {
+  clearSearch()
+  selectedGame.value = game
+  query.value = game.title
+  assessment.value = null
+  recommendation.value = null
+  errorMessage.value = ''
+  state.value = 'assessing'
+
+  try {
+    assessment.value = await assessGameRecommendation(game.steamAppId)
+    state.value = 'assessed'
+  } catch {
+    state.value = 'error'
+    errorMessage.value = 'A verificação não terminou. Tente selecionar o jogo novamente.'
+  }
+}
+
+const submitRecommendation = async () => {
+  const token = assessment.value?.assessmentToken
+  if (!token || !assessment.value?.eligible) return
+
+  state.value = 'submitting'
+  errorMessage.value = ''
+
+  try {
+    recommendation.value = await createGameRecommendation(token)
+    state.value = 'success'
+    await campaignStore.init()
+  } catch (error: unknown) {
+    state.value = 'error'
+    errorMessage.value = axios.isAxiosError<{ message?: string }>(error)
+      ? error.response?.data?.message || 'Não foi possível salvar a sugestão.'
+      : 'Não foi possível salvar a sugestão.'
+  }
+}
+
+const removeSuggestion = async () => {
+  if (removingSuggestion.value) return
+
+  removingSuggestion.value = true
+  errorMessage.value = ''
+
+  try {
+    await deleteGameRecommendation()
+    recommendation.value = null
+    resetSelection()
+    await campaignStore.init()
+  } catch (error: unknown) {
+    errorMessage.value = axios.isAxiosError<{ message?: string }>(error)
+      ? error.response?.data?.message || 'Não foi possível remover a sugestão.'
+      : 'Não foi possível remover a sugestão.'
+  } finally {
+    removingSuggestion.value = false
+  }
+}
+
+const resetSelection = () => {
+  selectedGame.value = null
+  assessment.value = null
+  recommendation.value = null
+  query.value = ''
+  state.value = 'idle'
+  errorMessage.value = ''
+}
+
+onBeforeUnmount(clearSearch)
+</script>
+
+<template>
+  <section class="recommendation-hearth" aria-labelledby="recommendation-title">
+    <header class="recommendation-heading">
+      <div class="recommendation-heading__icon" aria-hidden="true">
+        <n-icon size="20"><FlameOutline /></n-icon>
+      </div>
+      <div>
+        <p>Próxima votação</p>
+        <h2 id="recommendation-title">Traga um jogo para a fogueira</h2>
+        <span>
+          Vale jogo de até 20 horas, considerando a campanha e os extras. A pesquisa e os detalhes
+          ficam por nossa conta.
+        </span>
+      </div>
+    </header>
+
+    <template v-if="existingSuggestion">
+      <div class="recommendation-complete" role="status">
+        <n-icon size="25"><CheckmarkCircle /></n-icon>
+        <div>
+          <span>Sua sugestão deste ciclo</span>
+          <strong>{{ existingSuggestion.title }}</strong>
+          <p>Já está nas Brasas e tem lugar garantido na próxima votação.</p>
+        </div>
+        <button
+          type="button"
+          class="recommendation-remove"
+          :disabled="removingSuggestion"
+          @click="removeSuggestion"
+        >
+          <n-spin v-if="removingSuggestion" :size="14" />
+          <n-icon v-else size="15"><TrashOutline /></n-icon>
+          {{ removingSuggestion ? 'Removendo…' : 'Remover e escolher outro' }}
+        </button>
+      </div>
+      <p v-if="errorMessage" class="recommendation-error" role="alert">
+        {{ errorMessage }}
+      </p>
+    </template>
+
+    <div v-else class="recommendation-flow">
+      <div class="game-combobox">
+        <n-icon class="game-combobox__search" size="19"><SearchOutline /></n-icon>
+        <input
+          v-model="query"
+          type="search"
+          role="combobox"
+          autocomplete="off"
+          placeholder="Comece a escrever o nome de um jogo…"
+          aria-label="Pesquisar jogo no acervo e na Steam"
+          :aria-expanded="results.length > 0"
+          aria-controls="game-search-results"
+          :disabled="state === 'assessing' || state === 'submitting'"
+        />
+        <n-spin v-if="state === 'searching'" class="game-combobox__spinner" size="small" />
+
+        <div
+          v-if="results.length"
+          id="game-search-results"
+          class="game-search-results"
+          role="listbox"
+        >
+          <button
+            v-for="game in results"
+            :key="game.steamAppId"
+            type="button"
+            role="option"
+            @click="selectGame(game)"
+          >
+            <img v-if="game.image" :src="game.image" alt="" />
+            <span v-else class="game-search-results__placeholder" aria-hidden="true"></span>
+            <strong>{{ game.title }}</strong>
+            <small>{{ game.source === 'catalog' ? 'No acervo' : 'Steam' }}</small>
+          </button>
+        </div>
+      </div>
+
+      <p v-if="state === 'empty'" class="recommendation-empty" role="status">
+        Nenhum jogo encontrado no acervo ou na Steam. Tente outro nome.
+      </p>
+
+      <div
+        v-if="state === 'assessing' || state === 'submitting'"
+        class="recommendation-check recommendation-check--loading"
+        role="status"
+        aria-live="polite"
+      >
+        <n-spin :size="26" :stroke-width="12" stroke="#e7a06c" />
+        <span>{{ statusMessage }}</span>
+      </div>
+
+      <article
+        v-else-if="assessment"
+        class="recommendation-check"
+        :class="
+          assessment.eligible ? 'recommendation-check--eligible' : 'recommendation-check--blocked'
+        "
+        aria-live="polite"
+      >
+        <div
+          class="recommendation-game__cover"
+          :style="
+            assessment.game.cover
+              ? { backgroundImage: `url('${assessment.game.cover}')` }
+              : undefined
+          "
+        ></div>
+        <div class="recommendation-game__details">
+          <span>{{ assessment.eligible ? 'Dentro do limite' : 'Fora da regra' }}</span>
+          <h3>{{ assessment.game.title }}</h3>
+          <p>{{ statusMessage }}</p>
+          <a
+            v-if="assessment.game.howLongToBeatUrl"
+            :href="assessment.game.howLongToBeatUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <n-icon size="15"><TimeOutline /></n-icon>
+            Ver no HowLongToBeat
+          </a>
+        </div>
+        <div v-if="assessment.eligible" class="recommendation-game__action">
+          <small>Usa 1 token deste ciclo</small>
+          <button type="button" @click="submitRecommendation">
+            <n-icon size="16"><FlameOutline /></n-icon>
+            Sugerir este jogo
+          </button>
+        </div>
+        <button v-else type="button" class="recommendation-try-another" @click="resetSelection">
+          Escolher outro
+        </button>
+      </article>
+
+      <p v-if="state === 'error'" class="recommendation-error" role="alert">
+        {{ errorMessage }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.recommendation-hearth {
+  position: relative;
+  margin: -32px 0 76px;
+  padding: 24px;
+  overflow: visible;
+  background: linear-gradient(145deg, rgba(25, 19, 27, 0.96), rgba(14, 12, 18, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 9px;
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.22);
+}
+
+.recommendation-heading {
+  display: flex;
+  margin-bottom: 19px;
+  align-items: flex-start;
+  gap: 13px;
+}
+
+.recommendation-heading__icon {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  align-items: center;
+  justify-content: center;
+  color: #eea064;
+  background: rgba(157, 66, 35, 0.13);
+  border: 1px solid rgba(238, 160, 100, 0.2);
+  border-radius: 50%;
+}
+
+.recommendation-heading p,
+.recommendation-heading h2,
+.recommendation-heading span,
+.recommendation-check p,
+.recommendation-complete p {
+  margin: 0;
+}
+
+.recommendation-heading p,
+.recommendation-game__details > span,
+.recommendation-complete span {
+  color: rgba(242, 164, 92, 0.7);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.recommendation-heading h2 {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 18px;
+  font-weight: 750;
+  letter-spacing: -0.015em;
+}
+
+.recommendation-heading span {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 12px;
+}
+
+.game-combobox {
+  position: relative;
+  z-index: 5;
+}
+
+.game-combobox input {
+  width: 100%;
+  height: 52px;
+  padding: 0 48px;
+  color: rgba(255, 255, 255, 0.88);
+  font:
+    600 14px 'Mulish',
+    sans-serif;
+  outline: none;
+  background: rgba(5, 4, 8, 0.46);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 7px;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.game-combobox input:focus {
+  border-color: rgba(238, 160, 100, 0.52);
+  box-shadow: 0 0 0 3px rgba(213, 111, 58, 0.08);
+}
+
+.game-combobox input::placeholder {
+  color: rgba(255, 255, 255, 0.28);
+}
+
+.game-combobox__search,
+.game-combobox__spinner {
+  position: absolute;
+  top: 16px;
+  z-index: 1;
+}
+
+.game-combobox__search {
+  left: 17px;
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.game-combobox__spinner {
+  right: 17px;
+}
+
+.game-search-results {
+  position: absolute;
+  bottom: calc(100% + 7px);
+  right: 0;
+  left: 0;
+  max-height: 360px;
+  padding: 6px;
+  overflow-y: auto;
+  background: #151119;
+  border: 1px solid rgba(238, 160, 100, 0.2);
+  border-radius: 8px;
+  box-shadow: 0 22px 55px rgba(0, 0, 0, 0.52);
+}
+
+.game-search-results button {
+  display: grid;
+  width: 100%;
+  min-height: 58px;
+  padding: 7px;
+  grid-template-columns: 96px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.78);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.game-search-results button:hover,
+.game-search-results button:focus-visible {
+  background: rgba(230, 139, 80, 0.09);
+  outline: none;
+}
+
+.game-search-results img,
+.game-search-results__placeholder {
+  width: 96px;
+  height: 45px;
+  object-fit: cover;
+  background: #28202d;
+  border-radius: 3px;
+}
+
+.game-search-results strong {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.game-search-results small {
+  padding-right: 8px;
+  color: rgba(255, 255, 255, 0.28);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.recommendation-check {
+  display: grid;
+  min-height: 116px;
+  margin-top: 14px;
+  grid-template-columns: 190px minmax(0, 1fr) auto;
+  align-items: center;
+  overflow: hidden;
+  background: rgba(7, 6, 9, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 7px;
+}
+
+.recommendation-check--eligible {
+  border-color: rgba(117, 185, 128, 0.25);
+}
+
+.recommendation-check--blocked {
+  border-color: rgba(207, 104, 76, 0.25);
+}
+
+.recommendation-check--loading {
+  display: flex;
+  min-height: 84px;
+  padding: 20px;
+  justify-content: center;
+  gap: 13px;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 12px;
+}
+
+.recommendation-game__cover {
+  width: 100%;
+  height: 100%;
+  min-height: 116px;
+  background-color: #29222e;
+  background-position: center;
+  background-size: cover;
+  box-shadow: inset -34px 0 40px rgba(10, 8, 12, 0.5);
+}
+
+.recommendation-game__details {
+  min-width: 0;
+  padding: 15px 18px;
+}
+
+.recommendation-game__details h3 {
+  margin: 2px 0 4px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 18px;
+  font-weight: 750;
+}
+
+.recommendation-game__details p {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.recommendation-game__details a {
+  display: inline-flex;
+  margin-top: 6px;
+  align-items: center;
+  gap: 5px;
+  color: #d99766;
+  font-size: 10px;
+  text-decoration: none;
+}
+
+.recommendation-game__action {
+  display: flex;
+  padding: 16px 18px 16px 0;
+  align-items: flex-end;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.recommendation-game__action small {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 9px;
+}
+
+.recommendation-game__action button,
+.recommendation-try-another {
+  display: inline-flex;
+  min-height: 38px;
+  padding: 8px 14px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: rgba(255, 255, 255, 0.66);
+  font:
+    650 11px 'Mulish',
+    sans-serif;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.recommendation-game__action button:hover,
+.recommendation-game__action button:focus-visible,
+.recommendation-try-another:hover,
+.recommendation-try-another:focus-visible {
+  color: #f4b184;
+  background: rgba(242, 164, 92, 0.055);
+  border-color: rgba(242, 164, 92, 0.34);
+  outline: none;
+}
+
+.recommendation-try-another {
+  margin-right: 18px;
+  color: rgba(255, 255, 255, 0.64);
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.recommendation-error,
+.recommendation-empty {
+  margin: 12px 0 0;
+  color: #e7a28e;
+  font-size: 12px;
+}
+
+.recommendation-empty {
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.recommendation-complete {
+  display: flex;
+  min-height: 66px;
+  padding: 14px 16px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(6, 5, 8, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 7px;
+}
+
+.recommendation-complete {
+  justify-content: flex-start;
+  color: #8fc899;
+}
+
+.recommendation-complete > div {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.recommendation-complete strong {
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.recommendation-complete p {
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 11px;
+}
+
+.recommendation-remove {
+  display: inline-flex;
+  min-height: 34px;
+  padding: 7px 10px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  color: rgba(255, 255, 255, 0.48);
+  font:
+    650 10px 'Mulish',
+    sans-serif;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.recommendation-remove:hover,
+.recommendation-remove:focus-visible {
+  color: #e9a18d;
+  background: rgba(207, 104, 76, 0.055);
+  border-color: rgba(207, 104, 76, 0.3);
+  outline: none;
+}
+
+.recommendation-remove:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+@media (max-width: 720px) {
+  .recommendation-hearth {
+    padding: 18px;
+  }
+
+  .recommendation-check {
+    grid-template-columns: 1fr;
+  }
+
+  .recommendation-game__cover {
+    height: 150px;
+  }
+
+  .recommendation-game__action {
+    padding: 0 18px 18px;
+    align-items: stretch;
+  }
+
+  .recommendation-game__action small {
+    text-align: center;
+  }
+
+  .recommendation-complete {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .recommendation-remove {
+    width: 100%;
+  }
+
+  .recommendation-try-another {
+    margin: 0 18px 18px;
+  }
+}
+
+@media (max-width: 480px) {
+  .game-search-results button {
+    grid-template-columns: 76px 1fr;
+  }
+
+  .game-search-results img,
+  .game-search-results__placeholder {
+    width: 76px;
+    height: 40px;
+  }
+
+  .game-search-results small {
+    display: none;
+  }
+}
+</style>

--- a/client/src/components/__tests__/Backlog.spec.ts
+++ b/client/src/components/__tests__/Backlog.spec.ts
@@ -1,0 +1,85 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Backlog from '@/views/Backlog.vue'
+
+const gameServiceMocks = vi.hoisted(() => ({
+  getGameBacklog: vi.fn(),
+  getGameCover: vi.fn(() => ''),
+  formatDurationLabel: vi.fn(() => ''),
+}))
+
+vi.mock('@/services/gameService', () => gameServiceMocks)
+
+describe('Backlog', () => {
+  beforeEach(() => {
+    gameServiceMocks.getGameBacklog.mockResolvedValue({
+      retirementThreshold: 3,
+      targetPoolSize: 5,
+      nextVoteFillCount: 1,
+      rubble: [],
+      games: [
+        {
+          id: 1,
+          title: 'Fresh Game',
+          suggestion: true,
+          electionAppearances: 0,
+          guaranteedNextVote: true,
+          recommendedBy: [{ id: 10, name: 'Ana', avatar: null }],
+        },
+        {
+          id: 2,
+          title: 'Returning Game',
+          suggestion: true,
+          electionAppearances: 1,
+          guaranteedNextVote: false,
+          recommendedBy: [],
+        },
+      ],
+    })
+  })
+
+  it('separates pristine suggestions into the next-vote shelf', async () => {
+    const wrapper = mount(Backlog)
+    await flushPromises()
+
+    const nextVoteShelf = wrapper.get('.backlog-shelf--next-vote')
+    expect(nextVoteShelf.text()).toContain('Na próxima votação')
+    expect(nextVoteShelf.text()).toContain('Fresh Game')
+    expect(nextVoteShelf.text()).not.toContain('Ainda não passou')
+    expect(nextVoteShelf.text()).toContain('+1')
+    expect(nextVoteShelf.text()).toContain('jogo das Brasas')
+    expect(nextVoteShelf.text()).not.toContain('Returning Game')
+
+    const regularShelf = wrapper
+      .findAll('.backlog-shelf')
+      .find((shelf) => !shelf.classes().includes('backlog-shelf--next-vote'))
+    expect(regularShelf?.text()).toContain('Outros jogos nas Brasas')
+    expect(regularShelf?.text()).toContain('Returning Game')
+    expect(regularShelf?.text()).not.toContain('Fresh Game')
+  })
+
+  it('does not show the next-vote shelf without an active recommendation', async () => {
+    gameServiceMocks.getGameBacklog.mockResolvedValue({
+      retirementThreshold: 3,
+      targetPoolSize: 5,
+      nextVoteFillCount: 1,
+      rubble: [],
+      games: [
+        {
+          id: 2,
+          title: 'Waiting Game',
+          suggestion: true,
+          electionAppearances: 1,
+          guaranteedNextVote: false,
+          recommendedBy: [],
+        },
+      ],
+    })
+
+    const wrapper = mount(Backlog)
+    await flushPromises()
+
+    expect(wrapper.find('.backlog-shelf--next-vote').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Waiting Game')
+  })
+})

--- a/client/src/components/__tests__/GameRecommendation.spec.ts
+++ b/client/src/components/__tests__/GameRecommendation.spec.ts
@@ -1,0 +1,125 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import GameRecommendation from '../GameRecommendation.vue'
+import { useCampaignStore } from '@/stores/campaign'
+
+const gameServiceMocks = vi.hoisted(() => ({
+  searchGameRecommendations: vi.fn(),
+  assessGameRecommendation: vi.fn(),
+  createGameRecommendation: vi.fn(),
+  deleteGameRecommendation: vi.fn(),
+}))
+
+vi.mock('@/services/gameService', () => gameServiceMocks)
+
+describe('GameRecommendation', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    pinia = createPinia()
+    setActivePinia(pinia)
+    vi.spyOn(useCampaignStore(), 'init').mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    Object.values(gameServiceMocks).forEach((mock) => mock.mockReset())
+  })
+
+  it('searches, verifies, and submits an eligible game', async () => {
+    gameServiceMocks.searchGameRecommendations.mockResolvedValue([
+      {
+        steamAppId: 42,
+        title: 'Example Game',
+        image: 'https://example.com/capsule.jpg',
+        source: 'steam',
+      },
+    ])
+    gameServiceMocks.assessGameRecommendation.mockResolvedValue({
+      eligible: true,
+      reason: 'eligible',
+      limitHours: 20,
+      assessmentToken: 'signed-assessment',
+      game: {
+        steamAppId: 42,
+        title: 'Example Game',
+        steam: 'https://store.steampowered.com/app/42/',
+        cover: 'https://example.com/header.jpg',
+        howLongToBeatUrl: 'https://howlongtobeat.com/game/99',
+        durationLabel: '12–18 h',
+        mainHours: 12,
+        mainExtraHours: 18,
+        howLongToBeatTitle: 'Example Game',
+      },
+    })
+    gameServiceMocks.createGameRecommendation.mockResolvedValue({
+      created: true,
+      alreadyRecommended: false,
+      electionAppearances: 0,
+      game: {
+        id: 9,
+        title: 'Example Game',
+        suggestion: true,
+      },
+    })
+    const wrapper = mount(GameRecommendation, {
+      props: { campaignUser: null },
+      global: { plugins: [pinia] },
+    })
+
+    await wrapper.get('input').setValue('Example')
+    await vi.advanceTimersByTimeAsync(350)
+    await flushPromises()
+
+    expect(gameServiceMocks.searchGameRecommendations).toHaveBeenCalledWith(
+      'Example',
+      expect.any(AbortSignal),
+    )
+    await wrapper.get('[role="option"]').trigger('click')
+    await flushPromises()
+
+    expect(gameServiceMocks.assessGameRecommendation).toHaveBeenCalledWith(42)
+    expect(wrapper.text()).toContain('18 h na campanha com extras')
+
+    const submit = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Sugerir este jogo'))
+    expect(submit).toBeDefined()
+    await submit?.trigger('click')
+    await flushPromises()
+
+    expect(gameServiceMocks.createGameRecommendation).toHaveBeenCalledWith('signed-assessment')
+    expect(wrapper.text()).toContain('Sua sugestão deste ciclo')
+    expect(wrapper.text()).toContain('Já está nas Brasas')
+    expect(wrapper.text()).toContain('lugar garantido na próxima votação')
+  })
+
+  it('hides search while a suggestion exists and removes it immediately', async () => {
+    gameServiceMocks.deleteGameRecommendation.mockResolvedValue(undefined)
+    const wrapper = mount(GameRecommendation, {
+      props: {
+        campaignUser: {
+          id: 5,
+          player: { id: 10, name: 'Ana' },
+          played_the_game: false,
+          finished_the_game: false,
+          suggested_a_game: true,
+          suggestedGame: { id: 9, title: 'Silent Hill f', suggestion: true },
+          partook_in_the_meeting: false,
+          tokens: 0,
+        },
+      },
+      global: { plugins: [pinia] },
+    })
+
+    expect(wrapper.find('input').exists()).toBe(false)
+    await wrapper.get('.recommendation-remove').trigger('click')
+    await flushPromises()
+
+    expect(gameServiceMocks.deleteGameRecommendation).toHaveBeenCalledOnce()
+    expect(useCampaignStore().init).toHaveBeenCalled()
+  })
+})

--- a/client/src/services/gameService.ts
+++ b/client/src/services/gameService.ts
@@ -1,9 +1,48 @@
 ﻿import api from './api'
-import type { Game, GameBacklog } from '@/types/Game'
+import type {
+  CreatedGameRecommendation,
+  Game,
+  GameBacklog,
+  GameRecommendationAssessment,
+  SteamGameSearchResult,
+} from '@/types/Game'
 
 export const getGameBacklog = async (): Promise<GameBacklog> => {
   const { data } = await api.get<GameBacklog>('/games/backlog')
   return data
+}
+
+export const searchGameRecommendations = async (
+  query: string,
+  signal?: AbortSignal,
+): Promise<SteamGameSearchResult[]> => {
+  const { data } = await api.get<SteamGameSearchResult[]>('/games/recommendations/search', {
+    params: { query },
+    signal,
+  })
+  return data
+}
+
+export const assessGameRecommendation = async (
+  steamAppId: number,
+): Promise<GameRecommendationAssessment> => {
+  const { data } = await api.post<GameRecommendationAssessment>('/games/recommendations/assess', {
+    steamAppId,
+  })
+  return data
+}
+
+export const createGameRecommendation = async (
+  assessmentToken: string,
+): Promise<CreatedGameRecommendation> => {
+  const { data } = await api.post<CreatedGameRecommendation>('/games/recommendations', {
+    assessmentToken,
+  })
+  return data
+}
+
+export const deleteGameRecommendation = async (): Promise<void> => {
+  await api.delete('/games/recommendations')
 }
 
 export const getGameCover = (game?: Game | null): string => {

--- a/client/src/types/Game.ts
+++ b/client/src/types/Game.ts
@@ -8,6 +8,9 @@
   summary?: string | null
   howLongToBeatUrl?: string | null
   durationLabel?: string | null
+  mainHours?: number | null
+  mainExtraHours?: number | null
+  howLongToBeatTitle?: string | null
   recommendedBy?: GameRecommender[]
 }
 
@@ -19,6 +22,7 @@ export interface GameRecommender {
 
 export interface BacklogGame extends Game {
   electionAppearances: number
+  guaranteedNextVote: boolean
   recommendedBy: GameRecommender[]
 }
 
@@ -26,4 +30,51 @@ export interface GameBacklog {
   games: BacklogGame[]
   rubble: BacklogGame[]
   retirementThreshold: number
+  targetPoolSize: number
+  nextVoteFillCount: number
+}
+
+export interface SteamGameSearchResult {
+  steamAppId: number
+  title: string
+  image?: string | null
+  source: 'catalog' | 'steam'
+}
+
+export type GameAssessmentReason =
+  | 'eligible'
+  | 'too_long'
+  | 'duration_unavailable'
+  | 'not_a_game'
+  | 'already_played'
+  | 'already_suggested'
+
+export interface ResearchedGame {
+  steamAppId: number
+  title: string
+  cover?: string | null
+  steam: string
+  trailer?: string | null
+  summary?: string | null
+  howLongToBeatUrl?: string | null
+  durationLabel?: string | null
+  mainHours?: number | null
+  mainExtraHours?: number | null
+  howLongToBeatTitle?: string | null
+}
+
+export interface GameRecommendationAssessment {
+  eligible: boolean
+  reason: GameAssessmentReason
+  limitHours: number
+  game: ResearchedGame
+  assessmentToken?: string
+  existingSuggestion?: Pick<Game, 'id' | 'title'>
+}
+
+export interface CreatedGameRecommendation {
+  game: Game
+  created: boolean
+  alreadyRecommended: boolean
+  electionAppearances: number
 }

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -4,6 +4,7 @@ import { LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
 import { NIcon, NModal, NSpin, NTooltip } from 'naive-ui'
 import { formatDurationLabel, getGameBacklog, getGameCover } from '@/services/gameService'
 import type { BacklogGame, GameBacklog, GameRecommender } from '@/types/Game'
+import BacklogGameCard from '@/components/BacklogGameCard.vue'
 
 const backlog = ref<GameBacklog | null>(null)
 const loading = ref(true)
@@ -18,6 +19,14 @@ const backlogCountLabel = computed(() => {
   const count = backlog.value?.games.length ?? 0
   return `${count} ${count === 1 ? 'jogo' : 'jogos'} à espera da fogueira`
 })
+
+const isGuaranteedNextVote = (game: BacklogGame) => game.guaranteedNextVote
+
+const nextVoteGames = computed(() => backlog.value?.games.filter(isGuaranteedNextVote) ?? [])
+
+const returningGames = computed(
+  () => backlog.value?.games.filter((game) => !isGuaranteedNextVote(game)) ?? [],
+)
 
 const appearanceLabel = (count: number) => {
   if (count === 0) return 'Ainda não passou'
@@ -470,111 +479,65 @@ onBeforeUnmount(() => {
         </div>
       </header>
 
-      <div class="backlog-grid" aria-label="Jogos que ainda guardam calor">
-        <article v-for="game in backlog.games" :key="game.id" class="backlog-card">
-          <div class="backlog-card__art" :style="coverStyle(game)">
-            <div class="backlog-card__shade"></div>
-
-            <span class="backlog-card__count">
-              <strong>{{ game.electionAppearances }}</strong>
-              / {{ backlog.retirementThreshold }}
-            </span>
-
-            <header class="backlog-card__title">
-              <h3>{{ game.title }}</h3>
-            </header>
+      <section
+        v-if="nextVoteGames.length"
+        class="backlog-shelf backlog-shelf--next-vote"
+        aria-labelledby="next-vote-heading"
+      >
+        <header class="backlog-shelf__heading">
+          <div>
+            <span class="backlog-eyebrow">Lugar garantido</span>
+            <h2 id="next-vote-heading">Na próxima votação</h2>
           </div>
+          <p>Estas sugestões já estão confirmadas para a próxima rodada.</p>
+        </header>
 
-          <footer class="backlog-card__footer">
-            <div class="backlog-card__history">
-              <div
-                class="backlog-embers"
-                :aria-label="`${appearanceLabel(game.electionAppearances)} de ${backlog.retirementThreshold} antes de virar cinza`"
-              >
-                <span
-                  v-for="position in backlog.retirementThreshold"
-                  :key="position"
-                  :class="{ 'backlog-ember--lit': position <= game.electionAppearances }"
-                  aria-hidden="true"
-                ></span>
-              </div>
-              <span>{{ appearanceLabel(game.electionAppearances) }}</span>
+        <div class="backlog-grid backlog-grid--next-vote">
+          <BacklogGameCard
+            v-for="game in nextVoteGames"
+            :key="game.id"
+            :game="game"
+            :retirement-threshold="backlog.retirementThreshold"
+            next-vote
+          />
+
+          <article v-if="backlog.nextVoteFillCount" class="next-vote-fill-card">
+            <span class="next-vote-fill-card__count">+{{ backlog.nextVoteFillCount }}</span>
+            <div>
+              <h3>
+                {{ backlog.nextVoteFillCount === 1 ? 'jogo das Brasas' : 'jogos das Brasas' }}
+              </h3>
+              <p>
+                para chegar o mais perto possível de {{ backlog.targetPoolSize }} jogos na votação
+              </p>
             </div>
+          </article>
+        </div>
+      </section>
 
-            <div
-              v-if="game.recommendedBy?.length"
-              class="backlog-card__recommenders"
-              aria-label="Pessoas que apresentaram este jogo ao grupo"
-            >
-              <n-tooltip
-                v-for="recommender in visibleRecommenders(game)"
-                :key="recommender.id"
-                placement="top"
-              >
-                <template #trigger>
-                  <span
-                    class="backlog-recommender"
-                    tabindex="0"
-                    :aria-label="`Apresentado por ${recommender.name}`"
-                  >
-                    <img
-                      v-if="hasRecommenderAvatar(game, recommender)"
-                      :src="recommender.avatar ?? undefined"
-                      alt=""
-                      @error="markRecommenderAvatarFailed(game, recommender)"
-                    />
-                    <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
-                  </span>
-                </template>
-                Apresentado por {{ recommender.name }}
-              </n-tooltip>
+      <section
+        v-if="returningGames.length"
+        class="backlog-shelf"
+        :aria-labelledby="nextVoteGames.length ? 'returning-games-heading' : undefined"
+        :aria-label="nextVoteGames.length ? undefined : 'Jogos que ainda guardam calor'"
+      >
+        <header v-if="nextVoteGames.length" class="backlog-shelf__heading">
+          <div>
+            <span class="backlog-eyebrow">Ainda nas Brasas</span>
+            <h2 id="returning-games-heading">Outros jogos nas Brasas</h2>
+          </div>
+          <p>Jogos que continuam disponíveis para as próximas rodadas.</p>
+        </header>
 
-              <n-tooltip v-if="game.recommendedBy.length > 3" placement="top">
-                <template #trigger>
-                  <span
-                    class="backlog-recommender backlog-recommender--more"
-                    tabindex="0"
-                    :aria-label="`Mais ${game.recommendedBy.length - 3} pessoas apresentaram este jogo`"
-                  >
-                    +{{ game.recommendedBy.length - 3 }}
-                  </span>
-                </template>
-                Também apresentado por {{ hiddenRecommenderNames(game) }}
-              </n-tooltip>
-            </div>
-
-            <nav class="backlog-card__links" :aria-label="`Links de ${game.title}`">
-              <a
-                v-if="game.steam"
-                :href="game.steam"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Abrir na Steam"
-              >
-                <n-icon size="17"><LogoSteam /></n-icon>
-              </a>
-              <a
-                v-if="game.trailer"
-                :href="game.trailer"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Assistir ao trailer"
-              >
-                <n-icon size="17"><LogoYoutube /></n-icon>
-              </a>
-              <a
-                v-if="game.howLongToBeatUrl"
-                :href="game.howLongToBeatUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                :aria-label="`Ver duração${formatDurationLabel(game.durationLabel) ? `: ${formatDurationLabel(game.durationLabel)}` : ''}`"
-              >
-                <n-icon size="17"><TimeOutline /></n-icon>
-              </a>
-            </nav>
-          </footer>
-        </article>
-      </div>
+        <div class="backlog-grid" aria-label="Jogos que ainda guardam calor">
+          <BacklogGameCard
+            v-for="game in returningGames"
+            :key="game.id"
+            :game="game"
+            :retirement-threshold="backlog.retirementThreshold"
+          />
+        </div>
+      </section>
 
       <section
         v-if="backlog.rubble.length"

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -9,10 +9,13 @@ import {
 } from '@/services/campaignService.ts'
 import ElectionView from '@/components/ElectionView.vue'
 import CurrentGameHearth from '@/components/CurrentGameHearth.vue'
+import GameRecommendation from '@/components/GameRecommendation.vue'
 import { getJourneyFlags, getJourneyStatus, type JourneyStatus } from '@/services/userService'
+import { useAuthStore } from '@/stores/auth'
 
 const campaignStore = useCampaignStore()
 const { campaign, currentGame, campaignUser } = storeToRefs(campaignStore)
+const { isAuthenticated } = storeToRefs(useAuthStore())
 
 const journeyStatus = ref<JourneyStatus>('not-started')
 const saveState = ref<'idle' | 'saving' | 'saved'>('idle')
@@ -106,5 +109,6 @@ const recalculateElection = async () => {
       @change-journey="changeJourney"
     />
 
+    <GameRecommendation v-if="campaign && isAuthenticated" :campaign-user="campaignUser" />
   </div>
 </template>

--- a/mcp/src/schemas.ts
+++ b/mcp/src/schemas.ts
@@ -10,6 +10,9 @@ export const gameInputSchema = z.object({
   summary: z.string().optional(),
   howLongToBeatUrl: z.string().optional(),
   durationLabel: z.string().optional(),
+  mainHours: z.number().nonnegative().optional(),
+  mainExtraHours: z.number().nonnegative().optional(),
+  howLongToBeatTitle: z.string().optional(),
 });
 
 export const campaignInputSchema = z.object({

--- a/server/src/admin/admin.service.spec.ts
+++ b/server/src/admin/admin.service.spec.ts
@@ -185,4 +185,20 @@ describe('AdminService game recommendations', () => {
       dataSource.getRepository(CampaignPlayer).count(),
     ).resolves.toBe(0);
   });
+
+  it('automatically includes pristine recommendations when creating a pool', async () => {
+    await dataSource
+      .getRepository(GameRecommendation)
+      .save(
+        dataSource.getRepository(GameRecommendation).create({ game, player }),
+      );
+
+    const pool = await service.createPoolFromGames({});
+
+    expect(pool.options).toHaveLength(1);
+    expect(pool.options[0].game).toMatchObject({
+      id: game.id,
+      title: 'Known recommendation',
+    });
+  });
 });

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -13,6 +13,7 @@ import { ContentService } from '../content/content.service';
 import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
 import { GameRecommendation } from '../games/entities/game-recommendation.entity';
+import { buildNextVotePoolGames } from '../games/games.service';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -902,6 +903,18 @@ export class AdminService {
         game.durationLabel = input.durationLabel ?? null;
       }
 
+      if (input.mainHours !== undefined) {
+        game.mainHours = input.mainHours ?? null;
+      }
+
+      if (input.mainExtraHours !== undefined) {
+        game.mainExtraHours = input.mainExtraHours ?? null;
+      }
+
+      if (input.howLongToBeatTitle !== undefined) {
+        game.howLongToBeatTitle = input.howLongToBeatTitle ?? null;
+      }
+
       const savedGame = await gameRepository.save(game);
       savedGames.set(normalizeText(savedGame.title), savedGame);
     }
@@ -1092,15 +1105,7 @@ export class AdminService {
       games.push(game);
     }
 
-    const seenIds = new Set<number>();
-    return games.filter((game) => {
-      if (seenIds.has(game.id)) {
-        return false;
-      }
-
-      seenIds.add(game.id);
-      return true;
-    });
+    return buildNextVotePoolGames(manager, games);
   }
 
   private async resolvePoolGamesForPreview(
@@ -1141,10 +1146,19 @@ export class AdminService {
       }
     }
 
+    const persistedGames = games.filter((game): game is Game =>
+      Boolean(game.id),
+    );
+    const plannedGames = games.filter((game) => !game.id);
+    const selectedPersistedGames = await buildNextVotePoolGames(
+      this.dataSource.manager,
+      persistedGames,
+      plannedGames.length,
+    );
     const seenTitles = new Set<string>();
-    return games.filter((game) => {
-      const normalizedTitle = normalizeText(game.title);
 
+    return [...selectedPersistedGames, ...plannedGames].filter((game) => {
+      const normalizedTitle = normalizeText(game.title);
       if (seenTitles.has(normalizedTitle)) {
         warnings.push(`Duplicate pool option ignored: ${game.title}`);
         return false;
@@ -1795,6 +1809,36 @@ export class AdminService {
       changes.durationLabel = {
         from: existingGame.durationLabel ?? null,
         to: input.durationLabel,
+      };
+    }
+
+    if (
+      input.mainHours !== undefined &&
+      input.mainHours !== existingGame.mainHours
+    ) {
+      changes.mainHours = {
+        from: existingGame.mainHours ?? null,
+        to: input.mainHours,
+      };
+    }
+
+    if (
+      input.mainExtraHours !== undefined &&
+      input.mainExtraHours !== existingGame.mainExtraHours
+    ) {
+      changes.mainExtraHours = {
+        from: existingGame.mainExtraHours ?? null,
+        to: input.mainExtraHours,
+      };
+    }
+
+    if (
+      input.howLongToBeatTitle !== undefined &&
+      input.howLongToBeatTitle !== existingGame.howLongToBeatTitle
+    ) {
+      changes.howLongToBeatTitle = {
+        from: existingGame.howLongToBeatTitle ?? null,
+        to: input.howLongToBeatTitle,
       };
     }
 

--- a/server/src/admin/dto/monthly-plan.dto.ts
+++ b/server/src/admin/dto/monthly-plan.dto.ts
@@ -6,6 +6,7 @@ import {
   IsISO8601,
   IsInt,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
   Min,
@@ -51,6 +52,22 @@ export class AdminGameInputDto {
   @IsOptional()
   @IsString()
   durationLabel?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  mainHours?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  mainExtraHours?: number;
+
+  @IsOptional()
+  @IsString()
+  howLongToBeatTitle?: string;
 }
 
 export class AdminCampaignInputDto {

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -5,6 +5,7 @@ import { SiteContent1785729600000 } from './migrations/1785729600000-SiteContent
 import { CurrentGameDetails1785736800000 } from './migrations/1785736800000-CurrentGameDetails';
 import { GameRecommendations1785795104186 } from './migrations/1785795104186-GameRecommendations';
 import { GameRecommendationRegistry1785796200000 } from './migrations/1785796200000-GameRecommendationRegistry';
+import { GameResearchCache1785797300000 } from './migrations/1785797300000-GameResearchCache';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
 const safeRuntimeMigrations = [
@@ -13,6 +14,7 @@ const safeRuntimeMigrations = [
   CurrentGameDetails1785736800000,
   GameRecommendations1785795104186,
   GameRecommendationRegistry1785796200000,
+  GameResearchCache1785797300000,
 ];
 
 const getDatabasePort = (): number => {

--- a/server/src/db/migrations/1785797300000-GameResearchCache.ts
+++ b/server/src/db/migrations/1785797300000-GameResearchCache.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class GameResearchCache1785797300000 implements MigrationInterface {
+  name = 'GameResearchCache1785797300000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "main_hours" double precision`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "main_extra_hours" double precision`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN "how_long_to_beat_title" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "games" DROP COLUMN "how_long_to_beat_title"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" DROP COLUMN "main_extra_hours"`,
+    );
+    await queryRunner.query(`ALTER TABLE "games" DROP COLUMN "main_hours"`);
+  }
+}

--- a/server/src/games/dto/create-game.dto.ts
+++ b/server/src/games/dto/create-game.dto.ts
@@ -1,4 +1,11 @@
-import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 
 export class CreateGameDto {
   @IsString()
@@ -32,4 +39,18 @@ export class CreateGameDto {
   @IsString()
   @IsOptional()
   durationLabel?: string;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  mainHours?: number;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  mainExtraHours?: number;
+
+  @IsString()
+  @IsOptional()
+  howLongToBeatTitle?: string;
 }

--- a/server/src/games/dto/game-recommendation.dto.ts
+++ b/server/src/games/dto/game-recommendation.dto.ts
@@ -1,0 +1,21 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsString, Length, Min } from 'class-validator';
+
+export class SearchGamesQueryDto {
+  @IsString()
+  @Length(2, 80)
+  query!: string;
+}
+
+export class AssessGameRecommendationDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  steamAppId!: number;
+}
+
+export class CreateGameRecommendationDto {
+  @IsString()
+  @IsNotEmpty()
+  assessmentToken!: string;
+}

--- a/server/src/games/entities/game.entity.ts
+++ b/server/src/games/entities/game.entity.ts
@@ -28,4 +28,13 @@ export class Game {
 
   @Column({ name: 'duration_label', type: 'varchar', nullable: true })
   durationLabel: string | null;
+
+  @Column({ name: 'main_hours', type: 'float', nullable: true })
+  mainHours: number | null;
+
+  @Column({ name: 'main_extra_hours', type: 'float', nullable: true })
+  mainExtraHours: number | null;
+
+  @Column({ name: 'how_long_to_beat_title', type: 'varchar', nullable: true })
+  howLongToBeatTitle: string | null;
 }

--- a/server/src/games/game-research.service.spec.ts
+++ b/server/src/games/game-research.service.spec.ts
@@ -1,0 +1,154 @@
+import { ConfigService } from '@nestjs/config';
+import { GameResearchService } from './game-research.service';
+
+describe('GameResearchService', () => {
+  let service: GameResearchService;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    service = new GameResearchService(
+      new ConfigService({ JWT_SECRET: 'test-secret' }),
+    );
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('parses and deduplicates Steam autocomplete results', async () => {
+    fetchMock.mockResolvedValue(
+      htmlResponse(`
+        <a data-ds-appid="1245620" href="/app/1245620/">
+          <div class="match_name">ELDEN RING &amp; FRIENDS</div>
+          <div class="match_img"><img src="https://example.com/elden.jpg"></div>
+        </a>
+        <a data-ds-appid="1245620" href="/app/1245620/">
+          <div class="match_name">Duplicate</div>
+          <div class="match_img"><img src="https://example.com/duplicate.jpg"></div>
+        </a>
+      `),
+    );
+
+    await expect(service.searchSteam('elden ring')).resolves.toEqual([
+      {
+        steamAppId: 1245620,
+        title: 'ELDEN RING & FRIENDS',
+        image: 'https://example.com/elden.jpg',
+        source: 'steam',
+      },
+    ]);
+  });
+
+  it('researches Steam metadata and accepts a game within 20 hours', async () => {
+    mockAssessmentRequests(18 * 3600);
+
+    const assessment = await service.assessSteamGame(42);
+
+    expect(assessment).toMatchObject({
+      eligible: true,
+      reason: 'eligible',
+      limitHours: 20,
+      game: {
+        steamAppId: 42,
+        title: 'Example Game',
+        cover: 'https://example.com/header.jpg',
+        steam: 'https://store.steampowered.com/app/42/',
+        trailer: 'https://example.com/trailer.m3u8',
+        howLongToBeatUrl: 'https://howlongtobeat.com/game/99',
+        durationLabel: '12–18 h',
+        mainHours: 12,
+        mainExtraHours: 18,
+      },
+    });
+  });
+
+  it('blocks a game whose Main + Extras duration exceeds 20 hours', async () => {
+    mockAssessmentRequests(20 * 3600 + 1);
+
+    const assessment = await service.assessSteamGame(42);
+
+    expect(assessment.eligible).toBe(false);
+    expect(assessment.reason).toBe('too_long');
+    expect(assessment.game.mainExtraHours).toBeGreaterThan(20);
+  });
+
+  it('issues player-bound, expiring assessment tokens', () => {
+    const game = {
+      steamAppId: 42,
+      title: 'Example Game',
+      cover: null,
+      steam: 'https://store.steampowered.com/app/42/',
+      trailer: null,
+      summary: null,
+      howLongToBeatUrl: 'https://howlongtobeat.com/game/99',
+      durationLabel: '18 h',
+      mainHours: 12,
+      mainExtraHours: 18,
+      howLongToBeatTitle: 'Example Game',
+    };
+    const token = service.issueAssessmentToken(game, 7);
+
+    expect(service.verifyAssessmentToken(token, 7)).toEqual(game);
+    expect(() => service.verifyAssessmentToken(token, 8)).toThrow(
+      'Expired or invalid assessment token',
+    );
+  });
+
+  const mockAssessmentRequests = (mainExtraSeconds: number) => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          '42': {
+            success: true,
+            data: {
+              type: 'game',
+              name: 'Example Game',
+              header_image: 'https://example.com/header.jpg',
+              short_description: 'A compact adventure.',
+              developers: ['Example Studio'],
+              publishers: ['Example Publisher'],
+              movies: [
+                {
+                  name: 'Official trailer',
+                  hls_h264: 'https://example.com/trailer.m3u8',
+                },
+              ],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        htmlResponse('<script>var ytInitialData = {"contents":[]};</script>'),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ token: 'token', hpKey: 'field', hpVal: 'value' }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              game_id: 99,
+              game_name: 'Example Game',
+              game_alias: '',
+              game_type: 'game',
+              comp_main: 12 * 3600,
+              comp_plus: mainExtraSeconds,
+            },
+          ],
+        }),
+      );
+  };
+
+  const jsonResponse = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  const htmlResponse = (body: string) =>
+    new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+});

--- a/server/src/games/game-research.service.ts
+++ b/server/src/games/game-research.service.ts
@@ -1,0 +1,629 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const STEAM_SEARCH_URL = 'https://store.steampowered.com/search/suggest';
+const STEAM_DETAILS_URL = 'https://store.steampowered.com/api/appdetails';
+const HLTB_URL = 'https://howlongtobeat.com';
+const YOUTUBE_SEARCH_URL = 'https://www.youtube.com/results';
+const MAX_RECOMMENDATION_HOURS = 20;
+const ASSESSMENT_TOKEN_LIFETIME_SECONDS = 15 * 60;
+const REQUEST_TIMEOUT_MS = 12_000;
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124 Safari/537.36';
+
+export interface SteamGameSearchResult {
+  steamAppId: number;
+  title: string;
+  image: string | null;
+  source: 'catalog' | 'steam';
+}
+
+export type GameAssessmentReason =
+  | 'eligible'
+  | 'too_long'
+  | 'duration_unavailable'
+  | 'not_a_game'
+  | 'already_played'
+  | 'already_suggested';
+
+export interface ResearchedGame {
+  steamAppId: number;
+  title: string;
+  cover: string | null;
+  steam: string;
+  trailer: string | null;
+  summary: string | null;
+  howLongToBeatUrl: string | null;
+  durationLabel: string | null;
+  mainHours: number | null;
+  mainExtraHours: number | null;
+  howLongToBeatTitle: string | null;
+}
+
+export interface GameResearchAssessment {
+  eligible: boolean;
+  reason: GameAssessmentReason;
+  limitHours: number;
+  game: ResearchedGame;
+}
+
+interface SteamMovie {
+  name?: string;
+  hls_h264?: string;
+}
+
+interface SteamAppDetails {
+  type?: string;
+  name?: string;
+  steam_appid?: number;
+  header_image?: string;
+  short_description?: string;
+  developers?: string[];
+  publishers?: string[];
+  movies?: SteamMovie[];
+}
+
+interface SteamAppDetailsResponse {
+  success?: boolean;
+  data?: SteamAppDetails;
+}
+
+interface HltbSecurityInit {
+  token?: string;
+  hpKey?: string;
+  hpVal?: string;
+}
+
+interface HltbGame {
+  game_id?: number;
+  game_name?: string;
+  game_alias?: string;
+  game_type?: string;
+  comp_main?: number;
+  comp_plus?: number;
+}
+
+interface HltbSearchResponse {
+  data?: HltbGame[];
+}
+
+interface RecommendationTokenPayload {
+  version: 1;
+  playerId: number;
+  expiresAt: number;
+  game: ResearchedGame;
+}
+
+interface YoutubeText {
+  simpleText?: string;
+  runs?: Array<{ text?: string }>;
+}
+
+interface YoutubeVideoRenderer {
+  videoId?: string;
+  title?: YoutubeText;
+  ownerText?: YoutubeText;
+}
+
+const decodeHtml = (value: string): string =>
+  value
+    .replace(/&#(\d+);/g, (_match, code: string) =>
+      String.fromCodePoint(Number(code)),
+    )
+    .replace(/&#x([\da-f]+);/gi, (_match, code: string) =>
+      String.fromCodePoint(Number.parseInt(code, 16)),
+    )
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+
+export const normalizeGameTitle = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[™®©]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLocaleLowerCase('en-US');
+
+const levenshteinDistance = (left: string, right: string): number => {
+  const previous = Array.from(
+    { length: right.length + 1 },
+    (_, index) => index,
+  );
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      current[rightIndex] = Math.min(
+        (current[rightIndex - 1] ?? 0) + 1,
+        (previous[rightIndex] ?? 0) + 1,
+        (previous[rightIndex - 1] ?? 0) +
+          (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[right.length] ?? 0;
+};
+
+const titleSimilarity = (left: string, right: string): number => {
+  const normalizedLeft = normalizeGameTitle(left);
+  const normalizedRight = normalizeGameTitle(right);
+
+  if (!normalizedLeft || !normalizedRight) return 0;
+  if (normalizedLeft === normalizedRight) return 1;
+
+  const editSimilarity =
+    1 -
+    levenshteinDistance(normalizedLeft, normalizedRight) /
+      Math.max(normalizedLeft.length, normalizedRight.length);
+  const leftTokens = new Set(normalizedLeft.split(' '));
+  const rightTokens = new Set(normalizedRight.split(' '));
+  const intersection = [...leftTokens].filter((token) =>
+    rightTokens.has(token),
+  );
+  const tokenSimilarity =
+    intersection.length / new Set([...leftTokens, ...rightTokens]).size;
+
+  return Math.max(editSimilarity, tokenSimilarity);
+};
+
+const textValue = (value?: YoutubeText): string =>
+  value?.simpleText ?? value?.runs?.map((run) => run.text ?? '').join('') ?? '';
+
+const collectYoutubeVideos = (
+  value: unknown,
+  videos: YoutubeVideoRenderer[] = [],
+): YoutubeVideoRenderer[] => {
+  if (!value || typeof value !== 'object') return videos;
+
+  const record = value as Record<string, unknown>;
+  if (record.videoRenderer && typeof record.videoRenderer === 'object') {
+    videos.push(record.videoRenderer);
+  }
+
+  for (const child of Object.values(record)) {
+    if (Array.isArray(child)) {
+      child.forEach((entry) => collectYoutubeVideos(entry, videos));
+    } else if (child && typeof child === 'object') {
+      collectYoutubeVideos(child, videos);
+    }
+  }
+
+  return videos;
+};
+
+const organizationIdentity = (value: string): string => {
+  const ignored = new Set([
+    'co',
+    'company',
+    'corp',
+    'corporation',
+    'entertainment',
+    'game',
+    'games',
+    'inc',
+    'interactive',
+    'llc',
+    'ltd',
+    'official',
+    'studio',
+    'studios',
+  ]);
+
+  return normalizeGameTitle(value)
+    .split(' ')
+    .filter((token) => !ignored.has(token))
+    .join(' ');
+};
+
+const organizationsMatch = (left: string, right: string): boolean => {
+  const normalizedLeft = organizationIdentity(left);
+  const normalizedRight = organizationIdentity(right);
+
+  return (
+    normalizedLeft.length >= 4 &&
+    normalizedRight.length >= 4 &&
+    (normalizedLeft.includes(normalizedRight) ||
+      normalizedRight.includes(normalizedLeft))
+  );
+};
+
+const formatHours = (hours: number): string => {
+  const rounded = Math.round(hours * 2) / 2;
+  return Number.isInteger(rounded)
+    ? String(rounded)
+    : rounded.toFixed(1).replace('.', ',');
+};
+
+@Injectable()
+export class GameResearchService {
+  private readonly logger = new Logger(GameResearchService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  async searchSteam(query: string): Promise<SteamGameSearchResult[]> {
+    const normalizedQuery = query.trim().replace(/\s+/g, ' ');
+    if (normalizedQuery.length < 2) return [];
+
+    const url = new URL(STEAM_SEARCH_URL);
+    url.search = new URLSearchParams({
+      term: normalizedQuery,
+      f: 'games',
+      cc: 'BR',
+      l: 'portuguese',
+    }).toString();
+
+    const html = await this.fetchText(url, 'Steam search');
+    const results: SteamGameSearchResult[] = [];
+    const seenAppIds = new Set<number>();
+    const matches = html.matchAll(
+      /<a\b[^>]*data-ds-appid="(\d+)"[^>]*>[\s\S]*?<div class="match_name">([\s\S]*?)<\/div>[\s\S]*?<div class="match_img"><img src="([^"]+)"/gi,
+    );
+
+    for (const match of matches) {
+      const steamAppId = Number(match[1]);
+      if (!Number.isInteger(steamAppId) || seenAppIds.has(steamAppId)) continue;
+
+      seenAppIds.add(steamAppId);
+      results.push({
+        steamAppId,
+        title: decodeHtml((match[2] ?? '').replace(/<[^>]+>/g, '')).trim(),
+        image: decodeHtml(match[3] ?? '').trim() || null,
+        source: 'steam',
+      });
+
+      if (results.length >= 8) break;
+    }
+
+    return results;
+  }
+
+  async assessSteamGame(steamAppId: number): Promise<GameResearchAssessment> {
+    const steamDetails = await this.getSteamDetails(steamAppId);
+    const title = steamDetails.name?.trim() || `Steam App ${steamAppId}`;
+    const steam = `https://store.steampowered.com/app/${steamAppId}/`;
+    const baseGame: ResearchedGame = {
+      steamAppId,
+      title,
+      cover: steamDetails.header_image ?? null,
+      steam,
+      trailer: await this.findOfficialTrailer(steamDetails, title),
+      summary: steamDetails.short_description?.trim() || null,
+      howLongToBeatUrl: null,
+      durationLabel: null,
+      mainHours: null,
+      mainExtraHours: null,
+      howLongToBeatTitle: null,
+    };
+
+    if (steamDetails.type !== 'game') {
+      return this.assessment(false, 'not_a_game', baseGame);
+    }
+
+    const hltbMatch = await this.findHowLongToBeatMatch(title);
+    if (!hltbMatch?.game_id || !hltbMatch.comp_plus) {
+      return this.assessment(false, 'duration_unavailable', baseGame);
+    }
+
+    const mainHours = hltbMatch.comp_main ? hltbMatch.comp_main / 3600 : null;
+    const mainExtraHours = hltbMatch.comp_plus / 3600;
+    const durationLabel =
+      mainHours && Math.abs(mainHours - mainExtraHours) >= 0.25
+        ? `${formatHours(mainHours)}–${formatHours(mainExtraHours)} h`
+        : `${formatHours(mainExtraHours)} h`;
+    const game: ResearchedGame = {
+      ...baseGame,
+      howLongToBeatUrl: `${HLTB_URL}/game/${hltbMatch.game_id}`,
+      durationLabel,
+      mainHours,
+      mainExtraHours,
+      howLongToBeatTitle: hltbMatch.game_name?.trim() || title,
+    };
+
+    return this.assessResearchedGame(game);
+  }
+
+  assessResearchedGame(game: ResearchedGame): GameResearchAssessment {
+    if (game.mainExtraHours === null) {
+      return this.assessment(false, 'duration_unavailable', game);
+    }
+
+    return this.assessment(
+      game.mainExtraHours <= MAX_RECOMMENDATION_HOURS,
+      game.mainExtraHours <= MAX_RECOMMENDATION_HOURS ? 'eligible' : 'too_long',
+      game,
+    );
+  }
+
+  issueAssessmentToken(game: ResearchedGame, playerId: number): string {
+    const payload: RecommendationTokenPayload = {
+      version: 1,
+      playerId,
+      expiresAt:
+        Math.floor(Date.now() / 1000) + ASSESSMENT_TOKEN_LIFETIME_SECONDS,
+      game,
+    };
+    const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+      'base64url',
+    );
+
+    return `${encodedPayload}.${this.signTokenPayload(encodedPayload)}`;
+  }
+
+  verifyAssessmentToken(token: string, playerId: number): ResearchedGame {
+    const [encodedPayload, providedSignature, extra] = token.split('.');
+    if (!encodedPayload || !providedSignature || extra) {
+      throw new Error('Invalid assessment token');
+    }
+
+    const expectedSignature = this.signTokenPayload(encodedPayload);
+    const provided = Buffer.from(providedSignature, 'base64url');
+    const expected = Buffer.from(expectedSignature, 'base64url');
+
+    if (
+      provided.length !== expected.length ||
+      !timingSafeEqual(provided, expected)
+    ) {
+      throw new Error('Invalid assessment token');
+    }
+
+    let payload: RecommendationTokenPayload;
+    try {
+      payload = JSON.parse(
+        Buffer.from(encodedPayload, 'base64url').toString('utf8'),
+      ) as RecommendationTokenPayload;
+    } catch {
+      throw new Error('Invalid assessment token');
+    }
+
+    if (
+      payload.version !== 1 ||
+      payload.playerId !== playerId ||
+      payload.expiresAt < Math.floor(Date.now() / 1000) ||
+      !Number.isInteger(payload.game?.steamAppId) ||
+      !payload.game?.title ||
+      payload.game.mainExtraHours === null ||
+      payload.game.mainExtraHours > MAX_RECOMMENDATION_HOURS
+    ) {
+      throw new Error('Expired or invalid assessment token');
+    }
+
+    return payload.game;
+  }
+
+  private assessment(
+    eligible: boolean,
+    reason: GameAssessmentReason,
+    game: ResearchedGame,
+  ): GameResearchAssessment {
+    return { eligible, reason, limitHours: MAX_RECOMMENDATION_HOURS, game };
+  }
+
+  private async getSteamDetails(steamAppId: number): Promise<SteamAppDetails> {
+    const url = new URL(STEAM_DETAILS_URL);
+    url.search = new URLSearchParams({
+      appids: String(steamAppId),
+      cc: 'br',
+      l: 'portuguese',
+    }).toString();
+    const response = await this.fetchJson<
+      Record<string, SteamAppDetailsResponse>
+    >(url, 'Steam game details');
+    const app = response[String(steamAppId)];
+
+    if (!app?.success || !app.data) {
+      throw new ServiceUnavailableException(
+        'A Steam não retornou detalhes para este jogo.',
+      );
+    }
+
+    return app.data;
+  }
+
+  private async findHowLongToBeatMatch(
+    title: string,
+  ): Promise<HltbGame | null> {
+    try {
+      const results = await this.searchHowLongToBeat(title);
+      const scored = results
+        .filter((entry) => entry.game_name && entry.game_type !== 'mod')
+        .map((entry) => ({
+          entry,
+          score: Math.max(
+            titleSimilarity(title, entry.game_name ?? ''),
+            titleSimilarity(title, entry.game_alias ?? ''),
+          ),
+        }))
+        .sort((left, right) => right.score - left.score);
+      const best = scored[0];
+      const second = scored[1];
+
+      if (!best || best.score < 0.72) return null;
+      if (best.score < 1 && second && best.score - second.score < 0.08) {
+        return null;
+      }
+
+      return best.entry;
+    } catch (error: unknown) {
+      this.logger.warn(
+        `HowLongToBeat check failed: ${error instanceof Error ? error.message : 'unknown error'}`,
+      );
+      return null;
+    }
+  }
+
+  private async searchHowLongToBeat(title: string): Promise<HltbGame[]> {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const init = await this.fetchJson<HltbSecurityInit>(
+        new URL(`/api/bleed/init?t=${Date.now()}`, HLTB_URL),
+        'HowLongToBeat eligibility check',
+      );
+      if (!init.token) throw new Error('HowLongToBeat did not issue a token');
+
+      const payload: Record<string, unknown> = {
+        searchType: 'games',
+        searchTerms: title.trim().split(/\s+/),
+        searchPage: 1,
+        size: 20,
+        searchOptions: {
+          games: {
+            userId: 0,
+            platform: '',
+            sortCategory: 'popular',
+            rangeCategory: 'main',
+            rangeTime: { min: null, max: null },
+            gameplay: {
+              perspective: '',
+              flow: '',
+              genre: '',
+              difficulty: '',
+            },
+            rangeYear: { min: '', max: '' },
+            modifier: '',
+          },
+          users: { sortCategory: 'postcount' },
+          lists: { sortCategory: 'follows' },
+          filter: '',
+          sort: 0,
+          randomizer: 0,
+        },
+        useCache: true,
+      };
+      if (init.hpKey) payload[init.hpKey] = init.hpVal;
+
+      const response = await fetch(new URL('/api/bleed', HLTB_URL), {
+        method: 'POST',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': USER_AGENT,
+          origin: HLTB_URL,
+          referer: `${HLTB_URL}/`,
+          'x-auth-token': init.token,
+          'x-hp-key': init.hpKey ?? '',
+          'x-hp-val': init.hpVal ?? '',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.status === 403 && attempt === 0) continue;
+      if (!response.ok) {
+        throw new Error(`HowLongToBeat returned HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as HltbSearchResponse;
+      return Array.isArray(body.data) ? body.data : [];
+    }
+
+    return [];
+  }
+
+  private async findOfficialTrailer(
+    details: SteamAppDetails,
+    title: string,
+  ): Promise<string | null> {
+    const organizations = [
+      ...(details.developers ?? []),
+      ...(details.publishers ?? []),
+    ];
+
+    try {
+      const query =
+        `${title} official trailer ${organizations[0] ?? ''}`.trim();
+      const url = new URL(YOUTUBE_SEARCH_URL);
+      url.searchParams.set('search_query', query);
+      const html = await this.fetchText(url, 'YouTube trailer search');
+      const marker = 'var ytInitialData = ';
+      const start = html.indexOf(marker);
+      const end = start >= 0 ? html.indexOf(';</script>', start) : -1;
+
+      if (start >= 0 && end > start) {
+        const initialData = JSON.parse(
+          html.slice(start + marker.length, end),
+        ) as unknown;
+        const videos = collectYoutubeVideos(initialData);
+        const normalizedTitle = normalizeGameTitle(title);
+        const titleTokens = normalizedTitle.split(' ').filter(Boolean);
+        const official = videos.find((video) => {
+          const videoTitle = normalizeGameTitle(textValue(video.title));
+          const owner = textValue(video.ownerText);
+          const titleMatches = titleTokens
+            .slice(0, Math.min(3, titleTokens.length))
+            .every((token) => videoTitle.includes(token));
+          const trailerMatches = /trailer|announce|reveal|gameplay/.test(
+            videoTitle,
+          );
+          const ownerMatches = organizations.some((organization) =>
+            organizationsMatch(organization, owner),
+          );
+
+          return Boolean(
+            video.videoId && titleMatches && trailerMatches && ownerMatches,
+          );
+        });
+
+        if (official?.videoId) {
+          return `https://www.youtube.com/watch?v=${official.videoId}`;
+        }
+      }
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Official trailer lookup failed: ${error instanceof Error ? error.message : 'unknown error'}`,
+      );
+    }
+
+    return details.movies?.find((movie) => movie.hls_h264)?.hls_h264 ?? null;
+  }
+
+  private signTokenPayload(encodedPayload: string): string {
+    return createHmac('sha256', this.config.getOrThrow<string>('JWT_SECRET'))
+      .update(encodedPayload)
+      .digest('base64url');
+  }
+
+  private async fetchText(url: URL, label: string): Promise<string> {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        headers: { 'user-agent': USER_AGENT, referer: `${url.origin}/` },
+      });
+
+      if (!response.ok) {
+        throw new Error(`${label} returned HTTP ${response.status}`);
+      }
+
+      return response.text();
+    } catch (error: unknown) {
+      this.logger.warn(
+        `${label} failed: ${error instanceof Error ? error.message : 'unknown error'}`,
+      );
+      throw new ServiceUnavailableException(
+        `Não foi possível consultar ${label} agora.`,
+      );
+    }
+  }
+
+  private async fetchJson<T>(url: URL, label: string): Promise<T> {
+    const response = await this.fetchText(url, label);
+
+    try {
+      return JSON.parse(response) as T;
+    } catch {
+      throw new ServiceUnavailableException(
+        `${label} retornou uma resposta inválida.`,
+      );
+    }
+  }
+}

--- a/server/src/games/games.controller.ts
+++ b/server/src/games/games.controller.ts
@@ -7,14 +7,24 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
+  UseGuards,
 } from '@nestjs/common';
 import { GamesService } from './games.service';
 import { CreateGameDto } from './dto/create-game.dto';
 import { UpdateGameDto } from './dto/update-game.dto';
 import { Game } from './entities/game.entity';
 import { DeleteResult } from 'typeorm';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { GameBacklog, GameWithRecommenders } from './games.service';
+import {
+  AssessGameRecommendationDto,
+  CreateGameRecommendationDto,
+  SearchGamesQueryDto,
+} from './dto/game-recommendation.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { CurrentPlayer } from '../auth/decorators/current-player.decorator';
+import { Player } from '../players/entities/player.entity';
 
 @ApiTags('games')
 @Controller('games')
@@ -34,6 +44,40 @@ export class GamesController {
   @Get('backlog')
   findBacklog(): Promise<GameBacklog> {
     return this.gamesService.findBacklog();
+  }
+
+  @Get('recommendations/search')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  searchRecommendations(@Query() query: SearchGamesQueryDto) {
+    return this.gamesService.searchRecommendations(query.query);
+  }
+
+  @Post('recommendations/assess')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  assessRecommendation(
+    @Body() body: AssessGameRecommendationDto,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.gamesService.assessRecommendation(body.steamAppId, player);
+  }
+
+  @Post('recommendations')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  recommend(
+    @Body() body: CreateGameRecommendationDto,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.gamesService.recommend(body.assessmentToken, player);
+  }
+
+  @Delete('recommendations')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  withdrawRecommendation(@CurrentPlayer() player: Player) {
+    return this.gamesService.withdrawRecommendation(player);
   }
 
   @Get(':id')

--- a/server/src/games/games.module.ts
+++ b/server/src/games/games.module.ts
@@ -6,13 +6,14 @@ import { Game } from './entities/game.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { GameRecommendation } from './entities/game-recommendation.entity';
+import { GameResearchService } from './game-research.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Game, PoolOption, Campaign, GameRecommendation]),
   ],
   controllers: [GamesController],
-  providers: [GamesService],
+  providers: [GamesService, GameResearchService],
   exports: [TypeOrmModule],
 })
 export class GamesModule {}

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -7,10 +7,19 @@ import { Pool } from '../pool/entities/pool.entity';
 import { Game } from './entities/game.entity';
 import { GameRecommendation } from './entities/game-recommendation.entity';
 import { GamesService } from './games.service';
+import { GameResearchService } from './game-research.service';
 
 describe('GamesService backlog', () => {
   let dataSource: DataSource;
   let service: GamesService;
+  let researchService: Pick<
+    GameResearchService,
+    | 'verifyAssessmentToken'
+    | 'searchSteam'
+    | 'assessSteamGame'
+    | 'assessResearchedGame'
+    | 'issueAssessmentToken'
+  >;
 
   beforeEach(async () => {
     dataSource = new DataSource({
@@ -28,11 +37,20 @@ describe('GamesService backlog', () => {
     });
     await dataSource.initialize();
 
+    researchService = {
+      verifyAssessmentToken: jest.fn(),
+      searchSteam: jest.fn(),
+      assessSteamGame: jest.fn(),
+      assessResearchedGame: jest.fn(),
+      issueAssessmentToken: jest.fn(),
+    };
     service = new GamesService(
       dataSource.getRepository(Game),
       dataSource.getRepository(PoolOption),
       dataSource.getRepository(Campaign),
       dataSource.getRepository(GameRecommendation),
+      dataSource,
+      researchService as GameResearchService,
     );
   });
 
@@ -165,6 +183,272 @@ describe('GamesService backlog', () => {
     ]);
     expect(details?.recommendedBy).toEqual(backlog.games[0].recommendedBy);
     expect(backlog.games[0].recommendedBy[0]).not.toHaveProperty('email');
+  });
+
+  it('returns matching catalog games before Steam results without duplicates', async () => {
+    await saveGames([
+      {
+        title: 'Hidden Treasure',
+        suggestion: false,
+        steam: 'https://store.steampowered.com/app/42/',
+        cover: 'https://example.com/local.jpg',
+      },
+    ]);
+    jest.mocked(researchService.searchSteam).mockResolvedValue([
+      {
+        steamAppId: 42,
+        title: 'Hidden Treasure',
+        image: 'https://example.com/remote.jpg',
+        source: 'steam',
+      },
+      {
+        steamAppId: 77,
+        title: 'Hidden Treasure II',
+        image: null,
+        source: 'steam',
+      },
+    ]);
+
+    await expect(service.searchRecommendations('hidden')).resolves.toEqual([
+      {
+        steamAppId: 42,
+        title: 'Hidden Treasure',
+        image: 'https://example.com/local.jpg',
+        source: 'catalog',
+      },
+      {
+        steamAppId: 77,
+        title: 'Hidden Treasure II',
+        image: null,
+        source: 'steam',
+      },
+    ]);
+  });
+
+  it('assesses a fully cached game without refetching research', async () => {
+    const playerRepository = dataSource.getRepository(Player);
+    const player = await playerRepository.save(
+      playerRepository.create({ name: 'Ana' }),
+    );
+    const game = (
+      await saveGames([
+        {
+          title: 'Cached Game',
+          suggestion: false,
+          steam: 'https://store.steampowered.com/app/42/',
+          cover: 'https://example.com/header.jpg',
+          trailer: 'https://example.com/trailer',
+          howLongToBeatUrl: 'https://howlongtobeat.com/game/42',
+          durationLabel: '12–18 h',
+          mainHours: 12,
+          mainExtraHours: 18,
+          howLongToBeatTitle: 'Cached Game',
+        },
+      ])
+    )[0];
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: false,
+      }),
+    );
+    jest
+      .mocked(researchService.assessResearchedGame)
+      .mockImplementation((cachedGame) => ({
+        eligible: true,
+        reason: 'eligible',
+        limitHours: 20,
+        game: cachedGame,
+      }));
+    jest
+      .mocked(researchService.issueAssessmentToken)
+      .mockReturnValue('cached-token');
+
+    const assessment = await service.assessRecommendation(42, player);
+
+    expect(assessment).toMatchObject({
+      eligible: true,
+      assessmentToken: 'cached-token',
+      game: { title: game.title, mainExtraHours: 18 },
+    });
+    expect(researchService.assessResearchedGame).toHaveBeenCalledTimes(1);
+    expect(researchService.assessSteamGame).not.toHaveBeenCalled();
+  });
+
+  it('stores a researched recommendation and charges the current campaign token atomically', async () => {
+    const playerRepository = dataSource.getRepository(Player);
+    const player = await playerRepository.save(
+      playerRepository.create({ name: 'Ana' }),
+    );
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        played_the_game: false,
+        finished_the_game: false,
+        partook_in_the_meeting: false,
+        suggested_a_game: false,
+        suggestedGame: null,
+      }),
+    );
+    jest.mocked(researchService.verifyAssessmentToken).mockReturnValue({
+      steamAppId: 42,
+      title: 'Example Game',
+      cover: 'https://example.com/header.jpg',
+      steam: 'https://store.steampowered.com/app/42/',
+      trailer: 'https://www.youtube.com/watch?v=example',
+      summary: 'A compact adventure.',
+      howLongToBeatUrl: 'https://howlongtobeat.com/game/99',
+      durationLabel: '12–18 h',
+      mainHours: 12,
+      mainExtraHours: 18,
+      howLongToBeatTitle: 'Example Game',
+    });
+
+    const result = await service.recommend('signed-token', player);
+
+    expect(result).toMatchObject({
+      created: true,
+      alreadyRecommended: false,
+      electionAppearances: 0,
+      game: {
+        title: 'Example Game',
+        suggestion: true,
+        recommendedBy: [{ id: player.id, name: 'Ana', avatar: null }],
+      },
+    });
+    await expect(
+      dataSource.getRepository(CampaignPlayer).findOneOrFail({
+        where: { campaign: { id: campaign.id }, player: { id: player.id } },
+        relations: ['suggestedGame'],
+      }),
+    ).resolves.toMatchObject({
+      suggested_a_game: true,
+      suggestedGame: { title: 'Example Game' },
+    });
+    await expect(
+      dataSource.getRepository(GameRecommendation).count(),
+    ).resolves.toBe(1);
+    await expect(service.findBacklog()).resolves.toMatchObject({
+      games: [
+        {
+          title: 'Example Game',
+          electionAppearances: 0,
+          recommendedBy: [{ id: player.id, name: 'Ana', avatar: null }],
+        },
+      ],
+    });
+  });
+
+  it('keeps an explicitly re-suggested ashes game in the next-vote shelf', async () => {
+    const game = (
+      await saveGames([{ title: 'A Return From Ashes', suggestion: true }])
+    )[0];
+    await addAppearances(game, 3);
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: true,
+        suggestedGame: game,
+      }),
+    );
+
+    const backlog = await service.findBacklog();
+
+    expect(backlog.rubble).toHaveLength(0);
+    expect(backlog.games).toContainEqual(
+      expect.objectContaining({
+        title: 'A Return From Ashes',
+        electionAppearances: 3,
+        guaranteedNextVote: true,
+      }),
+    );
+  });
+
+  it('withdraws a fresh suggestion without deleting its researched game', async () => {
+    const game = (
+      await saveGames([
+        {
+          title: 'Preserved Game',
+          suggestion: true,
+          cover: 'https://example.com/cover.jpg',
+          trailer: 'https://example.com/trailer',
+          mainExtraHours: 12,
+        },
+      ])
+    )[0];
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: true,
+        suggestedGame: game,
+      }),
+    );
+
+    await expect(service.withdrawRecommendation(player)).resolves.toMatchObject(
+      {
+        hiddenFromCatalog: true,
+        game: { id: game.id, title: game.title },
+      },
+    );
+    await expect(
+      dataSource.getRepository(Game).findOneByOrFail({ id: game.id }),
+    ).resolves.toMatchObject({
+      suggestion: false,
+      cover: 'https://example.com/cover.jpg',
+      trailer: 'https://example.com/trailer',
+      mainExtraHours: 12,
+    });
+    await expect(
+      dataSource.getRepository(CampaignPlayer).findOneOrFail({
+        where: { campaign: { id: campaign.id }, player: { id: player.id } },
+        relations: ['suggestedGame'],
+      }),
+    ).resolves.toMatchObject({
+      suggested_a_game: false,
+      suggestedGame: null,
+    });
   });
 
   const saveGames = (games: Array<Partial<Game> & Pick<Game, 'title'>>) => {

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -1,14 +1,28 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateGameDto } from './dto/create-game.dto';
 import { UpdateGameDto } from './dto/update-game.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Game } from './entities/game.entity';
-import { DeleteResult, Repository } from 'typeorm';
+import { DataSource, DeleteResult, EntityManager, Repository } from 'typeorm';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { GameRecommendation } from './entities/game-recommendation.entity';
+import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
+import { Player } from '../players/entities/player.entity';
+import {
+  GameResearchAssessment,
+  GameResearchService,
+  ResearchedGame,
+  SteamGameSearchResult,
+  normalizeGameTitle,
+} from './game-research.service';
 
 const MAX_BACKLOG_APPEARANCES = 3;
+export const TARGET_POOL_SIZE = 5;
 
 export interface GameRecommender {
   id: number;
@@ -22,25 +36,48 @@ export interface GameWithRecommenders extends Game {
 
 export interface BacklogGame extends GameWithRecommenders {
   electionAppearances: number;
+  guaranteedNextVote: boolean;
 }
 
 export interface GameBacklog {
   games: BacklogGame[];
   rubble: BacklogGame[];
   retirementThreshold: number;
+  targetPoolSize: number;
+  nextVoteFillCount: number;
 }
 
-const normalizeGameIdentity = (game: Game): string => {
-  const steamUrl = game.steam
-    ?.trim()
-    .replace(/[/?#]+$/, '')
-    .toLocaleLowerCase('en-US');
+export interface RecommendationAssessment extends GameResearchAssessment {
+  assessmentToken?: string;
+  existingSuggestion?: Pick<Game, 'id' | 'title'>;
+}
 
-  if (steamUrl) {
-    return `steam:${steamUrl}`;
+export interface CreatedGameRecommendation {
+  game: GameWithRecommenders;
+  created: boolean;
+  alreadyRecommended: boolean;
+  electionAppearances: number;
+}
+
+export interface WithdrawnGameRecommendation {
+  game: Game;
+  hiddenFromCatalog: boolean;
+}
+
+export const extractSteamAppId = (steamUrl?: string | null): number | null => {
+  const match = steamUrl?.match(/store\.steampowered\.com\/app\/(\d+)/i);
+  const appId = match ? Number(match[1]) : NaN;
+  return Number.isInteger(appId) && appId > 0 ? appId : null;
+};
+
+export const normalizeGameIdentity = (game: Game): string => {
+  const steamAppId = extractSteamAppId(game.steam);
+
+  if (steamAppId) {
+    return `steam:${steamAppId}`;
   }
 
-  return `title:${game.title.trim().replace(/\s+/g, ' ').toLocaleLowerCase('pt-BR')}`;
+  return `title:${normalizeGameTitle(game.title)}`;
 };
 
 const gameCompleteness = (game: Game): number =>
@@ -51,7 +88,127 @@ const gameCompleteness = (game: Game): number =>
     game.summary,
     game.howLongToBeatUrl,
     game.durationLabel,
+    game.mainExtraHours,
+    game.howLongToBeatTitle,
   ].filter(Boolean).length;
+
+export const findGuaranteedNextVoteGames = async (
+  manager: EntityManager,
+): Promise<Game[]> => {
+  const campaign = await manager.getRepository(Campaign).findOne({
+    where: { current: true },
+    relations: ['players', 'players.suggestedGame'],
+  });
+  const gamesByIdentity = new Map<string, Game[]>();
+
+  for (const campaignPlayer of campaign?.players ?? []) {
+    const game = campaignPlayer.suggestedGame;
+    if (!game) continue;
+    const identity = normalizeGameIdentity(game);
+    gamesByIdentity.set(identity, [
+      ...(gamesByIdentity.get(identity) ?? []),
+      game,
+    ]);
+  }
+
+  return Array.from(gamesByIdentity.values())
+    .map(
+      (matchingGames) =>
+        [...matchingGames].sort(
+          (left, right) =>
+            gameCompleteness(right) - gameCompleteness(left) ||
+            left.id - right.id,
+        )[0],
+    )
+    .sort((left, right) => left.title.localeCompare(right.title, 'pt-BR'));
+};
+
+const findEligibleBacklogGames = async (
+  manager: EntityManager,
+  excludedIdentities: Set<string>,
+): Promise<Game[]> => {
+  const [games, poolOptions, campaigns] = await Promise.all([
+    manager.getRepository(Game).find({ order: { id: 'ASC' } }),
+    manager.getRepository(PoolOption).find({ relations: ['game', 'pool'] }),
+    manager.getRepository(Campaign).find({ relations: ['game'] }),
+  ]);
+  const winningIdentities = new Set(
+    campaigns
+      .map((campaign) => campaign.game)
+      .filter((game): game is Game => Boolean(game))
+      .map(normalizeGameIdentity),
+  );
+  const appearancesByIdentity = new Map<string, Set<number>>();
+  const gamesByIdentity = new Map<string, Game[]>();
+
+  for (const option of poolOptions) {
+    const identity = normalizeGameIdentity(option.game);
+    const poolIds = appearancesByIdentity.get(identity) ?? new Set<number>();
+    poolIds.add(option.pool.id);
+    appearancesByIdentity.set(identity, poolIds);
+  }
+
+  for (const game of games) {
+    const identity = normalizeGameIdentity(game);
+    gamesByIdentity.set(identity, [
+      ...(gamesByIdentity.get(identity) ?? []),
+      game,
+    ]);
+  }
+
+  return Array.from(gamesByIdentity, ([identity, matchingGames]) => ({
+    identity,
+    appearances: appearancesByIdentity.get(identity)?.size ?? 0,
+    game: [...matchingGames].sort(
+      (left, right) =>
+        gameCompleteness(right) - gameCompleteness(left) || left.id - right.id,
+    )[0],
+  }))
+    .filter(
+      ({ identity, appearances, game }) =>
+        game.suggestion &&
+        !excludedIdentities.has(identity) &&
+        !winningIdentities.has(identity) &&
+        appearances < MAX_BACKLOG_APPEARANCES,
+    )
+    .sort(
+      (left, right) =>
+        left.appearances - right.appearances ||
+        left.game.title.localeCompare(right.game.title, 'pt-BR'),
+    )
+    .map(({ game }) => game);
+};
+
+export const buildNextVotePoolGames = async (
+  manager: EntityManager,
+  requestedGames: Game[],
+  reservedSlots = 0,
+): Promise<Game[]> => {
+  const gamesByIdentity = new Map<string, Game>();
+
+  for (const game of requestedGames) {
+    gamesByIdentity.set(normalizeGameIdentity(game), game);
+  }
+
+  for (const game of await findGuaranteedNextVoteGames(manager)) {
+    gamesByIdentity.set(normalizeGameIdentity(game), game);
+  }
+
+  const persistedTarget = Math.max(0, TARGET_POOL_SIZE - reservedSlots);
+  if (gamesByIdentity.size < persistedTarget) {
+    const fillerGames = await findEligibleBacklogGames(
+      manager,
+      new Set(gamesByIdentity.keys()),
+    );
+
+    for (const game of fillerGames) {
+      if (gamesByIdentity.size >= persistedTarget) break;
+      gamesByIdentity.set(normalizeGameIdentity(game), game);
+    }
+  }
+
+  return Array.from(gamesByIdentity.values());
+};
 
 @Injectable()
 export class GamesService {
@@ -64,6 +221,8 @@ export class GamesService {
     private campaignRepository: Repository<Campaign>,
     @InjectRepository(GameRecommendation)
     private gameRecommendationRepository: Repository<GameRecommendation>,
+    private readonly dataSource: DataSource,
+    private readonly gameResearchService: GameResearchService,
   ) {}
 
   create(createGameDto: CreateGameDto): Promise<Game> {
@@ -75,12 +234,287 @@ export class GamesService {
     return this.gameRepository.find();
   }
 
+  async searchRecommendations(query: string): Promise<SteamGameSearchResult[]> {
+    const normalizedQuery = normalizeGameTitle(query);
+    const localResults = (
+      await this.gameRepository.find({ order: { title: 'ASC' } })
+    )
+      .filter((game) =>
+        normalizeGameTitle(game.title).includes(normalizedQuery),
+      )
+      .map((game) => ({ game, steamAppId: extractSteamAppId(game.steam) }))
+      .filter(
+        (entry): entry is { game: Game; steamAppId: number } =>
+          entry.steamAppId !== null,
+      )
+      .map(({ game, steamAppId }) => ({
+        steamAppId,
+        title: game.title,
+        image: game.cover ?? null,
+        source: 'catalog' as const,
+      }));
+
+    let steamResults: SteamGameSearchResult[] = [];
+    try {
+      steamResults = await this.gameResearchService.searchSteam(query);
+    } catch (error) {
+      if (!localResults.length) throw error;
+    }
+
+    const resultsByAppId = new Map<number, SteamGameSearchResult>();
+    for (const result of [...localResults, ...steamResults]) {
+      if (!resultsByAppId.has(result.steamAppId)) {
+        resultsByAppId.set(result.steamAppId, result);
+      }
+    }
+
+    return Array.from(resultsByAppId.values()).slice(0, 8);
+  }
+
+  async assessRecommendation(
+    steamAppId: number,
+    player: Player,
+  ): Promise<RecommendationAssessment> {
+    const campaign = await this.campaignRepository.findOne({
+      where: { current: true },
+      relations: ['game', 'players', 'players.player', 'players.suggestedGame'],
+    });
+
+    if (!campaign) {
+      throw new NotFoundException('No current campaign found');
+    }
+
+    const localGame = (await this.gameRepository.find()).find(
+      (game) => extractSteamAppId(game.steam) === steamAppId,
+    );
+    const cachedResearch = localGame
+      ? this.getCachedResearch(localGame, steamAppId)
+      : null;
+    const assessment = cachedResearch
+      ? this.gameResearchService.assessResearchedGame(cachedResearch)
+      : await this.gameResearchService.assessSteamGame(steamAppId);
+    if (!assessment.eligible) return assessment;
+
+    const campaignPlayer = campaign.players.find(
+      (entry) => entry.player.id === player.id,
+    );
+    if (campaignPlayer?.suggestedGame) {
+      return {
+        ...assessment,
+        eligible: false,
+        reason: 'already_suggested',
+        existingSuggestion: {
+          id: campaignPlayer.suggestedGame.id,
+          title: campaignPlayer.suggestedGame.title,
+        },
+      };
+    }
+
+    const matchingGame = await this.findEquivalentGame(
+      this.dataSource.manager,
+      assessment.game,
+    );
+    if (matchingGame && (await this.hasWonCampaign(matchingGame))) {
+      return { ...assessment, eligible: false, reason: 'already_played' };
+    }
+
+    return {
+      ...assessment,
+      assessmentToken: this.gameResearchService.issueAssessmentToken(
+        assessment.game,
+        player.id,
+      ),
+    };
+  }
+
+  async recommend(
+    assessmentToken: string,
+    player: Player,
+  ): Promise<CreatedGameRecommendation> {
+    let researchedGame: ResearchedGame;
+
+    try {
+      researchedGame = this.gameResearchService.verifyAssessmentToken(
+        assessmentToken,
+        player.id,
+      );
+    } catch {
+      throw new BadRequestException(
+        'A verificação expirou. Selecione o jogo novamente.',
+      );
+    }
+
+    const result = await this.dataSource.transaction(async (manager) => {
+      const campaign = await manager.getRepository(Campaign).findOne({
+        where: { current: true },
+        relations: [
+          'game',
+          'players',
+          'players.player',
+          'players.suggestedGame',
+        ],
+      });
+
+      if (!campaign) {
+        throw new NotFoundException('No current campaign found');
+      }
+
+      let game = await this.findEquivalentGame(manager, researchedGame);
+      const alreadySuggestedGame = campaign.players.find(
+        (entry) => entry.player.id === player.id,
+      )?.suggestedGame;
+
+      if (alreadySuggestedGame) {
+        const sameGame = game
+          ? normalizeGameIdentity(alreadySuggestedGame) ===
+            normalizeGameIdentity(game)
+          : extractSteamAppId(alreadySuggestedGame.steam) ===
+            researchedGame.steamAppId;
+
+        if (!sameGame) {
+          throw new BadRequestException(
+            `Você já sugeriu ${alreadySuggestedGame.title} neste ciclo.`,
+          );
+        }
+
+        return {
+          game: alreadySuggestedGame,
+          created: false,
+          alreadyRecommended: true,
+        };
+      }
+
+      if (game && (await this.hasWonCampaign(game, manager))) {
+        throw new BadRequestException(
+          'Este jogo já foi escolhido pelo grupo em outra campanha.',
+        );
+      }
+
+      const created = !game;
+      const gameRepository = manager.getRepository(Game);
+      game ??= gameRepository.create({
+        title: researchedGame.title,
+        suggestion: true,
+        cover: researchedGame.cover,
+        steam: researchedGame.steam,
+        trailer: researchedGame.trailer,
+        summary: researchedGame.summary,
+        howLongToBeatUrl: researchedGame.howLongToBeatUrl,
+        durationLabel: researchedGame.durationLabel,
+      });
+      game.suggestion = true;
+      game.cover ||= researchedGame.cover;
+      game.steam ||= researchedGame.steam;
+      game.trailer ||= researchedGame.trailer;
+      game.summary ||= researchedGame.summary;
+      game.howLongToBeatUrl ||= researchedGame.howLongToBeatUrl;
+      game.durationLabel ||= researchedGame.durationLabel;
+      game.mainHours ??= researchedGame.mainHours;
+      game.mainExtraHours ??= researchedGame.mainExtraHours;
+      game.howLongToBeatTitle ||= researchedGame.howLongToBeatTitle;
+      game = await gameRepository.save(game);
+
+      await manager
+        .getRepository(GameRecommendation)
+        .createQueryBuilder()
+        .insert()
+        .values({ game, player })
+        .orIgnore()
+        .execute();
+
+      const campaignPlayerRepository = manager.getRepository(CampaignPlayer);
+      let campaignPlayer = campaign.players.find(
+        (entry) => entry.player.id === player.id,
+      );
+      campaignPlayer ??= campaignPlayerRepository.create({
+        campaign,
+        player,
+        played_the_game: false,
+        finished_the_game: false,
+        partook_in_the_meeting: false,
+        suggested_a_game: false,
+        suggestedGame: null,
+      });
+      campaignPlayer.suggested_a_game = true;
+      campaignPlayer.suggestedGame = game;
+      await campaignPlayerRepository.save(campaignPlayer);
+
+      return { game, created, alreadyRecommended: false };
+    });
+
+    const [game, electionAppearances] = await Promise.all([
+      this.findOne(result.game.id),
+      this.countElectionAppearances(result.game),
+    ]);
+
+    if (!game) {
+      throw new NotFoundException(`Game #${result.game.id} not found`);
+    }
+
+    return { ...result, game, electionAppearances };
+  }
+
+  async withdrawRecommendation(
+    player: Player,
+  ): Promise<WithdrawnGameRecommendation> {
+    return this.dataSource.transaction(async (manager) => {
+      const campaign = await manager.getRepository(Campaign).findOne({
+        where: { current: true },
+        relations: ['players', 'players.player', 'players.suggestedGame'],
+      });
+
+      if (!campaign) {
+        throw new NotFoundException('No current campaign found');
+      }
+
+      const campaignPlayer = campaign.players.find(
+        (entry) => entry.player.id === player.id,
+      );
+      const game = campaignPlayer?.suggestedGame;
+      if (!campaignPlayer || !game) {
+        throw new BadRequestException(
+          'Você ainda não sugeriu um jogo neste ciclo.',
+        );
+      }
+
+      campaignPlayer.suggested_a_game = false;
+      campaignPlayer.suggestedGame = null;
+      await manager.getRepository(CampaignPlayer).save(campaignPlayer);
+
+      const identity = normalizeGameIdentity(game);
+      const activeSuggestionCount = campaign.players.filter(
+        (entry) =>
+          entry.suggestedGame &&
+          normalizeGameIdentity(entry.suggestedGame) === identity,
+      ).length;
+      const appearances = await manager.getRepository(PoolOption).find({
+        relations: ['game', 'pool'],
+      });
+      const appearanceCount = new Set(
+        appearances
+          .filter((option) => normalizeGameIdentity(option.game) === identity)
+          .map((option) => option.pool.id),
+      ).size;
+      const hiddenFromCatalog =
+        activeSuggestionCount === 0 && appearanceCount === 0;
+
+      if (hiddenFromCatalog) {
+        game.suggestion = false;
+        await manager.getRepository(Game).save(game);
+      }
+
+      return { game, hiddenFromCatalog };
+    });
+  }
+
   async findBacklog(): Promise<GameBacklog> {
     const [games, poolOptions, campaigns, recommendersByIdentity] =
       await Promise.all([
         this.gameRepository.find({ order: { id: 'ASC' } }),
         this.poolOptionRepository.find({ relations: ['game', 'pool'] }),
-        this.campaignRepository.find({ relations: ['game'] }),
+        this.campaignRepository.find({
+          relations: ['game', 'players', 'players.suggestedGame'],
+        }),
         this.findRecommendersByIdentity(),
       ]);
 
@@ -99,6 +533,12 @@ export class GamesService {
         .filter((game): game is Game => Boolean(game))
         .map(normalizeGameIdentity),
     );
+    const guaranteedIdentities = new Set(
+      (campaigns.find((campaign) => campaign.current)?.players ?? [])
+        .map((campaignPlayer) => campaignPlayer.suggestedGame)
+        .filter((game): game is Game => Boolean(game))
+        .map(normalizeGameIdentity),
+    );
 
     const appearancesByIdentity = new Map<string, Set<number>>();
     for (const option of poolOptions) {
@@ -111,8 +551,10 @@ export class GamesService {
     const backlogGames: BacklogGame[] = [];
     const rubbleGames: BacklogGame[] = [];
     for (const [identity, matchingGames] of gamesByIdentity) {
+      const guaranteedNextVote = guaranteedIdentities.has(identity);
       if (
-        !matchingGames.some((game) => game.suggestion) ||
+        (!matchingGames.some((game) => game.suggestion) &&
+          !guaranteedNextVote) ||
         winningIdentities.has(identity)
       ) {
         continue;
@@ -129,9 +571,13 @@ export class GamesService {
       const backlogGame = {
         ...game,
         electionAppearances,
+        guaranteedNextVote,
         recommendedBy: recommendersByIdentity.get(identity) ?? [],
       };
-      if (electionAppearances >= MAX_BACKLOG_APPEARANCES) {
+      if (
+        !guaranteedNextVote &&
+        electionAppearances >= MAX_BACKLOG_APPEARANCES
+      ) {
         rubbleGames.push(backlogGame);
       } else {
         backlogGames.push(backlogGame);
@@ -155,6 +601,11 @@ export class GamesService {
       games: backlogGames,
       rubble: rubbleGames,
       retirementThreshold: MAX_BACKLOG_APPEARANCES,
+      targetPoolSize: TARGET_POOL_SIZE,
+      nextVoteFillCount: Math.min(
+        Math.max(0, TARGET_POOL_SIZE - guaranteedIdentities.size),
+        backlogGames.filter((game) => !game.guaranteedNextVote).length,
+      ),
     };
   }
 
@@ -210,6 +661,75 @@ export class GamesService {
         ),
       ]),
     );
+  }
+
+  private async findEquivalentGame(
+    manager: EntityManager,
+    researchedGame: ResearchedGame,
+  ): Promise<Game | null> {
+    const games = await manager.getRepository(Game).find();
+    const normalizedTitle = normalizeGameTitle(researchedGame.title);
+
+    return (
+      games.find(
+        (game) => extractSteamAppId(game.steam) === researchedGame.steamAppId,
+      ) ??
+      games.find(
+        (game) => normalizeGameTitle(game.title) === normalizedTitle,
+      ) ??
+      null
+    );
+  }
+
+  private getCachedResearch(
+    game: Game,
+    steamAppId: number,
+  ): ResearchedGame | null {
+    if (game.mainExtraHours === null || game.mainExtraHours === undefined) {
+      return null;
+    }
+
+    return {
+      steamAppId,
+      title: game.title,
+      cover: game.cover ?? null,
+      steam: game.steam ?? `https://store.steampowered.com/app/${steamAppId}/`,
+      trailer: game.trailer ?? null,
+      summary: game.summary ?? null,
+      howLongToBeatUrl: game.howLongToBeatUrl ?? null,
+      durationLabel: game.durationLabel ?? null,
+      mainHours: game.mainHours ?? null,
+      mainExtraHours: game.mainExtraHours,
+      howLongToBeatTitle: game.howLongToBeatTitle ?? game.title,
+    };
+  }
+
+  private async hasWonCampaign(
+    game: Game,
+    manager: EntityManager = this.dataSource.manager,
+  ): Promise<boolean> {
+    const campaigns = await manager.getRepository(Campaign).find({
+      relations: ['game'],
+    });
+    const identity = normalizeGameIdentity(game);
+
+    return campaigns.some(
+      (campaign) =>
+        campaign.game && normalizeGameIdentity(campaign.game) === identity,
+    );
+  }
+
+  private async countElectionAppearances(game: Game): Promise<number> {
+    const options = await this.poolOptionRepository.find({
+      relations: ['game', 'pool'],
+    });
+    const identity = normalizeGameIdentity(game);
+
+    return new Set(
+      options
+        .filter((option) => normalizeGameIdentity(option.game) === identity)
+        .map((option) => option.pool.id),
+    ).size;
   }
 
   async update(id: number, updateGameDto: UpdateGameDto): Promise<Game> {

--- a/server/src/pool/pool.service.spec.ts
+++ b/server/src/pool/pool.service.spec.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { Game } from '../games/entities/game.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from './entities/pool-option.entity';
 import { Pool } from './entities/pool.entity';
@@ -14,7 +15,15 @@ describe('PoolService', () => {
   beforeEach(async () => {
     dataSource = new DataSource({
       type: 'sqljs',
-      entities: [Campaign, CampaignPlayer, Game, Player, Pool, PoolOption],
+      entities: [
+        Campaign,
+        CampaignPlayer,
+        Game,
+        GameRecommendation,
+        Player,
+        Pool,
+        PoolOption,
+      ],
       synchronize: true,
     });
     await dataSource.initialize();
@@ -41,5 +50,96 @@ describe('PoolService', () => {
       games[1].id,
     ]);
     await expect(dataSource.getRepository(PoolOption).count()).resolves.toBe(1);
+  });
+
+  it('automatically adds active user recommendations to a new pool', async () => {
+    const gameRepository = dataSource.getRepository(Game);
+    const playerRepository = dataSource.getRepository(Player);
+    const requestedGame = await gameRepository.save(
+      gameRepository.create({ title: 'Requested game' }),
+    );
+    const recommendedGame = await gameRepository.save(
+      gameRepository.create({
+        title: 'Fresh recommendation',
+        suggestion: true,
+      }),
+    );
+    const player = await playerRepository.save(
+      playerRepository.create({ name: 'Ana' }),
+    );
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: true,
+        suggestedGame: recommendedGame,
+      }),
+    );
+    await dataSource
+      .getRepository(GameRecommendation)
+      .save(
+        dataSource
+          .getRepository(GameRecommendation)
+          .create({ game: recommendedGame, player }),
+      );
+
+    const pool = await service.create({
+      options: [{ gameId: requestedGame.id }],
+    });
+
+    expect(pool.options.map((option) => option.game.title).sort()).toEqual([
+      'Fresh recommendation',
+      'Requested game',
+    ]);
+  });
+
+  it('fills a pool toward five games from eligible Brasas', async () => {
+    const gameRepository = dataSource.getRepository(Game);
+    const playerRepository = dataSource.getRepository(Player);
+    const guaranteed = await gameRepository.save(
+      gameRepository.create({ title: 'Guaranteed', suggestion: true }),
+    );
+    await gameRepository.save(
+      ['Alpha', 'Beta', 'Gamma', 'Delta', 'Unused'].map((title) =>
+        gameRepository.create({ title, suggestion: true }),
+      ),
+    );
+    const player = await playerRepository.save(
+      playerRepository.create({ name: 'Ana' }),
+    );
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: true,
+        suggestedGame: guaranteed,
+      }),
+    );
+
+    const pool = await service.create({ options: [] });
+
+    expect(pool.options.map((option) => option.game.title)).toEqual([
+      'Guaranteed',
+      'Alpha',
+      'Beta',
+      'Delta',
+      'Gamma',
+    ]);
   });
 });

--- a/server/src/pool/pool.service.ts
+++ b/server/src/pool/pool.service.ts
@@ -10,6 +10,7 @@ import { Pool } from './entities/pool.entity';
 import { DataSource, DeleteResult, EntityManager, Repository } from 'typeorm';
 import { PoolOption } from './entities/pool-option.entity';
 import { Game } from '../games/entities/game.entity';
+import { buildNextVotePoolGames } from '../games/games.service';
 
 @Injectable()
 export class PoolService {
@@ -79,7 +80,7 @@ export class PoolService {
     const gameRepository = manager.getRepository(Game);
     const optionRepository = manager.getRepository(PoolOption);
 
-    return Promise.all(
+    const requestedGames = await Promise.all(
       createPoolDto.options.map(async ({ gameId }) => {
         const game = await gameRepository.findOneBy({ id: gameId });
 
@@ -87,8 +88,13 @@ export class PoolService {
           throw new BadRequestException(`Game #${gameId} not found`);
         }
 
-        return optionRepository.create({ game, players: [] });
+        return game;
       }),
+    );
+    const poolGames = await buildNextVotePoolGames(manager, requestedGames);
+
+    return poolGames.map((game) =>
+      optionRepository.create({ game, players: [] }),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add authenticated game search, eligibility research, and recommendation withdrawal
- reuse cached game metadata and let previously researched games re-enter future selections
- guarantee active recommendations and fill new pools toward five eligible games
- refine the Brasas catalog, recommendation shelf, lighting, typography, and upward search results

## Validation
- focused server and client tests
- pnpm run ci
- catalog visual verification