### PR TITLE
Restrict login to Bonfire Discord members

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,12 @@ JWT_SECRET=replace-with-a-long-random-secret
 DISCORD_CLIENT_ID=replace-with-discord-client-id
 DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
+DISCORD_GUILD_ID=1534325844619821170
 ```
 
 In the Discord Developer Portal, configure the OAuth redirect URL to match `DISCORD_CALLBACK_URL`.
+Discord login requests `guilds.members.read`; only members of `DISCORD_GUILD_ID` are allowed to
+sign in. The Bonfire server ID above is also the application default.
 
 ## Getting started
 

--- a/client/src/components/CurrentGameHearth.vue
+++ b/client/src/components/CurrentGameHearth.vue
@@ -15,12 +15,15 @@ import JourneyRoster from '@/components/JourneyRoster.vue'
 
 type SaveState = 'idle' | 'saving' | 'saved'
 
+const BONFIRE_DISCORD_URL = 'https://discord.com/channels/1534325844619821170'
+
 const props = defineProps<{
   campaign: Campaign
   game: Game
   campaignUser: CampaignPlayer | null
   journeyStatus: JourneyStatus
   saveState: SaveState
+  isAuthenticated: boolean
 }>()
 
 const emit = defineEmits<{
@@ -82,6 +85,20 @@ const coverStyle = computed(() => {
 })
 
 const durationLabel = computed(() => formatDurationLabel(props.game.durationLabel))
+
+const meetingHref = computed(() => {
+  if (!props.isAuthenticated) {
+    return null
+  }
+
+  if (props.campaign.meetingUrl) {
+    return props.campaign.meetingUrl
+  }
+
+  return props.campaign.meetingLocation?.toLocaleLowerCase().includes('discord')
+    ? BONFIRE_DISCORD_URL
+    : null
+})
 </script>
 
 <template>
@@ -93,12 +110,12 @@ const durationLabel = computed(() => formatDurationLabel(props.game.durationLabe
       </div>
 
       <component
-        :is="campaign.meetingUrl ? 'a' : 'div'"
+        :is="meetingHref ? 'a' : 'div'"
         v-if="meeting || campaign.meetingLocation"
         class="meeting-callout"
-        :href="campaign.meetingUrl || undefined"
-        :target="campaign.meetingUrl ? '_blank' : undefined"
-        :rel="campaign.meetingUrl ? 'noopener noreferrer' : undefined"
+        :href="meetingHref || undefined"
+        :target="meetingHref ? '_blank' : undefined"
+        :rel="meetingHref ? 'noopener noreferrer' : undefined"
       >
         <n-icon size="17"><CalendarOutline /></n-icon>
         <span>

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -8,7 +8,6 @@ type AuthenticatedUser = User & { exp?: number }
 export const useAuthStore = defineStore('auth', () => {
   // State
   const jwt = ref<string | null>(null)
-  const accessToken = ref<string | null>(null)
   const user = ref<User | null>(null)
   const isAuthenticated = ref(false)
   const loading = ref(true)
@@ -17,10 +16,9 @@ export const useAuthStore = defineStore('auth', () => {
   // Actions
   async function handleAuthCallback() {
     const params = new URLSearchParams(window.location.search)
-    const accessTokenParam = params.get('access_token')
     const jwtParam = params.get('jwt')
 
-    if (!accessTokenParam || !jwtParam) {
+    if (!jwtParam) {
       throw new Error('Failed to fetch user')
     }
 
@@ -32,7 +30,6 @@ export const useAuthStore = defineStore('auth', () => {
 
     localStorage.setItem('jwt', jwtParam)
     localStorage.setItem('user', JSON.stringify(user))
-    localStorage.setItem('access_token', accessTokenParam)
 
     await init(true)
   }
@@ -42,9 +39,11 @@ export const useAuthStore = defineStore('auth', () => {
       return
     }
 
+    // Older versions kept Discord's OAuth token in the browser. It is no longer needed.
+    localStorage.removeItem('access_token')
+
     try {
       jwt.value = localStorage.getItem('jwt')
-      accessToken.value = localStorage.getItem('access_token')
       user.value = JSON.parse(localStorage.getItem('user') || 'null') as User | null
 
       if (jwt.value) {
@@ -74,14 +73,12 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('user')
     localStorage.removeItem('access_token')
     jwt.value = null
-    accessToken.value = null
     user.value = null
     isAuthenticated.value = false
   }
 
   return {
     jwt,
-    accessToken,
     user,
     isAuthenticated,
     loading,

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -42,9 +42,15 @@ onBeforeUnmount(() => {
 })
 
 const params = new URLSearchParams(window.location.search)
+const authenticationError = params.get('authentication_error')
 
-if (params.get('authentication_error') === 'true') {
-  message.error('Autenticação falhou. Tente novamente (ou desista).', {
+if (authenticationError) {
+  const authenticationMessage =
+    authenticationError === 'not_member'
+      ? 'A chama ainda não reconhece você. Entre no Discord do Bonfire e tente novamente.'
+      : 'Não foi possível confirmar sua presença no Discord. Tente novamente.'
+
+  message.error(authenticationMessage, {
     duration: 5000,
   })
 
@@ -106,6 +112,7 @@ const recalculateElection = async () => {
       :campaign-user="campaignUser"
       :journey-status="journeyStatus"
       :save-state="saveState"
+      :is-authenticated="isAuthenticated"
       @change-journey="changeJourney"
     />
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,6 +22,7 @@ JWT_SECRET=replace-with-a-long-random-secret
 DISCORD_CLIENT_ID=replace-with-discord-client-id
 DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
+DISCORD_GUILD_ID=1534325844619821170
 
 # Cloudflare R2 media storage. Leave all five required values blank to use original media URLs locally.
 R2_ENDPOINT=https://account-id.r2.cloudflarestorage.com

--- a/server/src/auth/auth.constants.ts
+++ b/server/src/auth/auth.constants.ts
@@ -1,0 +1,1 @@
+export const BONFIRE_AUTH_VERSION = 1;

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -4,6 +4,8 @@ import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
 import express from 'express';
 import { AuthPlayer, AuthService } from './auth.service';
+import { DiscordCallbackGuard } from './guards/discord-callback.guard';
+import type { DiscordCallbackRequest } from './guards/discord-callback.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -22,9 +24,9 @@ export class AuthController {
 
   // 2) Discord callback
   @Get('discord/callback')
-  @UseGuards(AuthGuard('discord'))
+  @UseGuards(DiscordCallbackGuard)
   async discordCallback(
-    @Req() req: express.Request,
+    @Req() req: DiscordCallbackRequest,
     @Res() res: express.Response,
   ) {
     const player = req.user as AuthPlayer;
@@ -32,13 +34,17 @@ export class AuthController {
       this.config.getOrThrow<string>('PUBLIC_CLIENT_URL');
 
     if (!player) {
-      return res.redirect(302, `${clientUrl}?authentication_error=true`);
+      const redirectUrl = new URL(clientUrl);
+      redirectUrl.searchParams.set(
+        'authentication_error',
+        req.discordAuthenticationError ?? 'true',
+      );
+      return res.redirect(302, redirectUrl.toString());
     }
 
     const token: string = await this.authService.signToken(player);
     const redirectUrl = new URL('/auth/callback', clientUrl);
     redirectUrl.searchParams.append('jwt', token);
-    redirectUrl.searchParams.append('access_token', player.accessToken);
 
     return res.redirect(302, redirectUrl.toString());
   }

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -9,6 +9,8 @@ import { DiscordStrategy } from './strategies/discord.strategy';
 import { PlayersModule } from '../players/players.module';
 import { JwtStrategy } from './strategies/jwt.strategy'; // assumes you have this
 import { MediaModule } from '../media/media.module';
+import { DiscordMembershipService } from './discord-membership.service';
+import { DiscordCallbackGuard } from './guards/discord-callback.guard';
 
 @Module({
   imports: [
@@ -26,7 +28,13 @@ import { MediaModule } from '../media/media.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, DiscordStrategy, JwtStrategy],
+  providers: [
+    AuthService,
+    DiscordStrategy,
+    DiscordMembershipService,
+    DiscordCallbackGuard,
+    JwtStrategy,
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -5,6 +5,8 @@ import { AuthService } from './auth.service';
 import { MediaStorageService } from '../media/media-storage.service';
 import type { Profile } from 'passport-discord';
 import { Player } from '../players/entities/player.entity';
+import { DiscordMembershipService } from './discord-membership.service';
+import { BONFIRE_AUTH_VERSION } from './auth.constants';
 
 describe('AuthService', () => {
   it('does not include the Discord access token in the signed JWT payload', async () => {
@@ -17,6 +19,10 @@ describe('AuthService', () => {
         { provide: PlayersService, useValue: {} },
         { provide: JwtService, useValue: { signAsync } },
         { provide: MediaStorageService, useValue: {} },
+        {
+          provide: DiscordMembershipService,
+          useValue: { assertBonfireMember: jest.fn() },
+        },
       ],
     }).compile();
     const service = module.get(AuthService);
@@ -26,7 +32,6 @@ describe('AuthService', () => {
       email: 'player@example.com',
       discord: { id: 'discord-id', username: 'player' },
       campaigns: [],
-      accessToken: 'sensitive-token',
     };
 
     await expect(service.signToken(player)).resolves.toBe('signed-token');
@@ -35,6 +40,7 @@ describe('AuthService', () => {
       email: player.email,
       name: player.name,
       discord: player.discord,
+      authVersion: BONFIRE_AUTH_VERSION,
     });
     expect(signAsync.mock.calls[0][0]).not.toHaveProperty('accessToken');
   });
@@ -56,10 +62,14 @@ describe('AuthService', () => {
     const mediaStorageService = {
       storeDiscordAvatar: jest.fn().mockResolvedValue(storedUrl),
     };
+    const discordMembershipService = {
+      assertBonfireMember: jest.fn().mockResolvedValue(undefined),
+    };
     const service = new AuthService(
       playersService as unknown as PlayersService,
       {} as JwtService,
       mediaStorageService as unknown as MediaStorageService,
+      discordMembershipService as unknown as DiscordMembershipService,
     );
     const profile = {
       id: '1234',
@@ -68,12 +78,12 @@ describe('AuthService', () => {
       avatar: 'abcdef123456',
     } as unknown as Profile;
 
-    const player = await service.validateDiscordUser(
-      profile,
-      'access-token',
-      'refresh-token',
-    );
+    const player = await service.validateDiscordUser(profile, 'access-token');
 
+    expect(discordMembershipService.assertBonfireMember).toHaveBeenCalledWith(
+      '1234',
+      'access-token',
+    );
     expect(mediaStorageService.storeDiscordAvatar).toHaveBeenCalledWith(
       '1234',
       'abcdef123456',
@@ -81,5 +91,35 @@ describe('AuthService', () => {
     );
     expect(create.mock.calls[0][0].discord?.avatar).toBe(storedUrl);
     expect(player.discord?.avatar).toBe(storedUrl);
+  });
+
+  it('does not create a player before Discord membership is verified', async () => {
+    const playersService = {
+      findByDiscordId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+    const discordMembershipService = {
+      assertBonfireMember: jest
+        .fn()
+        .mockRejectedValue(new Error('membership rejected')),
+    };
+    const service = new AuthService(
+      playersService as unknown as PlayersService,
+      {} as JwtService,
+      {} as MediaStorageService,
+      discordMembershipService as unknown as DiscordMembershipService,
+    );
+    const profile = {
+      id: 'outsider-id',
+      username: 'outsider',
+    } as unknown as Profile;
+
+    await expect(
+      service.validateDiscordUser(profile, 'access-token'),
+    ).rejects.toThrow('membership rejected');
+    expect(playersService.findByDiscordId).not.toHaveBeenCalled();
+    expect(playersService.create).not.toHaveBeenCalled();
+    expect(playersService.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -4,10 +4,10 @@ import type { Profile } from 'passport-discord';
 import { PlayersService } from '../players/players.service';
 import { Player } from '../players/entities/player.entity';
 import { MediaStorageService } from '../media/media-storage.service';
+import { DiscordMembershipService } from './discord-membership.service';
+import { BONFIRE_AUTH_VERSION } from './auth.constants';
 
-export type AuthPlayer = Player & {
-  accessToken: string;
-};
+export type AuthPlayer = Player;
 
 type DiscordProfileDetails = Profile & {
   email?: string | null;
@@ -23,16 +23,19 @@ export class AuthService {
     private readonly playersService: PlayersService,
     private readonly jwtService: JwtService,
     private readonly mediaStorageService: MediaStorageService,
+    private readonly discordMembershipService: DiscordMembershipService,
   ) {}
 
   async validateDiscordUser(
     profile: Profile,
     accessToken: string,
-    refreshToken: string,
   ): Promise<AuthPlayer> {
-    void refreshToken;
-
     const discordProfile = profile as DiscordProfileDetails;
+    await this.discordMembershipService.assertBonfireMember(
+      discordProfile.id,
+      accessToken,
+    );
+
     let avatar: string | undefined;
     if (discordProfile.avatar) {
       const discordAvatarUrl = this.playersService.buildDiscordAvatarUrl(
@@ -66,12 +69,18 @@ export class AuthService {
       player = await this.playersService.update(player.id, dto);
     }
 
-    return { ...player, accessToken };
+    return player;
   }
 
   async signToken(player: Player): Promise<string> {
     const { id, email, name, discord } = player;
-    return this.jwtService.signAsync({ id, email, name, discord });
+    return this.jwtService.signAsync({
+      id,
+      email,
+      name,
+      discord,
+      authVersion: BONFIRE_AUTH_VERSION,
+    });
   }
 
   private async storeDiscordAvatar(

--- a/server/src/auth/discord-membership.service.spec.ts
+++ b/server/src/auth/discord-membership.service.spec.ts
@@ -1,0 +1,60 @@
+import {
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  DEFAULT_BONFIRE_DISCORD_GUILD_ID,
+  DiscordMembershipService,
+} from './discord-membership.service';
+
+describe('DiscordMembershipService', () => {
+  const service = new DiscordMembershipService({
+    get: jest.fn().mockReturnValue(DEFAULT_BONFIRE_DISCORD_GUILD_ID),
+  } as unknown as ConfigService);
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('accepts a Discord user who belongs to the Bonfire server', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: 'member-id' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      service.assertBonfireMember('member-id', 'access-token'),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://discord.com/api/v10/users/@me/guilds/${DEFAULT_BONFIRE_DISCORD_GUILD_ID}/member`,
+      { headers: { Authorization: 'Bearer access-token' } },
+    );
+  });
+
+  it('rejects a Discord user who is not in the Bonfire server', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 404,
+      }),
+    );
+
+    await expect(
+      service.assertBonfireMember('outsider-id', 'access-token'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('does not treat a Discord outage as a membership rejection', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 503,
+      }),
+    );
+
+    await expect(
+      service.assertBonfireMember('member-id', 'access-token'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+});

--- a/server/src/auth/discord-membership.service.ts
+++ b/server/src/auth/discord-membership.service.ts
@@ -1,0 +1,81 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export const DEFAULT_BONFIRE_DISCORD_GUILD_ID = '1534325844619821170';
+
+type DiscordGuildMember = {
+  user?: {
+    id?: string;
+  };
+};
+
+@Injectable()
+export class DiscordMembershipService {
+  private readonly logger = new Logger(DiscordMembershipService.name);
+  private readonly guildId: string;
+
+  constructor(config: ConfigService) {
+    this.guildId =
+      config.get<string>('DISCORD_GUILD_ID')?.trim() ||
+      DEFAULT_BONFIRE_DISCORD_GUILD_ID;
+  }
+
+  async assertBonfireMember(
+    discordUserId: string,
+    accessToken: string,
+  ): Promise<void> {
+    let response: Response;
+
+    try {
+      response = await fetch(
+        `https://discord.com/api/v10/users/@me/guilds/${this.guildId}/member`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Could not verify Discord membership: ${reason}`);
+      throw new ServiceUnavailableException(
+        'Discord membership verification is temporarily unavailable',
+      );
+    }
+
+    if (
+      response.status === 401 ||
+      response.status === 403 ||
+      response.status === 404
+    ) {
+      throw new UnauthorizedException('discord_guild_membership_required');
+    }
+
+    if (!response.ok) {
+      this.logger.error(
+        `Discord membership verification failed with status ${response.status}`,
+      );
+      throw new ServiceUnavailableException(
+        'Discord membership verification is temporarily unavailable',
+      );
+    }
+
+    let member: DiscordGuildMember;
+    try {
+      member = (await response.json()) as DiscordGuildMember;
+    } catch {
+      throw new ServiceUnavailableException(
+        'Discord returned an invalid membership response',
+      );
+    }
+
+    if (member.user?.id !== discordUserId) {
+      throw new UnauthorizedException('discord_guild_membership_required');
+    }
+  }
+}

--- a/server/src/auth/guards/discord-callback.guard.spec.ts
+++ b/server/src/auth/guards/discord-callback.guard.spec.ts
@@ -1,0 +1,40 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  DiscordCallbackGuard,
+  DiscordCallbackRequest,
+} from './discord-callback.guard';
+
+describe('DiscordCallbackGuard', () => {
+  const createContext = (request: DiscordCallbackRequest): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    }) as ExecutionContext;
+
+  it('lets the controller redirect a rejected non-member', () => {
+    const request = {} as DiscordCallbackRequest;
+    const guard = new DiscordCallbackGuard();
+
+    expect(
+      guard.handleRequest(
+        new UnauthorizedException('discord_guild_membership_required'),
+        false,
+        undefined,
+        createContext(request),
+      ),
+    ).toBeNull();
+    expect(request.discordAuthenticationError).toBe('not_member');
+  });
+
+  it('preserves an authenticated Discord user', () => {
+    const request = {} as DiscordCallbackRequest;
+    const guard = new DiscordCallbackGuard();
+    const user = { id: 1 };
+
+    expect(
+      guard.handleRequest(null, user, undefined, createContext(request)),
+    ).toBe(user);
+    expect(request.discordAuthenticationError).toBeUndefined();
+  });
+});

--- a/server/src/auth/guards/discord-callback.guard.ts
+++ b/server/src/auth/guards/discord-callback.guard.ts
@@ -1,0 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import type { Request } from 'express';
+
+export type DiscordCallbackRequest = Request & {
+  discordAuthenticationError?: 'not_member' | 'unavailable';
+};
+
+@Injectable()
+export class DiscordCallbackGuard extends AuthGuard('discord') {
+  handleRequest<TUser>(
+    err: Error | null,
+    user: TUser | false,
+    _info: unknown,
+    context: ExecutionContext,
+  ): TUser | null {
+    if (!err && user) {
+      return user;
+    }
+
+    const request = context.switchToHttp().getRequest<DiscordCallbackRequest>();
+    request.discordAuthenticationError =
+      err?.message === 'discord_guild_membership_required'
+        ? 'not_member'
+        : 'unavailable';
+
+    return null;
+  }
+}

--- a/server/src/auth/strategies/discord.strategy.ts
+++ b/server/src/auth/strategies/discord.strategy.ts
@@ -14,7 +14,7 @@ export class DiscordStrategy extends PassportStrategy(Strategy, 'discord') {
       clientID: config.getOrThrow<string>('DISCORD_CLIENT_ID'),
       clientSecret: config.getOrThrow<string>('DISCORD_CLIENT_SECRET'),
       callbackURL: config.getOrThrow<string>('DISCORD_CALLBACK_URL'),
-      scope: ['identify', 'email'],
+      scope: ['identify', 'email', 'guilds.members.read'],
       passReqToCallback: false,
     });
   }
@@ -24,10 +24,8 @@ export class DiscordStrategy extends PassportStrategy(Strategy, 'discord') {
     refreshToken: string,
     profile: Profile,
   ): Promise<AuthPlayer> {
-    return this.authService.validateDiscordUser(
-      profile,
-      accessToken,
-      refreshToken,
-    );
+    void refreshToken;
+
+    return this.authService.validateDiscordUser(profile, accessToken);
   }
 }

--- a/server/src/auth/strategies/jwt.strategy.spec.ts
+++ b/server/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,37 @@
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
+import { PlayersService } from '../../players/players.service';
+import { Player } from '../../players/entities/player.entity';
+import { BONFIRE_AUTH_VERSION } from '../auth.constants';
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy', () => {
+  const player = { id: 1, name: 'Ember' } as Player;
+  const playerService = {
+    findOne: jest.fn().mockResolvedValue(player),
+  };
+  const strategy = new JwtStrategy(
+    {
+      getOrThrow: jest.fn().mockReturnValue('test-jwt-secret'),
+    } as unknown as ConfigService,
+    playerService as unknown as PlayersService,
+  );
+
+  beforeEach(() => {
+    playerService.findOne.mockClear();
+  });
+
+  it('accepts sessions issued after Discord membership verification', async () => {
+    await expect(
+      strategy.validate({ id: 1, authVersion: BONFIRE_AUTH_VERSION }),
+    ).resolves.toBe(player);
+    expect(playerService.findOne).toHaveBeenCalledWith(1);
+  });
+
+  it('invalidates sessions issued before the Discord membership gate', async () => {
+    await expect(strategy.validate({ id: 1 })).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(playerService.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/auth/strategies/jwt.strategy.ts
+++ b/server/src/auth/strategies/jwt.strategy.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PlayersService } from '../../players/players.service';
 import { Player } from '../../players/entities/player.entity';
+import { BONFIRE_AUTH_VERSION } from '../auth.constants';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -17,8 +18,14 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: { id?: unknown }): Promise<Player> {
-    if (!Number.isInteger(payload.id)) {
+  async validate(payload: {
+    id?: unknown;
+    authVersion?: unknown;
+  }): Promise<Player> {
+    if (
+      !Number.isInteger(payload.id) ||
+      payload.authVersion !== BONFIRE_AUTH_VERSION
+    ) {
       throw new UnauthorizedException();
     }
 

--- a/server/src/campaign/campaign.controller.spec.ts
+++ b/server/src/campaign/campaign.controller.spec.ts
@@ -1,0 +1,45 @@
+import { CampaignController } from './campaign.controller';
+import { CampaignService } from './campaign.service';
+import { Campaign } from './entities/campaign.entity';
+import { Player } from '../players/entities/player.entity';
+
+describe('CampaignController', () => {
+  const createCampaign = (): Campaign =>
+    ({
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      meetingUrl: 'https://discord.com/channels/server-id/channel-id',
+    }) as Campaign;
+
+  it('hides the private meeting URL from public visitors', async () => {
+    const campaign = createCampaign();
+    const campaignService = {
+      current: jest.fn().mockResolvedValue(campaign),
+    };
+    const controller = new CampaignController(
+      campaignService as unknown as CampaignService,
+    );
+
+    await expect(controller.current(null)).resolves.toMatchObject({
+      meetingUrl: null,
+    });
+  });
+
+  it('returns the meeting URL to an authenticated player', async () => {
+    const campaign = createCampaign();
+    const campaignService = {
+      current: jest.fn().mockResolvedValue(campaign),
+    };
+    const controller = new CampaignController(
+      campaignService as unknown as CampaignService,
+    );
+
+    await expect(
+      controller.current({ id: 1 } as Player),
+    ).resolves.toMatchObject({
+      meetingUrl: 'https://discord.com/channels/server-id/channel-id',
+    });
+  });
+});

--- a/server/src/campaign/campaign.controller.ts
+++ b/server/src/campaign/campaign.controller.ts
@@ -47,8 +47,14 @@ export class CampaignController {
 
   @Get('current')
   @UseGuards(OptionalJwtAuthGuard)
-  current(@CurrentPlayer() player: Player | null): Promise<Campaign> {
-    return this.campaignService.current(player);
+  async current(@CurrentPlayer() player: Player | null): Promise<Campaign> {
+    const campaign = await this.campaignService.current(player);
+
+    if (!player) {
+      campaign.meetingUrl = null;
+    }
+
+    return campaign;
   }
 
   @Get('history')


### PR DESCRIPTION
## Summary

- require Discord membership in guild 1534325844619821170 before creating or updating a player
- invalidate sessions issued before the membership gate and keep Discord OAuth tokens out of the browser
- show a clear denial message and expose Discord meeting links only to authenticated members
- link Discord meeting locations to the Bonfire server when no more specific meeting URL is configured

## Validation

- `pnpm run ci`
- 25 client tests passed
- 46 server tests passed