### PR TITLE
Promote automated campaign cycles to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ DISCORD_CLIENT_ID=replace-with-discord-client-id
 DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
 DISCORD_GUILD_ID=1534325844619821170
-BONFIRE_ADMIN_DISCORD_IDS=replace-with-owner-discord-id
+BONFIRE_CONDUCTOR_DISCORD_ID=replace-with-owner-discord-id
 DISCORD_BOT_TOKEN=replace-with-private-bot-token
 CYCLE_AUTOMATION_SECRET=replace-with-a-separate-long-random-secret
 ```
@@ -136,10 +136,10 @@ In the Discord Developer Portal, configure the OAuth redirect URL to match `DISC
 Discord login requests `guilds.members.read`; only members of `DISCORD_GUILD_ID` are allowed to
 sign in. The Bonfire server ID above is also the application default.
 
-`BONFIRE_ADMIN_DISCORD_IDS` is a comma-separated allowlist for the private
-`/conduzir` workflow. Administrators need to sign in again after being added so
-their browser receives a fresh JWT. `DISCORD_BOT_TOKEN` remains server-side and
-is used only after the conductor reviews and confirms a channel/event plan. The
+`BONFIRE_CONDUCTOR_DISCORD_ID` identifies the one owner of the private
+`/conduzir` workflow. The conductor needs to sign in again after this value
+changes so the browser receives a fresh JWT. `DISCORD_BOT_TOKEN` remains
+server-side and is used only after the conductor reviews and confirms a channel/event plan. The
 bot needs permission to manage channels and permission overwrites, plus
 `CREATE_EVENTS` in the configured guild and meeting voice channel.
 `CYCLE_AUTOMATION_SECRET` is optional;
@@ -207,7 +207,7 @@ The server exposes routes for:
 - `GET /content/rules` — Markdown rules currently published on the website.
 - `PUT /campaign/update-player-game-information` — update authenticated player's current campaign progress.
 - `POST /campaign/vote` and `POST /campaign/undo-vote` — campaign voting actions.
-- `GET /cycle/overview`, `POST /cycle/draw`, and `POST /cycle/start-election` — guarded cycle composition and election launch.
+- `GET /cycle/overview`, `POST /cycle/draw`, `POST /cycle/start-election`, and `POST /cycle/cancel-election` — guarded cycle composition, election launch, and explicit rollback.
 - `POST /cycle/transition/preview` and `POST /cycle/transition/apply` — guarded, reviewed campaign and Discord transition.
 - `GET /auth/discord` — start Discord OAuth flow.
 - `GET /auth/discord/callback` — Discord OAuth callback.

--- a/README.md
+++ b/README.md
@@ -127,11 +127,23 @@ DISCORD_CLIENT_ID=replace-with-discord-client-id
 DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
 DISCORD_GUILD_ID=1534325844619821170
+BONFIRE_ADMIN_DISCORD_IDS=replace-with-owner-discord-id
+DISCORD_BOT_TOKEN=replace-with-private-bot-token
+CYCLE_AUTOMATION_SECRET=replace-with-a-separate-long-random-secret
 ```
 
 In the Discord Developer Portal, configure the OAuth redirect URL to match `DISCORD_CALLBACK_URL`.
 Discord login requests `guilds.members.read`; only members of `DISCORD_GUILD_ID` are allowed to
 sign in. The Bonfire server ID above is also the application default.
+
+`BONFIRE_ADMIN_DISCORD_IDS` is a comma-separated allowlist for the private
+`/conduzir` workflow. Administrators need to sign in again after being added so
+their browser receives a fresh JWT. `DISCORD_BOT_TOKEN` remains server-side and
+is used only after the conductor reviews and confirms a channel/event plan. The
+bot needs permission to manage channels and permission overwrites, plus
+`CREATE_EVENTS` in the configured guild and meeting voice channel.
+`CYCLE_AUTOMATION_SECRET` is optional;
+when omitted, signed 30-minute previews use `JWT_SECRET`.
 
 ## Getting started
 
@@ -195,6 +207,8 @@ The server exposes routes for:
 - `GET /content/rules` — Markdown rules currently published on the website.
 - `PUT /campaign/update-player-game-information` — update authenticated player's current campaign progress.
 - `POST /campaign/vote` and `POST /campaign/undo-vote` — campaign voting actions.
+- `GET /cycle/overview`, `POST /cycle/draw`, and `POST /cycle/start-election` — guarded cycle composition and election launch.
+- `POST /cycle/transition/preview` and `POST /cycle/transition/apply` — guarded, reviewed campaign and Discord transition.
 - `GET /auth/discord` — start Discord OAuth flow.
 - `GET /auth/discord/callback` — Discord OAuth callback.
 - CRUD-style routes under `/campaign`, `/games`, `/players`, `/pool`, and `/users`.

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2200,13 +2200,14 @@ a.meeting-callout:focus-visible {
 }
 
 .election-hearth__heading h2 {
-  margin: 7px 0 8px;
+  margin: 3px 0 8px;
   color: rgba(255, 255, 255, 0.94);
-  font-family: 'Mulish', sans-serif;
-  font-size: clamp(25px, 3vw, 36px);
-  font-weight: 850;
-  letter-spacing: -0.04em;
-  line-height: 1.08;
+  font-family: 'Cinzel Decorative', cursive;
+  font-size: clamp(28px, 3.4vw, 38px);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  text-shadow: 0 7px 16px rgba(0, 0, 0, 0.58);
 }
 
 .election-hearth__heading p {
@@ -2214,6 +2215,12 @@ a.meeting-callout:focus-visible {
   color: rgba(255, 255, 255, 0.55);
   font-size: 13px;
   line-height: 1.55;
+}
+
+.election-hearth__heading p strong {
+  margin-right: 0.25em;
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 750;
 }
 
 .election-hearth__receipt {
@@ -2233,8 +2240,9 @@ a.meeting-callout:focus-visible {
 .election-grid {
   position: relative;
   z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(165px, 100%), 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 15px;
   margin-top: 24px;
 }
@@ -2244,6 +2252,7 @@ a.meeting-callout:focus-visible {
   display: flex;
   min-width: 0;
   overflow: hidden;
+  flex: 0 1 calc((100% - 30px) / 3);
   flex-direction: column;
   background: rgba(12, 10, 15, 0.66);
   border: 1px solid rgba(255, 255, 255, 0.085);
@@ -2325,7 +2334,7 @@ a.meeting-callout:focus-visible {
 
 .election-card__art {
   position: relative;
-  min-height: 164px;
+  min-height: 190px;
   overflow: hidden;
   background-color: #0b0910;
   background-position: center;
@@ -2506,8 +2515,14 @@ a.meeting-callout:focus-visible {
     gap: 16px;
   }
 
-  .election-card__art {
-    min-height: 190px;
+  .election-card {
+    flex-basis: calc((100% - 15px) / 2);
+  }
+}
+
+@media (max-width: 480px) {
+  .election-card {
+    flex-basis: 100%;
   }
 }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -901,56 +901,6 @@ body.bonfire-inner-page .user-menu-popover {
   font-weight: 700;
 }
 
-.guaranteed-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 9px;
-}
-
-.guaranteed-game {
-  display: flex;
-  min-width: 0;
-  min-height: 76px;
-  align-items: stretch;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.075);
-  border-radius: 6px;
-  background: rgba(9, 8, 12, 0.35);
-}
-
-.guaranteed-game__art {
-  width: 92px;
-  flex: 0 0 auto;
-  background-position: center;
-  background-size: cover;
-}
-
-.guaranteed-game > div:last-child {
-  display: grid;
-  min-width: 0;
-  padding: 10px 12px;
-  align-content: center;
-}
-
-.guaranteed-game small {
-  color: rgba(242, 164, 92, 0.72);
-  font-size: 8px;
-  font-weight: 850;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.guaranteed-game h5 {
-  margin: 3px 0 2px;
-  overflow: hidden;
-  color: rgba(255, 255, 255, 0.88);
-  font-size: 13px;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.guaranteed-game span,
 .guaranteed-empty,
 .random-selection__empty,
 .mystery-draw p {
@@ -970,6 +920,7 @@ body.bonfire-inner-page .user-menu-popover {
   display: grid;
   justify-items: center;
   text-align: center;
+  margin-top: 30px;
 }
 
 .mystery-draw p {
@@ -1015,16 +966,30 @@ body.bonfire-inner-page .user-menu-popover {
   margin-top: 30px;
 }
 
-.random-selection .reveal-grid {
-  grid-template-columns: repeat(auto-fill, minmax(168px, 220px));
-  justify-content: start;
+.cycle-catalog-grid {
+  gap: 14px;
 }
 
-.reveal-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
-  gap: 14px;
-  margin: 32px 0 22px;
+.cycle-catalog-grid .backlog-card__art {
+  height: 145px;
+}
+
+.cycle-catalog-grid .backlog-card__footer {
+  min-height: 58px;
+  padding: 11px 12px;
+}
+
+.cycle-catalog-grid--reveal {
+  margin: 24px 0 20px;
+}
+
+.cycle-catalog-card {
+  min-width: 0;
+  animation: card-reveal 560ms cubic-bezier(0.2, 0.82, 0.25, 1) both;
+}
+
+.cycle-catalog-card .backlog-card {
+  height: 100%;
 }
 
 .reveal-card {
@@ -1040,57 +1005,8 @@ body.bonfire-inner-page .user-menu-popover {
   animation: card-reveal 560ms cubic-bezier(0.2, 0.82, 0.25, 1) both;
 }
 
-.reveal-card__art {
-  position: relative;
-  min-height: 118px;
-  background-position: center;
-  background-size: cover;
-}
-
-.reveal-card__art::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(transparent 28%, rgba(15, 11, 16, 0.92));
-}
-
-.reveal-card__art span {
-  position: absolute;
-  z-index: 1;
-  left: 11px;
-  bottom: 9px;
-  color: #ffbd78;
-  font-size: 9px;
-  font-weight: 900;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.reveal-card__body {
-  min-height: 118px;
-  padding: 14px;
-}
-
-.reveal-card__body small {
-  color: rgba(247, 222, 208, 0.32);
-}
-
-.reveal-card__body h4 {
-  margin: 6px 0 12px;
-  color: #fff4e9;
-  font-family: 'Mulish', sans-serif;
-  font-size: 16px;
-  font-weight: 820;
-  line-height: 1.25;
-}
-
-.reveal-card__body p {
-  color: rgba(247, 222, 208, 0.58);
-  font-size: 12px;
-}
-
 .reveal-card--hidden {
-  min-height: 237px;
+  min-height: 205px;
   display: grid;
   place-items: center;
   align-content: center;
@@ -1111,6 +1027,39 @@ body.bonfire-inner-page .user-menu-popover {
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.results-privacy {
+  display: flex;
+  margin-top: 28px;
+  padding: 26px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  border: 1px solid rgba(242, 164, 92, 0.18);
+  border-radius: 7px;
+  background:
+    radial-gradient(circle at 15% 0, rgba(159, 66, 39, 0.12), transparent 42%), rgba(9, 8, 12, 0.38);
+}
+
+.results-privacy h4 {
+  margin: 5px 0 7px;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: 'Mulish', sans-serif;
+  font-size: 20px;
+}
+
+.results-privacy p {
+  max-width: 590px;
+  margin: 0;
+  color: rgba(247, 222, 208, 0.5);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.results-revealed-actions {
+  justify-content: flex-end;
+  margin-top: 20px;
 }
 
 .election-launch {
@@ -1412,10 +1361,6 @@ body.bonfire-inner-page .user-menu-popover {
     grid-template-columns: 1fr;
   }
 
-  .random-selection .reveal-grid {
-    grid-template-columns: 1fr;
-  }
-
   .result-row {
     flex-wrap: wrap;
     gap: 10px;
@@ -1429,11 +1374,17 @@ body.bonfire-inner-page .user-menu-popover {
     align-items: flex-start;
     flex-direction: column;
   }
+
+  .results-privacy {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .cycle-status--active span,
-  .reveal-card {
+  .reveal-card,
+  .cycle-catalog-card {
     animation: none;
   }
 }

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2342,8 +2342,11 @@ a.meeting-callout:focus-visible {
   position: absolute;
   inset: 0;
   background:
+    repeating-linear-gradient(0deg, rgba(8, 7, 10, 0.1) 0 1px, transparent 1px 4px),
+    repeating-linear-gradient(90deg, rgba(8, 7, 10, 0.08) 0 1px, transparent 1px 4px),
     linear-gradient(180deg, rgba(4, 3, 6, 0.28), rgba(4, 3, 6, 0.15) 35%, rgba(7, 5, 9, 0.94)),
     radial-gradient(ellipse 72% 110px at 50% 0, rgba(238, 139, 82, 0.08), transparent 74%);
+  pointer-events: none;
 }
 
 .election-card__links {
@@ -2654,6 +2657,8 @@ a.meeting-callout:focus-visible {
   position: absolute;
   inset: 0;
   background:
+    repeating-linear-gradient(0deg, rgba(8, 7, 10, 0.1) 0 1px, transparent 1px 4px),
+    repeating-linear-gradient(90deg, rgba(8, 7, 10, 0.08) 0 1px, transparent 1px 4px),
     radial-gradient(ellipse at 50% 0, rgba(255, 194, 143, 0.18), transparent 52%),
     linear-gradient(
       180deg,
@@ -2662,6 +2667,7 @@ a.meeting-callout:focus-visible {
       rgba(8, 7, 10, 0.28) 62%,
       rgba(8, 7, 10, 0.92) 100%
     );
+  pointer-events: none;
 }
 
 .campaign-history-card__heading {
@@ -3089,8 +3095,11 @@ a.meeting-callout:focus-visible {
   position: absolute;
   inset: 0;
   background:
+    repeating-linear-gradient(0deg, rgba(8, 7, 10, 0.1) 0 1px, transparent 1px 4px),
+    repeating-linear-gradient(90deg, rgba(8, 7, 10, 0.08) 0 1px, transparent 1px 4px),
     linear-gradient(180deg, rgba(12, 10, 15, 0.12), transparent 42%),
     linear-gradient(0deg, rgba(9, 7, 11, 0.95), transparent 66%);
+  pointer-events: none;
 }
 
 .backlog-card__count {

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2152,167 +2152,273 @@ a.meeting-callout:focus-visible {
   }
 }
 
-@keyframes glow {
-  from {
-    box-shadow: 0 0 37px rgba(157, 45, 20, 0.54);
-  }
-  to {
-    box-shadow: 0 0 37px rgba(225, 145, 37, 0.46);
-  }
+.election-hearth {
+  position: relative;
+  margin: 0 0 76px;
+  padding: clamp(22px, 4vw, 38px);
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 13% 0, rgba(171, 72, 35, 0.16), transparent 34%),
+    linear-gradient(145deg, rgba(31, 22, 32, 0.98), rgba(13, 11, 17, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-top-color: rgba(222, 134, 81, 0.48);
+  border-radius: 8px;
+  box-shadow: 0 24px 54px rgba(0, 0, 0, 0.26);
 }
 
-.election-wrap {
-  h3 {
-    font-size: 18px;
-    text-align: center;
-    margin: 0 0 30px;
-    text-shadow:
-      0 5px 3px rgba(0, 0, 0, 0.7),
-      0 -1px 1px rgba(0, 0, 0, 0.7);
-  }
+.election-hearth::before {
+  position: absolute;
+  top: 0;
+  right: 16%;
+  left: 16%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(247, 176, 108, 0.48), transparent);
+  content: '';
 }
 
-.election {
+.election-hearth__heading {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  padding-bottom: 23px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.election-hearth__heading > div:first-child {
+  max-width: 670px;
+}
+
+.election-hearth__heading > div:first-child > span {
+  color: #d98b5a;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.election-hearth__heading h2 {
+  margin: 7px 0 8px;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Mulish', sans-serif;
+  font-size: clamp(25px, 3vw, 36px);
+  font-weight: 850;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+
+.election-hearth__heading p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.election-hearth__receipt {
+  display: inline-flex;
+  padding: 8px 11px;
+  align-items: center;
+  gap: 7px;
+  color: #e9b185;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  background: rgba(185, 93, 47, 0.09);
+  border: 1px solid rgba(224, 140, 84, 0.25);
+  border-radius: 5px;
+}
+
+.election-grid {
+  position: relative;
+  z-index: 1;
   display: grid;
-  grid-auto-flow: column;
-  gap: 30px;
-  justify-content: center;
-  margin: 0 0 100px;
-
-  .election-option {
-    background: #18131c;
-    border-radius: 5px;
-    border-top: 1px solid #b07663;
-    width: 200px;
-    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.2);
-    transition:
-      transform 0.3s,
-      margin 0.3s;
-
-    &&.--voted {
-      transform: scale(1.14);
-      margin: 10px 17px 0;
-      animation: glow 1s ease-in-out infinite alternate;
-    }
-
-    .election-option-cover {
-      height: 120px;
-      position: relative;
-      border-bottom: 1px solid #5b5264;
-
-      .election-option-cover-bg {
-        background-repeat: no-repeat;
-        background-color: black;
-        background-size: cover;
-        background-position: center;
-        height: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        opacity: 0.6;
-        z-index: 1;
-      }
-
-      .election-option-cover-content {
-        height: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        z-index: 2;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: 0 20px;
-
-        &&.--top {
-          align-items: flex-end;
-          justify-content: right;
-          padding: 14px 20px 0 0;
-
-          a {
-            color: #b6b6b6;
-            transition: color 0.5s;
-
-            &:hover {
-              color: var(--color-accent-two);
-            }
-          }
-        }
-
-        h4 {
-          text-transform: uppercase;
-          color: white;
-          text-align: center;
-          font-size: 22px;
-          margin: 0;
-          font-weight: 400;
-          text-shadow: 0 3px 2px rgba(0, 0, 0, 0.8);
-        }
-
-        @media (max-width: 900px) {
-          p {
-            font-size: 18px;
-          }
-
-          h2 {
-            font-size: 32px;
-          }
-        }
-
-        @media (max-width: 480px) {
-          p {
-            font-size: 14px;
-          }
-
-          h2 {
-            font-size: 28px;
-          }
-        }
-      }
-
-      @media (max-width: 768px) {
-        height: 280px;
-      }
-
-      @media (max-width: 480px) {
-        height: 200px;
-      }
-    }
-
-    .election-option-content {
-      padding: 20px;
-      word-wrap: break-word;
-
-      h4 {
-        font-size: 22px;
-      }
-
-      .n-space {
-        margin: 10px 0;
-      }
-
-      a {
-        color: #b6b6b6;
-        transition: color 0.5s;
-
-        &:hover {
-          color: var(--color-accent-two);
-        }
-      }
-    }
-  }
+  grid-template-columns: repeat(auto-fit, minmax(min(205px, 100%), 1fr));
+  gap: 15px;
+  margin-top: 24px;
 }
 
-.election:has(.election-option.--voted) .election-option {
-  .undo-vote-action {
-    display: block;
+.election-card {
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+  flex-direction: column;
+  background: rgba(12, 10, 15, 0.66);
+  border: 1px solid rgba(255, 255, 255, 0.085);
+  border-radius: 6px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.election-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(222, 146, 91, 0.28);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.22);
+}
+
+.election-card--selected {
+  border-color: rgba(226, 139, 81, 0.52);
+  box-shadow:
+    0 14px 30px rgba(0, 0, 0, 0.24),
+    inset 0 0 0 1px rgba(226, 139, 81, 0.1);
+}
+
+.election-card__art {
+  position: relative;
+  min-height: 164px;
+  overflow: hidden;
+  background-color: #0b0910;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.election-card__shade {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(4, 3, 6, 0.28), rgba(4, 3, 6, 0.15) 35%, rgba(7, 5, 9, 0.94)),
+    linear-gradient(90deg, rgba(6, 4, 8, 0.22), transparent 55%);
+}
+
+.election-card__links {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 5px;
+}
+
+.election-card__links a {
+  display: inline-flex;
+  width: 31px;
+  height: 31px;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(8, 6, 10, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 5px;
+  backdrop-filter: blur(8px);
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.election-card__links a:hover,
+.election-card__links a:focus-visible {
+  color: #f4b184;
+  background: rgba(42, 24, 22, 0.9);
+  border-color: rgba(242, 164, 92, 0.38);
+}
+
+.election-card__selected-badge {
+  position: absolute;
+  top: 11px;
+  left: 11px;
+  display: inline-flex;
+  padding: 6px 8px;
+  align-items: center;
+  gap: 5px;
+  color: #f2bb8d;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  background: rgba(39, 20, 19, 0.86);
+  border: 1px solid rgba(235, 151, 91, 0.35);
+  border-radius: 4px;
+  backdrop-filter: blur(8px);
+}
+
+.election-card__title {
+  position: absolute;
+  right: 17px;
+  bottom: 15px;
+  left: 17px;
+}
+
+.election-card__title small {
+  display: block;
+  margin-bottom: 3px;
+  color: rgba(241, 177, 128, 0.82);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.election-card__title h3 {
+  margin: 0;
+  color: #fff;
+  font-family: 'Mulish', sans-serif;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+  text-shadow: 0 2px 9px rgba(0, 0, 0, 0.9);
+}
+
+.election-card__body {
+  display: flex;
+  min-height: 150px;
+  padding: 16px 17px 17px;
+  flex: 1;
+  flex-direction: column;
+}
+
+.election-card__body > p {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 12px;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.election-card__body footer {
+  display: flex;
+  margin-top: auto;
+  padding-top: 17px;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.election-card__body footer > small,
+.election-card__quiet-state {
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.election-card__quiet-state {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+}
+
+@media (max-width: 680px) {
+  .election-hearth {
+    margin-bottom: 52px;
   }
 
-  .vote-action {
-    display: none;
+  .election-hearth__heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .election-card__art {
+    min-height: 190px;
   }
 }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2949,7 +2949,8 @@ a.meeting-callout:focus-visible {
   margin-top: 66px;
 }
 
-.backlog-shelf--next-vote {
+.backlog-shelf--next-vote,
+.backlog-shelf--current-vote {
   position: relative;
   padding: 27px;
   background:
@@ -2958,6 +2959,13 @@ a.meeting-callout:focus-visible {
   border: 1px solid rgba(242, 164, 92, 0.14);
   border-radius: 9px;
   box-shadow: 0 16px 36px rgba(0, 0, 0, 0.16);
+}
+
+.backlog-shelf--current-vote {
+  background:
+    radial-gradient(ellipse 68% 190px at 50% 0, rgba(202, 75, 38, 0.14), transparent 76%),
+    rgba(16, 13, 19, 0.58);
+  border-color: rgba(242, 130, 72, 0.2);
 }
 
 .backlog-shelf__heading {
@@ -3018,6 +3026,14 @@ a.meeting-callout:focus-visible {
   box-shadow:
     0 15px 30px rgba(0, 0, 0, 0.24),
     inset 0 1px rgba(255, 224, 194, 0.035);
+}
+
+.backlog-card--current-vote {
+  border-top-color: rgba(235, 116, 62, 0.48);
+  box-shadow:
+    0 -8px 24px rgba(184, 64, 31, 0.08),
+    0 15px 30px rgba(0, 0, 0, 0.24),
+    inset 0 1px rgba(255, 224, 194, 0.04);
 }
 
 .next-vote-fill-card {
@@ -3104,7 +3120,11 @@ a.meeting-callout:focus-visible {
   left: auto;
 }
 
-.backlog-card__next-vote {
+.backlog-card__count--with-menu {
+  right: 51px;
+}
+
+.backlog-card__vote-state {
   position: absolute;
   top: 12px;
   left: 12px;
@@ -3124,6 +3144,84 @@ a.meeting-callout:focus-visible {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.28);
   text-transform: uppercase;
   backdrop-filter: blur(6px);
+}
+
+.backlog-card__vote-state--current {
+  color: #ef9b68;
+  background: rgba(35, 14, 13, 0.88);
+  border-color: rgba(239, 125, 68, 0.34);
+}
+
+.backlog-card__menu {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 3;
+}
+
+.backlog-card__menu summary {
+  display: inline-flex;
+  width: 31px;
+  height: 29px;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.58);
+  background: rgba(9, 7, 11, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 5px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.28);
+  cursor: pointer;
+  list-style: none;
+  backdrop-filter: blur(6px);
+}
+
+.backlog-card__menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.backlog-card__menu summary:hover,
+.backlog-card__menu summary:focus-visible,
+.backlog-card__menu[open] summary {
+  color: #f4b184;
+  border-color: rgba(242, 164, 92, 0.34);
+  outline: none;
+}
+
+.backlog-card__menu > button {
+  position: absolute;
+  top: 35px;
+  right: 0;
+  display: inline-flex;
+  min-width: 148px;
+  min-height: 34px;
+  padding: 8px 10px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
+  color: #dfa08e;
+  font:
+    650 10px 'Mulish',
+    sans-serif;
+  white-space: nowrap;
+  background: rgba(24, 16, 20, 0.98);
+  border: 1px solid rgba(207, 104, 76, 0.24);
+  border-radius: 5px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.42);
+  cursor: pointer;
+}
+
+.backlog-card__menu > button:hover,
+.backlog-card__menu > button:focus-visible {
+  color: #f1b09d;
+  background: rgba(48, 25, 27, 0.98);
+  border-color: rgba(207, 104, 76, 0.4);
+  outline: none;
+}
+
+.backlog-card__menu > button:disabled,
+.backlog-card__menu summary[aria-disabled='true'] {
+  cursor: wait;
+  opacity: 0.64;
 }
 
 .backlog-card__title {
@@ -3578,7 +3676,8 @@ a.meeting-callout:focus-visible {
     font-size: 42px;
   }
 
-  .backlog-shelf--next-vote {
+  .backlog-shelf--next-vote,
+  .backlog-shelf--current-vote {
     padding: 21px;
   }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -872,6 +872,154 @@ body.bonfire-inner-page .user-menu-popover {
   align-content: center;
 }
 
+.guaranteed-selection {
+  margin-top: 28px;
+}
+
+.guaranteed-selection > header,
+.random-selection > header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
+}
+
+.guaranteed-selection h4,
+.mystery-draw h4 {
+  margin: 5px 0 0;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: 'Mulish', sans-serif;
+  font-size: 18px;
+  font-weight: 820;
+}
+
+.guaranteed-selection > header > strong,
+.random-selection > header > strong {
+  color: rgba(247, 222, 208, 0.42);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.guaranteed-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 9px;
+}
+
+.guaranteed-game {
+  display: flex;
+  min-width: 0;
+  min-height: 76px;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 6px;
+  background: rgba(9, 8, 12, 0.35);
+}
+
+.guaranteed-game__art {
+  width: 92px;
+  flex: 0 0 auto;
+  background-position: center;
+  background-size: cover;
+}
+
+.guaranteed-game > div:last-child {
+  display: grid;
+  min-width: 0;
+  padding: 10px 12px;
+  align-content: center;
+}
+
+.guaranteed-game small {
+  color: rgba(242, 164, 92, 0.72);
+  font-size: 8px;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.guaranteed-game h5 {
+  margin: 3px 0 2px;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 13px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.guaranteed-game span,
+.guaranteed-empty,
+.random-selection__empty,
+.mystery-draw p {
+  color: rgba(247, 222, 208, 0.46);
+  font-size: 11px;
+}
+
+.guaranteed-empty,
+.random-selection__empty {
+  margin: 25px 0 0;
+  padding: 14px 16px;
+  border: 1px dashed rgba(247, 222, 208, 0.12);
+  border-radius: 6px;
+}
+
+.mystery-draw {
+  display: grid;
+  justify-items: center;
+  text-align: center;
+}
+
+.mystery-draw p {
+  max-width: 430px;
+  margin: 8px 0 17px;
+  line-height: 1.55;
+}
+
+.mystery-stack {
+  position: relative;
+  width: 92px;
+  height: 63px;
+  margin-bottom: 20px;
+}
+
+.mystery-stack span {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: rgba(247, 181, 116, 0.82);
+  border: 1px solid rgba(242, 164, 92, 0.3);
+  border-radius: 6px;
+  background: linear-gradient(145deg, rgba(90, 38, 34, 0.92), rgba(22, 16, 23, 0.98));
+  box-shadow: 0 9px 20px rgba(0, 0, 0, 0.24);
+  font-family: 'Cinzel', serif;
+  font-size: 24px;
+}
+
+.mystery-stack span:first-child {
+  transform: translateX(-15px) rotate(-9deg);
+}
+
+.mystery-stack span:nth-child(2) {
+  transform: translateX(15px) rotate(9deg);
+}
+
+.mystery-stack span:last-child {
+  transform: translateY(-3px);
+}
+
+.random-selection {
+  margin-top: 30px;
+}
+
+.random-selection .reveal-grid {
+  grid-template-columns: repeat(auto-fill, minmax(168px, 220px));
+  justify-content: start;
+}
+
 .reveal-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
@@ -1264,6 +1412,10 @@ body.bonfire-inner-page .user-menu-popover {
     grid-template-columns: 1fr;
   }
 
+  .random-selection .reveal-grid {
+    grid-template-columns: 1fr;
+  }
+
   .result-row {
     flex-wrap: wrap;
     gap: 10px;
@@ -1477,7 +1629,8 @@ a.meeting-callout:focus-visible {
   gap: 8px;
 }
 
-.game-links a {
+.game-links a,
+.game-links button {
   display: inline-flex;
   min-height: 34px;
   padding: 7px 11px;
@@ -1496,11 +1649,25 @@ a.meeting-callout:focus-visible {
     background 180ms ease;
 }
 
+.game-links button {
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+
 .game-links a:hover,
-.game-links a:focus-visible {
+.game-links a:focus-visible,
+.game-links button:hover:not(:disabled),
+.game-links button:focus-visible {
   color: #f4b184;
   background: rgba(242, 164, 92, 0.055);
   border-color: rgba(242, 164, 92, 0.34);
+}
+
+.game-links button:disabled {
+  cursor: wait;
+  opacity: 0.5;
 }
 
 .hearth-community {

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -866,108 +866,10 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 .draw-hearth {
-  min-height: 300px;
+  min-height: 190px;
   display: grid;
   place-items: center;
   align-content: center;
-  gap: 26px;
-}
-
-.draw-hearth__flame {
-  position: relative;
-  width: 72px;
-  height: 72px;
-  border: 1px solid rgba(255, 194, 124, 0.34);
-  border-radius: 50%;
-  background: radial-gradient(circle, #ffd089 0 8%, #e97442 22%, #7d302c 48%, transparent 70%);
-  box-shadow: 0 0 58px rgba(219, 93, 48, 0.28);
-  animation: flame-breathe 2.2s ease-in-out infinite;
-}
-
-.draw-hearth__flame::before,
-.draw-hearth__flame::after {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 54px;
-  height: 5px;
-  border-radius: 999px;
-  background: #492729;
-  box-shadow: inset 0 1px rgba(255, 190, 132, 0.18);
-  content: '';
-}
-
-.draw-hearth__flame::before {
-  transform: translate(-50%, -50%) rotate(32deg);
-}
-
-.draw-hearth__flame::after {
-  transform: translate(-50%, -50%) rotate(-32deg);
-}
-
-.cycle-primary,
-.cycle-secondary,
-.cycle-quiet,
-.cycle-danger,
-.duration-presets button {
-  border: 0;
-  border-radius: 5px;
-  font: inherit;
-  font-weight: 800;
-  cursor: pointer;
-  transition:
-    transform 160ms ease,
-    background 160ms ease,
-    opacity 160ms ease;
-}
-
-.cycle-primary {
-  padding: 13px 20px;
-  color: #271414;
-  background: linear-gradient(135deg, #f5b879, #df7041);
-  box-shadow: 0 10px 30px rgba(211, 87, 44, 0.2);
-}
-
-.cycle-primary--wide {
-  width: 100%;
-  padding: 16px 22px;
-}
-
-.cycle-secondary,
-.duration-presets button {
-  padding: 10px 14px;
-  color: #f5c69d;
-  border: 1px solid rgba(242, 164, 92, 0.32);
-  background: rgba(111, 49, 39, 0.16);
-}
-
-.cycle-quiet {
-  padding: 10px;
-  color: rgba(247, 222, 208, 0.55);
-  background: transparent;
-}
-
-.cycle-danger {
-  padding: 10px 14px;
-  color: #ffd5ca;
-  border: 1px solid rgba(225, 100, 78, 0.38);
-  background: rgba(129, 39, 37, 0.28);
-}
-
-.cycle-primary:hover:not(:disabled),
-.cycle-secondary:hover:not(:disabled),
-.cycle-quiet:hover:not(:disabled),
-.cycle-danger:hover:not(:disabled),
-.duration-presets button:hover {
-  transform: translateY(-2px);
-}
-
-.cycle-primary:disabled,
-.cycle-secondary:disabled,
-.cycle-quiet:disabled,
-.cycle-danger:disabled {
-  cursor: wait;
-  opacity: 0.55;
 }
 
 .reveal-grid {
@@ -1183,6 +1085,11 @@ body.bonfire-inner-page .user-menu-popover {
   gap: 16px;
 }
 
+.transition-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .cycle-check {
   display: flex;
   align-items: flex-start;
@@ -1324,13 +1231,6 @@ body.bonfire-inner-page .user-menu-popover {
   }
 }
 
-@keyframes flame-breathe {
-  50% {
-    transform: scale(1.06);
-    box-shadow: 0 0 68px rgba(239, 116, 63, 0.38);
-  }
-}
-
 @keyframes cycle-pulse {
   50% {
     opacity: 0.65;
@@ -1380,7 +1280,6 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .draw-hearth__flame,
   .cycle-status--active span,
   .reveal-card {
     animation: none;

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2158,8 +2158,8 @@ a.meeting-callout:focus-visible {
   padding: clamp(22px, 4vw, 38px);
   overflow: hidden;
   background:
-    radial-gradient(circle at 13% 0, rgba(171, 72, 35, 0.16), transparent 34%),
-    linear-gradient(145deg, rgba(31, 22, 32, 0.98), rgba(13, 11, 17, 0.98));
+    radial-gradient(ellipse 68% 210px at 50% -22px, rgba(186, 79, 43, 0.17), transparent 72%),
+    linear-gradient(180deg, rgba(31, 22, 32, 0.98), rgba(13, 11, 17, 0.98));
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-top-color: rgba(222, 134, 81, 0.48);
   border-radius: 8px;
@@ -2240,6 +2240,7 @@ a.meeting-callout:focus-visible {
 }
 
 .election-card {
+  position: relative;
   display: flex;
   min-width: 0;
   overflow: hidden;
@@ -2250,21 +2251,48 @@ a.meeting-callout:focus-visible {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
   transition:
     border-color 180ms ease,
-    transform 180ms ease,
     box-shadow 180ms ease;
 }
 
 .election-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(222, 146, 91, 0.28);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.22);
+  border-color: rgba(234, 165, 112, 0.48);
 }
 
 .election-card--selected {
-  border-color: rgba(226, 139, 81, 0.52);
+  border-color: rgba(245, 157, 91, 0.84);
+  background:
+    radial-gradient(ellipse 86% 150px at 50% 0, rgba(196, 71, 30, 0.18), transparent 76%),
+    rgba(12, 10, 15, 0.76);
+  animation: election-card-aflame 2.2s ease-in-out infinite alternate;
+}
+
+.election-card--selected::after {
+  position: absolute;
+  z-index: 3;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 154, 80, 0.1), transparent 42%);
   box-shadow:
-    0 14px 30px rgba(0, 0, 0, 0.24),
-    inset 0 0 0 1px rgba(226, 139, 81, 0.1);
+    inset 0 1px rgba(255, 219, 174, 0.32),
+    inset 0 0 20px rgba(218, 81, 34, 0.07);
+  content: '';
+}
+
+@keyframes election-card-aflame {
+  from {
+    box-shadow:
+      0 12px 28px rgba(0, 0, 0, 0.24),
+      0 0 13px rgba(206, 72, 29, 0.24),
+      inset 0 0 0 1px rgba(235, 127, 67, 0.13);
+  }
+
+  to {
+    box-shadow:
+      0 14px 32px rgba(0, 0, 0, 0.27),
+      0 0 27px rgba(240, 111, 49, 0.43),
+      0 -5px 18px rgba(247, 153, 82, 0.2),
+      inset 0 0 0 1px rgba(255, 191, 132, 0.23);
+  }
 }
 
 .election-card__art {
@@ -2283,7 +2311,7 @@ a.meeting-callout:focus-visible {
   inset: 0;
   background:
     linear-gradient(180deg, rgba(4, 3, 6, 0.28), rgba(4, 3, 6, 0.15) 35%, rgba(7, 5, 9, 0.94)),
-    linear-gradient(90deg, rgba(6, 4, 8, 0.22), transparent 55%);
+    radial-gradient(ellipse 72% 110px at 50% 0, rgba(238, 139, 82, 0.08), transparent 74%);
 }
 
 .election-card__links {
@@ -2384,6 +2412,30 @@ a.meeting-callout:focus-visible {
   -webkit-line-clamp: 3;
 }
 
+.election-card__recommenders {
+  display: flex;
+  min-width: 0;
+  margin-top: 14px;
+  align-items: center;
+  gap: 8px;
+}
+
+.election-card__recommenders .backlog-card__recommenders {
+  margin-left: 0;
+}
+
+.election-card__recommenders > span {
+  display: -webkit-box;
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.46);
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .election-card__body footer {
   display: flex;
   margin-top: auto;
@@ -2419,6 +2471,16 @@ a.meeting-callout:focus-visible {
 
   .election-card__art {
     min-height: 190px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .election-card--selected {
+    animation: none;
+    box-shadow:
+      0 14px 30px rgba(0, 0, 0, 0.24),
+      0 0 20px rgba(231, 101, 44, 0.34),
+      inset 0 0 0 1px rgba(255, 191, 132, 0.2);
   }
 }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2234,7 +2234,7 @@ a.meeting-callout:focus-visible {
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(205px, 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(165px, 100%), 1fr));
   gap: 15px;
   margin-top: 24px;
 }
@@ -2263,7 +2263,42 @@ a.meeting-callout:focus-visible {
   background:
     radial-gradient(ellipse 86% 150px at 50% 0, rgba(196, 71, 30, 0.18), transparent 76%),
     rgba(12, 10, 15, 0.76);
-  animation: election-card-aflame 2.2s ease-in-out infinite alternate;
+  box-shadow:
+    0 14px 30px rgba(0, 0, 0, 0.26),
+    0 0 22px rgba(226, 93, 39, 0.34),
+    0 -4px 17px rgba(247, 153, 82, 0.16),
+    inset 0 0 0 1px rgba(255, 191, 132, 0.2);
+}
+
+.election-card--selected::before {
+  position: absolute;
+  top: -12px;
+  right: -18px;
+  left: -18px;
+  z-index: 4;
+  height: 48px;
+  pointer-events: none;
+  background:
+    radial-gradient(
+        ellipse 20px 34px at 20px 100%,
+        rgba(255, 215, 148, 0.76) 0 10%,
+        rgba(242, 119, 48, 0.54) 34%,
+        transparent 72%
+      )
+      0 0 / 54px 43px repeat-x,
+    radial-gradient(
+        ellipse 16px 27px at 16px 100%,
+        rgba(255, 164, 79, 0.54) 0 18%,
+        rgba(199, 63, 25, 0.3) 45%,
+        transparent 75%
+      )
+      26px 8px / 68px 36px repeat-x;
+  mix-blend-mode: screen;
+  filter: blur(3px);
+  opacity: 0.72;
+  transform-origin: 50% 100%;
+  animation: election-flame-drift 3.6s ease-in-out infinite alternate;
+  content: '';
 }
 
 .election-card--selected::after {
@@ -2278,20 +2313,13 @@ a.meeting-callout:focus-visible {
   content: '';
 }
 
-@keyframes election-card-aflame {
+@keyframes election-flame-drift {
   from {
-    box-shadow:
-      0 12px 28px rgba(0, 0, 0, 0.24),
-      0 0 13px rgba(206, 72, 29, 0.24),
-      inset 0 0 0 1px rgba(235, 127, 67, 0.13);
+    transform: translate3d(-7px, 2px, 0) scaleY(0.94) skewX(-2deg);
   }
 
   to {
-    box-shadow:
-      0 14px 32px rgba(0, 0, 0, 0.27),
-      0 0 27px rgba(240, 111, 49, 0.43),
-      0 -5px 18px rgba(247, 153, 82, 0.2),
-      inset 0 0 0 1px rgba(255, 191, 132, 0.23);
+    transform: translate3d(7px, -2px, 0) scaleY(1.06) skewX(2deg);
   }
 }
 
@@ -2475,12 +2503,8 @@ a.meeting-callout:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .election-card--selected {
+  .election-card--selected::before {
     animation: none;
-    box-shadow:
-      0 14px 30px rgba(0, 0, 0, 0.24),
-      0 0 20px rgba(231, 101, 44, 0.34),
-      inset 0 0 0 1px rgba(255, 191, 132, 0.2);
   }
 }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -1529,8 +1529,11 @@ a.meeting-callout:focus-visible {
   position: absolute;
   inset: 0;
   background:
+    repeating-linear-gradient(0deg, rgba(8, 7, 10, 0.1) 0 1px, transparent 1px 4px),
+    repeating-linear-gradient(90deg, rgba(8, 7, 10, 0.08) 0 1px, transparent 1px 4px),
     radial-gradient(ellipse at 50% 0%, rgba(235, 137, 79, 0.18), transparent 48%),
     linear-gradient(180deg, rgba(10, 8, 13, 0.06), transparent 34%, rgba(10, 8, 13, 0.14));
+  pointer-events: none;
 }
 
 .game-spotlight__shade {
@@ -2158,7 +2161,6 @@ a.meeting-callout:focus-visible {
 .election-hearth {
   position: relative;
   margin: 0 0 76px;
-  padding: clamp(22px, 4vw, 38px);
   overflow: hidden;
   background:
     radial-gradient(ellipse 68% 210px at 50% -22px, rgba(186, 79, 43, 0.17), transparent 72%),
@@ -2183,30 +2185,27 @@ a.meeting-callout:focus-visible {
   position: relative;
   z-index: 1;
   display: flex;
-  padding-bottom: 23px;
+  padding: 21px 24px 18px;
   align-items: center;
   justify-content: space-between;
-  gap: 28px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.election-hearth__heading > div:first-child {
-  max-width: 670px;
+  gap: 30px;
 }
 
 .election-hearth__heading > div:first-child > span {
-  color: #d98b5a;
+  display: block;
+  margin: 0 0 3px;
+  color: rgba(242, 164, 92, 0.74);
   font-size: 10px;
   font-weight: 800;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
 }
 
 .election-hearth__heading h2 {
-  margin: 3px 0 0;
+  margin: 0;
   color: rgba(255, 255, 255, 0.94);
   font-family: 'Cinzel Decorative', cursive;
-  font-size: clamp(28px, 3.4vw, 38px);
+  font-size: clamp(22px, 3vw, 30px);
   font-weight: 600;
   letter-spacing: 0.04em;
   line-height: 1.1;
@@ -2240,7 +2239,7 @@ a.meeting-callout:focus-visible {
   flex-wrap: wrap;
   justify-content: center;
   gap: 15px;
-  margin-top: 24px;
+  margin: 0 24px 24px;
 }
 
 .election-card {
@@ -2488,14 +2487,15 @@ a.meeting-callout:focus-visible {
 }
 
 @media (max-width: 680px) {
-  .election-hearth {
-    margin-bottom: 52px;
-  }
-
   .election-hearth__heading {
+    padding: 18px;
     align-items: flex-start;
     flex-direction: column;
-    gap: 16px;
+    gap: 12px;
+  }
+
+  .election-grid {
+    margin: 0 18px 18px;
   }
 
   .election-card {
@@ -2503,6 +2503,7 @@ a.meeting-callout:focus-visible {
   }
 
   .election-hearth__receipt {
+    width: 100%;
     white-space: normal;
   }
 }

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -3122,6 +3122,7 @@ a.meeting-callout:focus-visible {
 
 .backlog-card__count--with-menu {
   right: 51px;
+  left: auto;
 }
 
 .backlog-card__vote-state {

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -1404,7 +1404,6 @@ main {
     linear-gradient(155deg, rgba(29, 21, 29, 0.985), rgba(17, 14, 21, 0.99));
   border: 1px solid rgba(255, 255, 255, 0.065);
   border-top-color: rgba(238, 160, 105, 0.5);
-  border-bottom-color: rgba(0, 0, 0, 0.78);
   border-radius: 9px;
   box-shadow:
     0 -14px 38px rgba(174, 65, 32, 0.07),
@@ -1950,6 +1949,10 @@ a.meeting-callout:focus-visible {
   .journey-control button + button {
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.055);
   }
+
+  .hearth-community__header span {
+    display: none;
+  }
 }
 
 .main-block {
@@ -2181,7 +2184,7 @@ a.meeting-callout:focus-visible {
   z-index: 1;
   display: flex;
   padding-bottom: 23px;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 28px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.07);
@@ -2200,7 +2203,7 @@ a.meeting-callout:focus-visible {
 }
 
 .election-hearth__heading h2 {
-  margin: 3px 0 8px;
+  margin: 3px 0 0;
   color: rgba(255, 255, 255, 0.94);
   font-family: 'Cinzel Decorative', cursive;
   font-size: clamp(28px, 3.4vw, 38px);
@@ -2208,19 +2211,6 @@ a.meeting-callout:focus-visible {
   letter-spacing: 0.04em;
   line-height: 1.1;
   text-shadow: 0 7px 16px rgba(0, 0, 0, 0.58);
-}
-
-.election-hearth__heading p {
-  margin: 0;
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 13px;
-  line-height: 1.55;
-}
-
-.election-hearth__heading p strong {
-  margin-right: 0.25em;
-  color: rgba(255, 255, 255, 0.8);
-  font-weight: 750;
 }
 
 .election-hearth__receipt {
@@ -2235,6 +2225,12 @@ a.meeting-callout:focus-visible {
   background: rgba(185, 93, 47, 0.09);
   border: 1px solid rgba(224, 140, 84, 0.25);
   border-radius: 5px;
+}
+
+.election-hearth__receipt--locked {
+  color: rgba(255, 255, 255, 0.52);
+  background: rgba(9, 7, 11, 0.2);
+  border-color: rgba(255, 255, 255, 0.11);
 }
 
 .election-grid {
@@ -2491,19 +2487,6 @@ a.meeting-callout:focus-visible {
   gap: 7px;
 }
 
-.election-card__body footer > small,
-.election-card__quiet-state {
-  color: rgba(255, 255, 255, 0.38);
-  font-size: 10px;
-  line-height: 1.4;
-}
-
-.election-card__quiet-state {
-  display: inline-flex;
-  min-height: 34px;
-  align-items: center;
-}
-
 @media (max-width: 680px) {
   .election-hearth {
     margin-bottom: 52px;
@@ -2517,6 +2500,10 @@ a.meeting-callout:focus-visible {
 
   .election-card {
     flex-basis: calc((100% - 15px) / 2);
+  }
+
+  .election-hearth__receipt {
+    white-space: normal;
   }
 }
 

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -2346,8 +2346,13 @@ a.meeting-callout:focus-visible {
   position: absolute;
   top: 10px;
   right: 10px;
+  z-index: 6;
   display: flex;
   gap: 5px;
+}
+
+.election-card--selected .election-card__links {
+  top: 42px;
 }
 
 .election-card__links a {
@@ -2374,22 +2379,26 @@ a.meeting-callout:focus-visible {
   border-color: rgba(242, 164, 92, 0.38);
 }
 
-.election-card__selected-badge {
+.election-card__selected-bar {
   position: absolute;
-  top: 11px;
-  left: 11px;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 6;
   display: inline-flex;
-  padding: 6px 8px;
+  min-height: 31px;
+  padding: 6px 10px;
   align-items: center;
+  justify-content: center;
   gap: 5px;
   color: #f2bb8d;
   font-size: 10px;
   font-weight: 800;
-  letter-spacing: 0.03em;
-  background: rgba(39, 20, 19, 0.86);
-  border: 1px solid rgba(235, 151, 91, 0.35);
-  border-radius: 4px;
-  backdrop-filter: blur(8px);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: rgba(40, 20, 18, 0.9);
+  border-bottom: 1px solid rgba(235, 151, 91, 0.38);
+  backdrop-filter: blur(10px);
 }
 
 .election-card__title {

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -671,6 +671,602 @@ body.bonfire-inner-page .user-menu-popover {
   }
 }
 
+/* Cycle conductor */
+.cycle-conductor {
+  width: min(1120px, calc(100% - 36px));
+  margin: 0 auto 120px;
+  color: #f7ded0;
+}
+
+.cycle-loading {
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  color: rgba(247, 222, 208, 0.72);
+}
+
+.cycle-hero,
+.cycle-panel__heading,
+.draw-actions,
+.election-launch,
+.result-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.cycle-hero {
+  padding: 34px 38px;
+  border: 1px solid rgba(242, 164, 92, 0.22);
+  background:
+    radial-gradient(circle at 82% 10%, rgba(217, 91, 49, 0.15), transparent 34%),
+    rgba(20, 15, 22, 0.8);
+  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.26);
+}
+
+.cycle-hero h2,
+.cycle-panel h3 {
+  margin: 5px 0 8px;
+  font-family: 'Cinzel', serif;
+  color: #fff4e9;
+}
+
+.cycle-hero h2 {
+  font-size: clamp(28px, 4vw, 46px);
+}
+
+.cycle-hero p,
+.cycle-panel__copy,
+.election-launch p {
+  max-width: 680px;
+  color: rgba(247, 222, 208, 0.7);
+}
+
+.cycle-eyebrow {
+  color: #f2a45c;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.cycle-status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 13px;
+  border: 1px solid rgba(247, 222, 208, 0.14);
+  border-radius: 999px;
+  color: rgba(247, 222, 208, 0.75);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.cycle-status span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #7e6970;
+}
+
+.cycle-status--active span {
+  background: #ff9b4b;
+  box-shadow: 0 0 15px #ff7138;
+  animation: cycle-pulse 2s ease-in-out infinite;
+}
+
+.cycle-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 22px 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid rgba(247, 222, 208, 0.1);
+  background: rgba(11, 9, 14, 0.45);
+}
+
+.cycle-steps li {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 13px;
+  color: rgba(247, 222, 208, 0.44);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cycle-steps li + li {
+  border-left: 1px solid rgba(247, 222, 208, 0.1);
+}
+
+.cycle-steps li.active {
+  color: #ffbd78;
+  background: rgba(168, 71, 39, 0.1);
+}
+
+.cycle-steps span {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 10px;
+}
+
+.cycle-panel {
+  padding: clamp(24px, 4vw, 46px);
+  border: 1px solid rgba(242, 164, 92, 0.18);
+  background: linear-gradient(145deg, rgba(31, 21, 27, 0.96), rgba(15, 12, 18, 0.98));
+  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.34);
+}
+
+.cycle-panel__heading {
+  align-items: flex-end;
+  border-bottom: 1px solid rgba(247, 222, 208, 0.1);
+  padding-bottom: 19px;
+}
+
+.cycle-panel__heading h3 {
+  font-size: clamp(23px, 3vw, 34px);
+}
+
+.cycle-panel__heading > strong {
+  padding-bottom: 8px;
+  color: rgba(247, 222, 208, 0.58);
+  font-size: 12px;
+}
+
+.cycle-panel__copy {
+  margin-top: 22px;
+}
+
+.draw-hearth {
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 26px;
+}
+
+.draw-hearth__flame {
+  width: 86px;
+  height: 104px;
+  border-radius: 58% 42% 54% 46% / 67% 44% 56% 33%;
+  background: radial-gradient(circle at 50% 72%, #ffd089 0 18%, #ef743f 40%, #8c342f 72%);
+  filter: drop-shadow(0 0 30px rgba(239, 116, 63, 0.48));
+  transform: rotate(4deg);
+  animation: flame-breathe 2.2s ease-in-out infinite;
+}
+
+.cycle-primary,
+.cycle-secondary,
+.cycle-quiet,
+.duration-presets button {
+  border: 0;
+  border-radius: 3px;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    background 160ms ease,
+    opacity 160ms ease;
+}
+
+.cycle-primary {
+  padding: 13px 20px;
+  color: #271414;
+  background: linear-gradient(135deg, #ffc27c, #e97442);
+  box-shadow: 0 10px 30px rgba(211, 87, 44, 0.2);
+}
+
+.cycle-primary--wide {
+  width: 100%;
+  padding: 16px 22px;
+}
+
+.cycle-secondary,
+.duration-presets button {
+  padding: 10px 14px;
+  color: #f5c69d;
+  border: 1px solid rgba(242, 164, 92, 0.32);
+  background: rgba(111, 49, 39, 0.16);
+}
+
+.cycle-quiet {
+  padding: 10px;
+  color: rgba(247, 222, 208, 0.55);
+  background: transparent;
+}
+
+.cycle-primary:hover:not(:disabled),
+.cycle-secondary:hover:not(:disabled),
+.cycle-quiet:hover:not(:disabled),
+.duration-presets button:hover {
+  transform: translateY(-2px);
+}
+
+.cycle-primary:disabled,
+.cycle-secondary:disabled,
+.cycle-quiet:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.reveal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+  gap: 14px;
+  margin: 32px 0 22px;
+}
+
+.reveal-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(247, 222, 208, 0.13);
+  border-radius: 4px;
+  background: #171218;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.26);
+  animation: card-reveal 560ms cubic-bezier(0.2, 0.82, 0.25, 1) both;
+}
+
+.reveal-card__art {
+  position: relative;
+  min-height: 118px;
+  background-position: center;
+  background-size: cover;
+}
+
+.reveal-card__art::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(transparent 28%, rgba(15, 11, 16, 0.92));
+}
+
+.reveal-card__art span {
+  position: absolute;
+  z-index: 1;
+  left: 11px;
+  bottom: 9px;
+  color: #ffbd78;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.reveal-card__body {
+  min-height: 118px;
+  padding: 14px;
+}
+
+.reveal-card__body small {
+  color: rgba(247, 222, 208, 0.32);
+  font-family: 'Cinzel', serif;
+}
+
+.reveal-card__body h4 {
+  margin: 6px 0 12px;
+  color: #fff4e9;
+  font-family: 'Cinzel', serif;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.reveal-card__body p {
+  color: rgba(247, 222, 208, 0.58);
+  font-size: 12px;
+}
+
+.reveal-card--hidden {
+  min-height: 237px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  color: #f7b574;
+  border-style: dashed;
+  background: radial-gradient(circle, rgba(152, 58, 38, 0.2), rgba(18, 14, 20, 0.96));
+  cursor: pointer;
+}
+
+.reveal-card--hidden span {
+  font-family: 'Cinzel', serif;
+  font-size: 48px;
+}
+
+.reveal-card--hidden strong {
+  max-width: 120px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.election-launch {
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-top: 30px;
+  padding: 24px;
+  border: 1px solid rgba(239, 116, 63, 0.28);
+  background: rgba(91, 35, 32, 0.15);
+}
+
+.election-launch > div:first-child {
+  flex: 1 1 360px;
+}
+
+.duration-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.cycle-field {
+  display: grid;
+  gap: 7px;
+  color: rgba(247, 222, 208, 0.66);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.cycle-field small {
+  color: rgba(247, 222, 208, 0.35);
+  font-weight: 500;
+  text-transform: none;
+}
+
+.cycle-field input,
+.cycle-field textarea,
+.cycle-field select {
+  width: 100%;
+  padding: 11px 12px;
+  color: #f7ded0;
+  border: 1px solid rgba(247, 222, 208, 0.17);
+  border-radius: 3px;
+  outline: none;
+  background: rgba(9, 8, 12, 0.66);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.cycle-field input:focus,
+.cycle-field textarea:focus,
+.cycle-field select:focus {
+  border-color: #d87649;
+  box-shadow: 0 0 0 2px rgba(216, 118, 73, 0.12);
+}
+
+.result-list {
+  margin: 28px 0;
+  border-top: 1px solid rgba(247, 222, 208, 0.09);
+}
+
+.result-row {
+  justify-content: flex-start;
+  padding: 15px 8px;
+  border-bottom: 1px solid rgba(247, 222, 208, 0.09);
+}
+
+.result-row--leader {
+  background: linear-gradient(90deg, rgba(202, 91, 49, 0.12), transparent);
+}
+
+.result-row__rank {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid rgba(247, 222, 208, 0.18);
+  border-radius: 50%;
+  color: rgba(247, 222, 208, 0.58);
+  font-size: 11px;
+}
+
+.result-row strong {
+  flex: 1;
+  color: #fff4e9;
+}
+
+.result-row > span:not(.result-row__rank) {
+  color: #f2a45c;
+  font-weight: 800;
+}
+
+.result-row small {
+  width: 70px;
+  color: rgba(247, 222, 208, 0.4);
+  text-align: right;
+}
+
+.transition-form,
+.transition-preview,
+.discord-controls {
+  display: grid;
+  gap: 20px;
+  margin-top: 28px;
+  padding: 24px;
+  border: 1px solid rgba(247, 222, 208, 0.11);
+  background: rgba(9, 8, 12, 0.32);
+}
+
+.transition-form__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.cycle-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  color: rgba(247, 222, 208, 0.66);
+  cursor: pointer;
+}
+
+.cycle-check input {
+  margin-top: 3px;
+  accent-color: #db7748;
+}
+
+.cycle-check span {
+  display: grid;
+  gap: 3px;
+  font-size: 12px;
+}
+
+.cycle-check strong {
+  color: #f7ded0;
+  font-size: 14px;
+}
+
+.cycle-check--caution {
+  color: #f0b38a;
+}
+
+.cycle-warning {
+  margin: 14px 0;
+  padding: 11px 13px;
+  color: #f5bb8f;
+  border-left: 2px solid #d87649;
+  background: rgba(152, 58, 38, 0.13);
+  font-size: 13px;
+}
+
+.discord-controls h4 {
+  margin: 0;
+  color: #fff4e9;
+  font-family: 'Cinzel', serif;
+  font-size: 20px;
+}
+
+.transition-preview {
+  border-color: rgba(242, 164, 92, 0.25);
+  background: radial-gradient(circle at 80% 0, rgba(164, 67, 38, 0.14), transparent 36%);
+}
+
+.transition-preview h3 {
+  margin: 0;
+}
+
+.transition-preview pre {
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  color: rgba(247, 222, 208, 0.75);
+  border: 1px solid rgba(247, 222, 208, 0.09);
+  background: rgba(6, 5, 8, 0.45);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.preview-notices {
+  padding: 14px 16px;
+  color: #eac19e;
+  border: 1px solid rgba(242, 164, 92, 0.18);
+  background: rgba(128, 69, 42, 0.12);
+}
+
+.preview-notices--error {
+  color: #ffaaa0;
+  border-color: rgba(231, 92, 78, 0.3);
+  background: rgba(130, 35, 37, 0.15);
+}
+
+.preview-notices ul,
+.discord-plan-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.discord-plan-list {
+  display: grid;
+  gap: 7px;
+  color: rgba(247, 222, 208, 0.7);
+}
+
+@keyframes card-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.94) rotateY(18deg);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes flame-breathe {
+  50% {
+    transform: rotate(-3deg) scale(1.05, 0.96);
+    filter: drop-shadow(0 0 42px rgba(239, 116, 63, 0.62));
+  }
+}
+
+@keyframes cycle-pulse {
+  50% {
+    opacity: 0.65;
+    transform: scale(0.8);
+  }
+}
+
+@media (max-width: 760px) {
+  .cycle-conductor {
+    width: min(100% - 20px, 1120px);
+  }
+
+  .cycle-hero,
+  .cycle-panel__heading,
+  .election-launch {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .cycle-status {
+    align-self: flex-start;
+  }
+
+  .cycle-steps li {
+    gap: 5px;
+    padding: 11px 6px;
+    font-size: 9px;
+  }
+
+  .transition-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .result-row {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .result-row strong {
+    flex: 1 1 calc(100% - 60px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .draw-hearth__flame,
+  .cycle-status--active span,
+  .reveal-card {
+    animation: none;
+  }
+}
+
 main {
   width: 1000px;
   max-width: 90%;

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -673,9 +673,9 @@ body.bonfire-inner-page .user-menu-popover {
 
 /* Cycle conductor */
 .cycle-conductor {
-  width: min(1120px, calc(100% - 36px));
-  margin: 0 auto 120px;
-  color: #f7ded0;
+  width: 100%;
+  margin: 0 0 120px;
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .cycle-loading {
@@ -697,35 +697,62 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 .cycle-hero {
-  padding: 34px 38px;
-  border: 1px solid rgba(242, 164, 92, 0.22);
+  position: relative;
+  min-height: 184px;
+  padding: 38px 42px;
+  overflow: hidden;
   background:
-    radial-gradient(circle at 82% 10%, rgba(217, 91, 49, 0.15), transparent 34%),
-    rgba(20, 15, 22, 0.8);
-  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.26);
+    radial-gradient(ellipse 68% 210px at 50% -22px, rgba(186, 79, 43, 0.17), transparent 72%),
+    linear-gradient(155deg, rgba(29, 21, 29, 0.985), rgba(17, 14, 21, 0.99));
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top-color: rgba(238, 160, 105, 0.5);
+  border-bottom-color: rgba(0, 0, 0, 0.78);
+  border-radius: 9px;
+  box-shadow:
+    0 -14px 38px rgba(174, 65, 32, 0.07),
+    0 18px 46px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 222, 190, 0.05);
+}
+
+.cycle-hero::before,
+.cycle-panel::before {
+  position: absolute;
+  top: -1px;
+  left: 23%;
+  z-index: 2;
+  width: 54%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 200, 146, 0.72), transparent);
+  content: '';
+  pointer-events: none;
 }
 
 .cycle-hero h2,
 .cycle-panel h3 {
   margin: 5px 0 8px;
-  font-family: 'Cinzel', serif;
-  color: #fff4e9;
+  color: rgba(255, 255, 255, 0.94);
+  font-family: 'Mulish', sans-serif;
+  font-weight: 850;
+  letter-spacing: -0.04em;
 }
 
 .cycle-hero h2 {
-  font-size: clamp(28px, 4vw, 46px);
+  font-size: clamp(27px, 4vw, 39px);
+  line-height: 1.08;
 }
 
 .cycle-hero p,
 .cycle-panel__copy,
 .election-launch p {
   max-width: 680px;
-  color: rgba(247, 222, 208, 0.7);
+  color: rgba(255, 255, 255, 0.53);
+  font-size: 14px;
+  line-height: 1.65;
 }
 
 .cycle-eyebrow {
-  color: #f2a45c;
-  font-size: 11px;
+  color: rgba(242, 164, 92, 0.72);
+  font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -738,8 +765,8 @@ body.bonfire-inner-page .user-menu-popover {
   gap: 9px;
   padding: 9px 13px;
   border: 1px solid rgba(247, 222, 208, 0.14);
-  border-radius: 999px;
-  color: rgba(247, 222, 208, 0.75);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.58);
   font-size: 12px;
   font-weight: 700;
 }
@@ -763,8 +790,11 @@ body.bonfire-inner-page .user-menu-popover {
   margin: 22px 0;
   padding: 0;
   list-style: none;
-  border: 1px solid rgba(247, 222, 208, 0.1);
-  background: rgba(11, 9, 14, 0.45);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-radius: 8px;
+  background: rgba(14, 11, 17, 0.72);
+  box-shadow: 0 13px 28px rgba(0, 0, 0, 0.16);
 }
 
 .cycle-steps li {
@@ -786,7 +816,7 @@ body.bonfire-inner-page .user-menu-popover {
 
 .cycle-steps li.active {
   color: #ffbd78;
-  background: rgba(168, 71, 39, 0.1);
+  background: linear-gradient(90deg, rgba(168, 71, 39, 0.16), rgba(168, 71, 39, 0.06));
 }
 
 .cycle-steps span {
@@ -800,10 +830,19 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 .cycle-panel {
+  position: relative;
   padding: clamp(24px, 4vw, 46px);
-  border: 1px solid rgba(242, 164, 92, 0.18);
-  background: linear-gradient(145deg, rgba(31, 21, 27, 0.96), rgba(15, 12, 18, 0.98));
-  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.34);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top-color: rgba(238, 160, 105, 0.42);
+  border-radius: 9px;
+  background:
+    radial-gradient(ellipse 68% 190px at 50% 0, rgba(192, 91, 47, 0.1), transparent 76%),
+    linear-gradient(155deg, rgba(29, 21, 29, 0.985), rgba(17, 14, 21, 0.99));
+  box-shadow:
+    0 -10px 28px rgba(174, 65, 32, 0.06),
+    0 18px 46px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 220, 190, 0.04);
 }
 
 .cycle-panel__heading {
@@ -813,7 +852,7 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 .cycle-panel__heading h3 {
-  font-size: clamp(23px, 3vw, 34px);
+  font-size: clamp(23px, 3vw, 31px);
 }
 
 .cycle-panel__heading > strong {
@@ -835,21 +874,44 @@ body.bonfire-inner-page .user-menu-popover {
 }
 
 .draw-hearth__flame {
-  width: 86px;
-  height: 104px;
-  border-radius: 58% 42% 54% 46% / 67% 44% 56% 33%;
-  background: radial-gradient(circle at 50% 72%, #ffd089 0 18%, #ef743f 40%, #8c342f 72%);
-  filter: drop-shadow(0 0 30px rgba(239, 116, 63, 0.48));
-  transform: rotate(4deg);
+  position: relative;
+  width: 72px;
+  height: 72px;
+  border: 1px solid rgba(255, 194, 124, 0.34);
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffd089 0 8%, #e97442 22%, #7d302c 48%, transparent 70%);
+  box-shadow: 0 0 58px rgba(219, 93, 48, 0.28);
   animation: flame-breathe 2.2s ease-in-out infinite;
+}
+
+.draw-hearth__flame::before,
+.draw-hearth__flame::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 54px;
+  height: 5px;
+  border-radius: 999px;
+  background: #492729;
+  box-shadow: inset 0 1px rgba(255, 190, 132, 0.18);
+  content: '';
+}
+
+.draw-hearth__flame::before {
+  transform: translate(-50%, -50%) rotate(32deg);
+}
+
+.draw-hearth__flame::after {
+  transform: translate(-50%, -50%) rotate(-32deg);
 }
 
 .cycle-primary,
 .cycle-secondary,
 .cycle-quiet,
+.cycle-danger,
 .duration-presets button {
   border: 0;
-  border-radius: 3px;
+  border-radius: 5px;
   font: inherit;
   font-weight: 800;
   cursor: pointer;
@@ -862,7 +924,7 @@ body.bonfire-inner-page .user-menu-popover {
 .cycle-primary {
   padding: 13px 20px;
   color: #271414;
-  background: linear-gradient(135deg, #ffc27c, #e97442);
+  background: linear-gradient(135deg, #f5b879, #df7041);
   box-shadow: 0 10px 30px rgba(211, 87, 44, 0.2);
 }
 
@@ -885,16 +947,25 @@ body.bonfire-inner-page .user-menu-popover {
   background: transparent;
 }
 
+.cycle-danger {
+  padding: 10px 14px;
+  color: #ffd5ca;
+  border: 1px solid rgba(225, 100, 78, 0.38);
+  background: rgba(129, 39, 37, 0.28);
+}
+
 .cycle-primary:hover:not(:disabled),
 .cycle-secondary:hover:not(:disabled),
 .cycle-quiet:hover:not(:disabled),
+.cycle-danger:hover:not(:disabled),
 .duration-presets button:hover {
   transform: translateY(-2px);
 }
 
 .cycle-primary:disabled,
 .cycle-secondary:disabled,
-.cycle-quiet:disabled {
+.cycle-quiet:disabled,
+.cycle-danger:disabled {
   cursor: wait;
   opacity: 0.55;
 }
@@ -909,10 +980,13 @@ body.bonfire-inner-page .user-menu-popover {
 .reveal-card {
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(247, 222, 208, 0.13);
-  border-radius: 4px;
-  background: #171218;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.26);
+  border: 1px solid rgba(255, 255, 255, 0.065);
+  border-top: 2px solid rgba(242, 164, 92, 0.52);
+  border-radius: 8px;
+  background: linear-gradient(160deg, rgba(29, 21, 28, 0.98), rgba(13, 11, 16, 0.99));
+  box-shadow:
+    0 -10px 28px rgba(174, 65, 32, 0.07),
+    0 13px 28px rgba(0, 0, 0, 0.22);
   animation: card-reveal 560ms cubic-bezier(0.2, 0.82, 0.25, 1) both;
 }
 
@@ -949,14 +1023,14 @@ body.bonfire-inner-page .user-menu-popover {
 
 .reveal-card__body small {
   color: rgba(247, 222, 208, 0.32);
-  font-family: 'Cinzel', serif;
 }
 
 .reveal-card__body h4 {
   margin: 6px 0 12px;
   color: #fff4e9;
-  font-family: 'Cinzel', serif;
+  font-family: 'Mulish', sans-serif;
   font-size: 16px;
+  font-weight: 820;
   line-height: 1.25;
 }
 
@@ -995,6 +1069,7 @@ body.bonfire-inner-page .user-menu-popover {
   margin-top: 30px;
   padding: 24px;
   border: 1px solid rgba(239, 116, 63, 0.28);
+  border-radius: 7px;
   background: rgba(91, 35, 32, 0.15);
 }
 
@@ -1031,7 +1106,7 @@ body.bonfire-inner-page .user-menu-popover {
   padding: 11px 12px;
   color: #f7ded0;
   border: 1px solid rgba(247, 222, 208, 0.17);
-  border-radius: 3px;
+  border-radius: 5px;
   outline: none;
   background: rgba(9, 8, 12, 0.66);
   font: inherit;
@@ -1098,6 +1173,7 @@ body.bonfire-inner-page .user-menu-popover {
   margin-top: 28px;
   padding: 24px;
   border: 1px solid rgba(247, 222, 208, 0.11);
+  border-radius: 7px;
   background: rgba(9, 8, 12, 0.32);
 }
 
@@ -1147,13 +1223,52 @@ body.bonfire-inner-page .user-menu-popover {
 .discord-controls h4 {
   margin: 0;
   color: #fff4e9;
-  font-family: 'Cinzel', serif;
+  font-family: 'Mulish', sans-serif;
   font-size: 20px;
+  font-weight: 820;
 }
 
 .transition-preview {
   border-color: rgba(242, 164, 92, 0.25);
   background: radial-gradient(circle at 80% 0, rgba(164, 67, 38, 0.14), transparent 36%);
+}
+
+.cycle-undo {
+  display: flex;
+  margin: -5px 0 26px;
+  padding: 14px 16px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  color: rgba(255, 255, 255, 0.46);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 7px;
+  background: rgba(8, 7, 10, 0.22);
+}
+
+.cycle-undo > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+
+.cycle-undo strong {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 12px;
+}
+
+.cycle-undo span {
+  font-size: 11px;
+}
+
+.cycle-undo--open {
+  border-color: rgba(225, 100, 78, 0.24);
+  background: rgba(107, 33, 34, 0.13);
+}
+
+.cycle-undo__actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 7px;
 }
 
 .transition-preview h3 {
@@ -1211,8 +1326,8 @@ body.bonfire-inner-page .user-menu-popover {
 
 @keyframes flame-breathe {
   50% {
-    transform: rotate(-3deg) scale(1.05, 0.96);
-    filter: drop-shadow(0 0 42px rgba(239, 116, 63, 0.62));
+    transform: scale(1.06);
+    box-shadow: 0 0 68px rgba(239, 116, 63, 0.38);
   }
 }
 
@@ -1225,7 +1340,7 @@ body.bonfire-inner-page .user-menu-popover {
 
 @media (max-width: 760px) {
   .cycle-conductor {
-    width: min(100% - 20px, 1120px);
+    width: 100%;
   }
 
   .cycle-hero,
@@ -1256,6 +1371,11 @@ body.bonfire-inner-page .user-menu-popover {
 
   .result-row strong {
     flex: 1 1 calc(100% - 60px);
+  }
+
+  .cycle-undo {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 
@@ -2501,6 +2621,14 @@ a.meeting-callout:focus-visible {
   max-width: 650px;
 }
 
+.backlog-overview__aside {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  flex: 0 0 auto;
+  gap: 18px;
+}
+
 .backlog-eyebrow {
   display: block;
   margin-bottom: 8px;
@@ -2540,6 +2668,38 @@ a.meeting-callout:focus-visible {
   align-items: center;
   gap: 13px;
   border-left: 1px solid rgba(242, 164, 92, 0.22);
+}
+
+.backlog-conductor-link {
+  display: grid;
+  padding: 11px 0 0 26px;
+  gap: 2px;
+  color: rgba(255, 255, 255, 0.5);
+  border-left: 1px solid rgba(242, 164, 92, 0.22);
+  text-decoration: none;
+}
+
+.backlog-conductor-link span {
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.backlog-conductor-link strong {
+  color: #eba86f;
+  font-size: 12px;
+  transition: color 180ms ease;
+}
+
+.backlog-conductor-link:hover strong,
+.backlog-conductor-link:focus-visible strong {
+  color: #ffd0a6;
+}
+
+.backlog-conductor-link:focus-visible {
+  outline: 2px solid rgba(255, 193, 138, 0.72);
+  outline-offset: 4px;
 }
 
 .backlog-limit strong {
@@ -3179,6 +3339,16 @@ a.meeting-callout:focus-visible {
   .backlog-limit {
     min-width: 0;
     padding: 16px 0 0;
+    border-top: 1px solid rgba(242, 164, 92, 0.18);
+    border-left: 0;
+  }
+
+  .backlog-overview__aside {
+    width: 100%;
+  }
+
+  .backlog-conductor-link {
+    padding: 14px 0 0;
     border-top: 1px solid rgba(242, 164, 92, 0.18);
     border-left: 0;
   }

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -3120,11 +3120,6 @@ a.meeting-callout:focus-visible {
   left: auto;
 }
 
-.backlog-card__count--with-menu {
-  right: 51px;
-  left: auto;
-}
-
 .backlog-card__vote-state {
   position: absolute;
   top: 12px;

--- a/client/src/components/BacklogGameCard.vue
+++ b/client/src/components/BacklogGameCard.vue
@@ -19,14 +19,14 @@ const props = withDefaults(
     retirementThreshold: number
     nextVote?: boolean
     currentVote?: boolean
-    canWithdraw?: boolean
-    withdrawing?: boolean
+    canRetire?: boolean
+    retiring?: boolean
   }>(),
-  { nextVote: false, currentVote: false, canWithdraw: false, withdrawing: false },
+  { nextVote: false, currentVote: false, canRetire: false, retiring: false },
 )
 
 const emit = defineEmits<{
-  withdraw: [game: BacklogGame]
+  retire: [game: BacklogGame]
 }>()
 
 const failedRecommenderAvatars = ref(new Set<number>())
@@ -84,25 +84,25 @@ const hiddenRecommenderNames = () =>
         class="backlog-card__count"
         :class="{
           'backlog-card__count--aside': featuredVote,
-          'backlog-card__count--with-menu': canWithdraw,
+          'backlog-card__count--with-menu': canRetire,
         }"
       >
         <strong>{{ game.electionAppearances }}</strong>
         / {{ retirementThreshold }}
       </span>
 
-      <details v-if="canWithdraw" class="backlog-card__menu">
+      <details v-if="canRetire" class="backlog-card__menu">
         <summary
           :aria-label="`Opções para ${game.title}`"
-          :aria-disabled="withdrawing"
-          @click="withdrawing && $event.preventDefault()"
+          :aria-disabled="retiring"
+          @click="retiring && $event.preventDefault()"
         >
-          <n-spin v-if="withdrawing" :size="13" />
+          <n-spin v-if="retiring" :size="13" />
           <n-icon v-else size="18"><EllipsisHorizontal /></n-icon>
         </summary>
-        <button type="button" :disabled="withdrawing" @click="emit('withdraw', game)">
+        <button type="button" :disabled="retiring" @click="emit('retire', game)">
           <n-icon size="15"><TrashOutline /></n-icon>
-          {{ withdrawing ? 'Retirando…' : 'Retirar das Brasas' }}
+          {{ retiring ? 'Retirando…' : 'Retirar da rotação' }}
         </button>
       </details>
 

--- a/client/src/components/BacklogGameCard.vue
+++ b/client/src/components/BacklogGameCard.vue
@@ -84,7 +84,6 @@ const hiddenRecommenderNames = () =>
         class="backlog-card__count"
         :class="{
           'backlog-card__count--aside': featuredVote,
-          'backlog-card__count--with-menu': canRetire,
         }"
       >
         <strong>{{ game.electionAppearances }}</strong>

--- a/client/src/components/BacklogGameCard.vue
+++ b/client/src/components/BacklogGameCard.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { CheckmarkCircle, LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
-import { NIcon, NTooltip } from 'naive-ui'
+import { computed, ref } from 'vue'
+import {
+  CheckmarkCircle,
+  EllipsisHorizontal,
+  FlameOutline,
+  LogoSteam,
+  LogoYoutube,
+  TimeOutline,
+  TrashOutline,
+} from '@vicons/ionicons5'
+import { NIcon, NSpin, NTooltip } from 'naive-ui'
 import { formatDurationLabel, getGameCover } from '@/services/gameService'
 import type { BacklogGame, GameRecommender } from '@/types/Game'
 
@@ -10,11 +18,19 @@ const props = withDefaults(
     game: BacklogGame
     retirementThreshold: number
     nextVote?: boolean
+    currentVote?: boolean
+    canWithdraw?: boolean
+    withdrawing?: boolean
   }>(),
-  { nextVote: false },
+  { nextVote: false, currentVote: false, canWithdraw: false, withdrawing: false },
 )
 
+const emit = defineEmits<{
+  withdraw: [game: BacklogGame]
+}>()
+
 const failedRecommenderAvatars = ref(new Set<number>())
+const featuredVote = computed(() => props.nextVote || props.currentVote)
 
 const appearanceLabel = (count: number) => {
   if (count === 0) return 'Ainda não passou'
@@ -45,19 +61,50 @@ const hiddenRecommenderNames = () =>
 </script>
 
 <template>
-  <article class="backlog-card" :class="{ 'backlog-card--next-vote': nextVote }">
+  <article
+    class="backlog-card"
+    :class="{
+      'backlog-card--next-vote': nextVote,
+      'backlog-card--current-vote': currentVote,
+    }"
+  >
     <div class="backlog-card__art" :style="coverStyle()">
       <div class="backlog-card__shade"></div>
 
-      <span v-if="nextVote" class="backlog-card__next-vote">
+      <span v-if="currentVote" class="backlog-card__vote-state backlog-card__vote-state--current">
+        <n-icon size="14"><FlameOutline /></n-icon>
+        Votação acesa
+      </span>
+      <span v-else-if="nextVote" class="backlog-card__vote-state">
         <n-icon size="14"><CheckmarkCircle /></n-icon>
         Próxima votação
       </span>
 
-      <span class="backlog-card__count" :class="{ 'backlog-card__count--aside': nextVote }">
+      <span
+        class="backlog-card__count"
+        :class="{
+          'backlog-card__count--aside': featuredVote,
+          'backlog-card__count--with-menu': canWithdraw,
+        }"
+      >
         <strong>{{ game.electionAppearances }}</strong>
         / {{ retirementThreshold }}
       </span>
+
+      <details v-if="canWithdraw" class="backlog-card__menu">
+        <summary
+          :aria-label="`Opções para ${game.title}`"
+          :aria-disabled="withdrawing"
+          @click="withdrawing && $event.preventDefault()"
+        >
+          <n-spin v-if="withdrawing" :size="13" />
+          <n-icon v-else size="18"><EllipsisHorizontal /></n-icon>
+        </summary>
+        <button type="button" :disabled="withdrawing" @click="emit('withdraw', game)">
+          <n-icon size="15"><TrashOutline /></n-icon>
+          {{ withdrawing ? 'Retirando…' : 'Retirar das Brasas' }}
+        </button>
+      </details>
 
       <header class="backlog-card__title">
         <h3>{{ game.title }}</h3>
@@ -77,7 +124,7 @@ const hiddenRecommenderNames = () =>
             aria-hidden="true"
           ></span>
         </div>
-        <span v-if="!nextVote">{{ appearanceLabel(game.electionAppearances) }}</span>
+        <span v-if="!featuredVote">{{ appearanceLabel(game.electionAppearances) }}</span>
       </div>
 
       <div

--- a/client/src/components/BacklogGameCard.vue
+++ b/client/src/components/BacklogGameCard.vue
@@ -83,7 +83,7 @@ const hiddenRecommenderNames = () =>
       <div
         v-if="game.recommendedBy?.length"
         class="backlog-card__recommenders"
-        aria-label="Pessoas que apresentaram este jogo ao grupo"
+        aria-label="Pessoas que sugeriram este jogo ao grupo"
       >
         <n-tooltip
           v-for="recommender in visibleRecommenders()"
@@ -94,7 +94,7 @@ const hiddenRecommenderNames = () =>
             <span
               class="backlog-recommender"
               tabindex="0"
-              :aria-label="`Apresentado por ${recommender.name}`"
+              :aria-label="`Sugerido por ${recommender.name}`"
             >
               <img
                 v-if="hasRecommenderAvatar(recommender)"
@@ -105,7 +105,7 @@ const hiddenRecommenderNames = () =>
               <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
             </span>
           </template>
-          Apresentado por {{ recommender.name }}
+          Sugerido por {{ recommender.name }}
         </n-tooltip>
 
         <n-tooltip v-if="game.recommendedBy.length > 3" placement="top">
@@ -113,12 +113,12 @@ const hiddenRecommenderNames = () =>
             <span
               class="backlog-recommender backlog-recommender--more"
               tabindex="0"
-              :aria-label="`Mais ${game.recommendedBy.length - 3} pessoas apresentaram este jogo`"
+              :aria-label="`Mais ${game.recommendedBy.length - 3} pessoas sugeriram este jogo`"
             >
               +{{ game.recommendedBy.length - 3 }}
             </span>
           </template>
-          Também apresentado por {{ hiddenRecommenderNames() }}
+          Também sugerido por {{ hiddenRecommenderNames() }}
         </n-tooltip>
       </div>
 

--- a/client/src/components/ElectionView.vue
+++ b/client/src/components/ElectionView.vue
@@ -84,9 +84,12 @@ const voteAction = async (optionId: number) => {
   <section v-if="electionActive" class="election-hearth" aria-labelledby="election-heading">
     <header class="election-hearth__heading">
       <div>
-        <span>Votação acesa</span>
-        <h2 id="election-heading">Qual jogo recebe a próxima chama?</h2>
-        <p>Conheça cada jornada e escolha com calma. A contagem permanece em segredo.</p>
+        <span>Votação</span>
+        <h2 id="election-heading">Acesa</h2>
+        <p>
+          <strong>Qual jogo recebe a próxima chama?</strong>
+          Conheça cada jornada e escolha com calma. A contagem permanece em segredo.
+        </p>
       </div>
       <div v-if="selectedOption" class="election-hearth__receipt">
         <n-icon size="17"><CheckmarkCircle /></n-icon>

--- a/client/src/components/ElectionView.vue
+++ b/client/src/components/ElectionView.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { CheckmarkCircle, LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
+import {
+  CheckmarkCircle,
+  LockClosedOutline,
+  LogoSteam,
+  LogoYoutube,
+  TimeOutline,
+} from '@vicons/ionicons5'
 import { NIcon, NTooltip, useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { useCampaignStore } from '@/stores/campaign'
@@ -86,14 +92,14 @@ const voteAction = async (optionId: number) => {
       <div>
         <span>Votação</span>
         <h2 id="election-heading">Acesa</h2>
-        <p>
-          <strong>Qual jogo recebe a próxima chama?</strong>
-          Conheça cada jornada e escolha com calma. A contagem permanece em segredo.
-        </p>
       </div>
       <div v-if="selectedOption" class="election-hearth__receipt">
         <n-icon size="17"><CheckmarkCircle /></n-icon>
-        <span>Seu voto está guardado</span>
+        <span>Seu voto foi lançado à fogueira</span>
+      </div>
+      <div v-else-if="!user" class="election-hearth__receipt election-hearth__receipt--locked">
+        <n-icon size="16"><LockClosedOutline /></n-icon>
+        <span>Revele-se à fogueira para lançar seu voto</span>
       </div>
     </header>
 
@@ -205,7 +211,7 @@ const voteAction = async (optionId: number) => {
             <span>{{ recommenderLabel(option) }}</span>
           </div>
 
-          <footer>
+          <footer v-if="user">
             <div v-if="didIVoteForThis(option.players ?? [])" class="game-links">
               <button type="button" :disabled="!!loadingVote" @click="undoVoteAction">
                 {{ loadingVote === true ? 'Retirando…' : 'Retirar meu voto' }}
@@ -220,8 +226,6 @@ const voteAction = async (optionId: number) => {
                 {{ loadingVote === option.id ? 'Guardando voto…' : 'Votar neste jogo' }}
               </button>
             </div>
-            <span v-else class="election-card__quiet-state">Você já escolheu outra chama.</span>
-            <small v-if="!user">Revele-se pelo Discord para votar.</small>
           </footer>
         </div>
       </article>

--- a/client/src/components/ElectionView.vue
+++ b/client/src/components/ElectionView.vue
@@ -51,8 +51,8 @@ const hiddenRecommenderNames = (option: PoolOption) =>
 const recommenderLabel = (option: PoolOption) => {
   const names = (option.game.recommendedBy ?? []).map((recommender) => recommender.name)
   if (!names.length) return ''
-  if (names.length === 1) return `Apresentado por ${names[0]}`
-  return `Apresentado por ${names.slice(0, -1).join(', ')} e ${names[names.length - 1]}`
+  if (names.length === 1) return `Sugerido por ${names[0]}`
+  return `Sugerido por ${names.slice(0, -1).join(', ')} e ${names[names.length - 1]}`
 }
 
 const undoVoteAction = async () => {
@@ -108,7 +108,7 @@ const voteAction = async (optionId: number) => {
         >
           <div class="election-card__shade"></div>
 
-          <span v-if="didIVoteForThis(option.players ?? [])" class="election-card__selected-badge">
+          <span v-if="didIVoteForThis(option.players ?? [])" class="election-card__selected-bar">
             <n-icon size="14"><CheckmarkCircle /></n-icon>
             Sua escolha
           </span>
@@ -187,7 +187,7 @@ const voteAction = async (optionId: number) => {
                     <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
                   </span>
                 </template>
-                Apresentado por {{ recommender.name }}
+                Sugerido por {{ recommender.name }}
               </n-tooltip>
 
               <n-tooltip v-if="option.game.recommendedBy.length > 3" placement="top">
@@ -196,7 +196,7 @@ const voteAction = async (optionId: number) => {
                     +{{ option.game.recommendedBy.length - 3 }}
                   </span>
                 </template>
-                Também apresentado por {{ hiddenRecommenderNames(option) }}
+                Também sugerido por {{ hiddenRecommenderNames(option) }}
               </n-tooltip>
             </div>
             <span>{{ recommenderLabel(option) }}</span>

--- a/client/src/components/ElectionView.vue
+++ b/client/src/components/ElectionView.vue
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/stores/auth'
 import { formatDurationLabel, getGameCover } from '@/services/gameService'
 import { undoVote, vote } from '@/services/campaignService'
 import type { PoolOption } from '@/types/Campaign'
+import type { GameRecommender } from '@/types/Game'
 import type { User } from '@/types/User'
 
 const campaignStore = useCampaignStore()
@@ -15,6 +16,7 @@ const { electionActive, election: pool } = storeToRefs(campaignStore)
 const { user } = storeToRefs(useAuthStore())
 
 const loadingVote = ref<boolean | number>(false)
+const failedRecommenderAvatars = ref(new Set<number>())
 const message = useMessage()
 
 const didIVoteForThis = (players: User[]) =>
@@ -27,6 +29,31 @@ const selectedOption = computed(() =>
 const durationLabel = (option: PoolOption) =>
   formatDurationLabel(option.game.durationLabel) ||
   (option.game.mainExtraHours != null ? `${option.game.mainExtraHours} h` : '')
+
+const hasRecommenderAvatar = (recommender: GameRecommender) =>
+  Boolean(recommender.avatar) && !failedRecommenderAvatars.value.has(recommender.id)
+
+const markRecommenderAvatarFailed = (recommender: GameRecommender) => {
+  failedRecommenderAvatars.value = new Set(failedRecommenderAvatars.value).add(recommender.id)
+}
+
+const recommenderInitial = (recommender: GameRecommender) =>
+  recommender.name.trim().charAt(0).toLocaleUpperCase('pt-BR') || '?'
+
+const visibleRecommenders = (option: PoolOption) => (option.game.recommendedBy ?? []).slice(0, 3)
+
+const hiddenRecommenderNames = (option: PoolOption) =>
+  (option.game.recommendedBy ?? [])
+    .slice(3)
+    .map((recommender) => recommender.name)
+    .join(', ')
+
+const recommenderLabel = (option: PoolOption) => {
+  const names = (option.game.recommendedBy ?? []).map((recommender) => recommender.name)
+  if (!names.length) return ''
+  if (names.length === 1) return `Apresentado por ${names[0]}`
+  return `Apresentado por ${names.slice(0, -1).join(', ')} e ${names[names.length - 1]}`
+}
 
 const undoVoteAction = async () => {
   loadingVote.value = true
@@ -137,6 +164,43 @@ const voteAction = async (optionId: number) => {
         <div class="election-card__body">
           <p v-if="option.game.summary">{{ option.game.summary }}</p>
           <p v-else>Uma possível nova jornada para compartilhar ao redor da fogueira.</p>
+
+          <div
+            v-if="option.game.recommendedBy?.length"
+            class="election-card__recommenders"
+            :aria-label="recommenderLabel(option)"
+          >
+            <div class="backlog-card__recommenders" aria-hidden="true">
+              <n-tooltip
+                v-for="recommender in visibleRecommenders(option)"
+                :key="recommender.id"
+                placement="top"
+              >
+                <template #trigger>
+                  <span class="backlog-recommender" tabindex="0">
+                    <img
+                      v-if="hasRecommenderAvatar(recommender)"
+                      :src="recommender.avatar ?? undefined"
+                      alt=""
+                      @error="markRecommenderAvatarFailed(recommender)"
+                    />
+                    <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
+                  </span>
+                </template>
+                Apresentado por {{ recommender.name }}
+              </n-tooltip>
+
+              <n-tooltip v-if="option.game.recommendedBy.length > 3" placement="top">
+                <template #trigger>
+                  <span class="backlog-recommender backlog-recommender--more" tabindex="0">
+                    +{{ option.game.recommendedBy.length - 3 }}
+                  </span>
+                </template>
+                Também apresentado por {{ hiddenRecommenderNames(option) }}
+              </n-tooltip>
+            </div>
+            <span>{{ recommenderLabel(option) }}</span>
+          </div>
 
           <footer>
             <div v-if="didIVoteForThis(option.players ?? [])" class="game-links">

--- a/client/src/components/ElectionView.vue
+++ b/client/src/components/ElectionView.vue
@@ -1,30 +1,35 @@
-﻿<script setup lang="ts">
-import { useCampaignStore } from '@/stores/campaign.ts'
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { CheckmarkCircle, LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
+import { NIcon, NTooltip, useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
-import { getGameCover } from '@/services/gameService.ts'
-import { LogoSteam, LogoYoutube } from '@vicons/ionicons5'
-import { NButton, NIcon, NSpace, NSpin, NTooltip, useMessage } from 'naive-ui'
-import { useAuthStore } from '@/stores/auth.ts'
-import type { User } from '@/types/User.ts'
-import { undoVote, vote } from '@/services/campaignService.ts'
-import { ref } from 'vue'
+import { useCampaignStore } from '@/stores/campaign'
+import { useAuthStore } from '@/stores/auth'
+import { formatDurationLabel, getGameCover } from '@/services/gameService'
+import { undoVote, vote } from '@/services/campaignService'
+import type { PoolOption } from '@/types/Campaign'
+import type { User } from '@/types/User'
 
 const campaignStore = useCampaignStore()
 const { electionActive, election: pool } = storeToRefs(campaignStore)
-
-const auth = useAuthStore()
-const { user } = storeToRefs(auth)
+const { user } = storeToRefs(useAuthStore())
 
 const loadingVote = ref<boolean | number>(false)
 const message = useMessage()
 
-const didIVoteForThis = (players: User[]) => {
-  return !!(players ?? []).find((player: User) => player?.id === user?.value?.id)
-}
+const didIVoteForThis = (players: User[]) =>
+  Boolean(user.value && (players ?? []).some((player) => player?.id === user.value?.id))
+
+const selectedOption = computed(() =>
+  pool.value?.options.find((option) => didIVoteForThis(option.players ?? [])),
+)
+
+const durationLabel = (option: PoolOption) =>
+  formatDurationLabel(option.game.durationLabel) ||
+  (option.game.mainExtraHours != null ? `${option.game.mainExtraHours} h` : '')
 
 const undoVoteAction = async () => {
   loadingVote.value = true
-
   try {
     const newCampaignValue = await undoVote()
     await campaignStore.init(newCampaignValue)
@@ -35,11 +40,10 @@ const undoVoteAction = async () => {
   }
 }
 
-const voteAction = async (option: number) => {
-  loadingVote.value = option
-
+const voteAction = async (optionId: number) => {
+  loadingVote.value = optionId
   try {
-    const newCampaignValue = await vote(option)
+    const newCampaignValue = await vote(optionId)
     await campaignStore.init(newCampaignValue)
   } catch {
     message.error('Não foi possível registrar o voto. Tente novamente.')
@@ -50,87 +54,110 @@ const voteAction = async (option: number) => {
 </script>
 
 <template>
-  <div v-if="electionActive" class="election-wrap">
-    <h3>Hora de lançar seus votos à fogueira:</h3>
+  <section v-if="electionActive" class="election-hearth" aria-labelledby="election-heading">
+    <header class="election-hearth__heading">
+      <div>
+        <span>Votação acesa</span>
+        <h2 id="election-heading">Qual jogo recebe a próxima chama?</h2>
+        <p>Conheça cada jornada e escolha com calma. A contagem permanece em segredo.</p>
+      </div>
+      <div v-if="selectedOption" class="election-hearth__receipt">
+        <n-icon size="17"><CheckmarkCircle /></n-icon>
+        <span>Seu voto está guardado</span>
+      </div>
+    </header>
 
-    <div class="election">
-      <div
+    <div class="election-grid">
+      <article
         v-for="option in pool?.options || []"
         :key="option.id"
-        class="election-option"
-        :class="didIVoteForThis(option?.players || []) ? '--voted' : '--not-voted'"
+        class="election-card"
+        :class="{ 'election-card--selected': didIVoteForThis(option.players ?? []) }"
+        :aria-busy="loadingVote === option.id"
       >
-        <div v-if="option?.game">
-          <div class="election-option-cover">
-            <div
-              class="election-option-cover-bg"
-              :style="`background-image: url('${getGameCover(option.game)}')`"
-            ></div>
-            <div class="election-option-cover-content --top">
-              <n-space justify="center" align="center">
-                <n-tooltip v-if="option?.game?.steam">
-                  <template #trigger>
-                    <a target="_blank" :href="option?.game?.steam">
-                      <n-icon size="28">
-                        <LogoSteam />
-                      </n-icon>
-                    </a>
-                  </template>
+        <div
+          class="election-card__art"
+          :style="{ backgroundImage: `url('${getGameCover(option.game)}')` }"
+        >
+          <div class="election-card__shade"></div>
 
-                  <span>Steam</span>
-                </n-tooltip>
+          <span v-if="didIVoteForThis(option.players ?? [])" class="election-card__selected-badge">
+            <n-icon size="14"><CheckmarkCircle /></n-icon>
+            Sua escolha
+          </span>
 
-                <n-tooltip v-if="option?.game?.trailer">
-                  <template #trigger>
-                    <a target="_blank" :href="option?.game?.trailer">
-                      <n-icon size="22">
-                        <LogoYoutube />
-                      </n-icon>
-                    </a>
-                  </template>
-
-                  <span>Trailer</span>
-                </n-tooltip>
-              </n-space>
-            </div>
-          </div>
-          <div class="election-option-content">
-            <h4>{{ option.game?.title }}</h4>
-
-            <div class="undo-vote-action" v-if="user">
-              <div v-if="didIVoteForThis(option?.players || [])">
-                <n-button
-                  quaternary
-                  style="margin: 10px 0 0; width: 100%"
-                  size="small"
-                  @click="undoVoteAction"
-                  :disabled="!!loadingVote"
+          <nav class="election-card__links" :aria-label="`Links de ${option.game.title}`">
+            <n-tooltip v-if="option.game.steam">
+              <template #trigger>
+                <a
+                  :href="option.game.steam"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Abrir na Steam"
                 >
-                  <n-spin size="small" v-show="loadingVote" />
-                  <span v-show="!loadingVote">Retirar o seu voto</span>
-                </n-button>
-              </div>
-            </div>
+                  <n-icon size="17"><LogoSteam /></n-icon>
+                </a>
+              </template>
+              Steam
+            </n-tooltip>
+            <n-tooltip v-if="option.game.trailer">
+              <template #trigger>
+                <a
+                  :href="option.game.trailer"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Assistir ao trailer"
+                >
+                  <n-icon size="17"><LogoYoutube /></n-icon>
+                </a>
+              </template>
+              Trailer
+            </n-tooltip>
+            <n-tooltip v-if="option.game.howLongToBeatUrl">
+              <template #trigger>
+                <a
+                  :href="option.game.howLongToBeatUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Ver duração no HowLongToBeat"
+                >
+                  <n-icon size="17"><TimeOutline /></n-icon>
+                </a>
+              </template>
+              {{ durationLabel(option) || 'HowLongToBeat' }}
+            </n-tooltip>
+          </nav>
 
-            <div class="vote-action">
-              <n-tooltip :disabled="!!user">
-                <template #trigger>
-                  <n-button
-                    style="margin: 10px 0 0; width: 100%"
-                    size="large"
-                    @click="voteAction(option.id)"
-                    :disabled="!!loadingVote || !user"
-                  >
-                    <n-spin size="small" v-show="loadingVote === option.id" />
-                    <span v-show="loadingVote !== option.id">Votar</span>
-                  </n-button>
-                </template>
-                <div v-if="!user">Você precisa estar logado para votar.</div>
-              </n-tooltip>
-            </div>
+          <div class="election-card__title">
+            <small v-if="durationLabel(option)">{{ durationLabel(option) }}</small>
+            <h3>{{ option.game.title }}</h3>
           </div>
         </div>
-      </div>
+
+        <div class="election-card__body">
+          <p v-if="option.game.summary">{{ option.game.summary }}</p>
+          <p v-else>Uma possível nova jornada para compartilhar ao redor da fogueira.</p>
+
+          <footer>
+            <div v-if="didIVoteForThis(option.players ?? [])" class="game-links">
+              <button type="button" :disabled="!!loadingVote" @click="undoVoteAction">
+                {{ loadingVote === true ? 'Retirando…' : 'Retirar meu voto' }}
+              </button>
+            </div>
+            <div v-else-if="!selectedOption" class="game-links">
+              <button
+                type="button"
+                :disabled="!!loadingVote || !user"
+                @click="voteAction(option.id)"
+              >
+                {{ loadingVote === option.id ? 'Guardando voto…' : 'Votar neste jogo' }}
+              </button>
+            </div>
+            <span v-else class="election-card__quiet-state">Você já escolheu outra chama.</span>
+            <small v-if="!user">Revele-se pelo Discord para votar.</small>
+          </footer>
+        </div>
+      </article>
     </div>
-  </div>
+  </section>
 </template>

--- a/client/src/components/TopNavigation.vue
+++ b/client/src/components/TopNavigation.vue
@@ -53,6 +53,9 @@ const logout = async () => {
         <RouterLink to="/campanhas" class="top-navigation__link">Campanhas</RouterLink>
         <RouterLink to="/brasas" class="top-navigation__link">Brasas</RouterLink>
         <RouterLink to="/regras" class="top-navigation__link">Regras</RouterLink>
+        <RouterLink v-if="user?.isAdmin" to="/conduzir" class="top-navigation__link">
+          Conduzir
+        </RouterLink>
       </div>
 
       <div v-if="isAuthenticated" class="top-navigation__account">

--- a/client/src/components/TopNavigation.vue
+++ b/client/src/components/TopNavigation.vue
@@ -12,7 +12,7 @@ const auth = useAuthStore()
 const { isAuthenticated, user } = storeToRefs(auth)
 
 const campaignStore = useCampaignStore()
-const { campaignUser } = storeToRefs(campaignStore)
+const { campaign, campaignUser } = storeToRefs(campaignStore)
 
 const userMenuOpen = ref(false)
 
@@ -29,6 +29,11 @@ const userInitial = computed(() => displayName.value.charAt(0).toUpperCase())
 const tokenBreakdown = computed(() => {
   return campaignUser.value ? getUserTokenBreakdown(campaignUser.value) : []
 })
+const showConductorShortcut = computed(() =>
+  Boolean(
+    user.value?.isAdmin && campaign.value?.electionStartedAt && campaign.value.pool?.options.length,
+  ),
+)
 
 onMounted(async () => {
   try {
@@ -53,7 +58,7 @@ const logout = async () => {
         <RouterLink to="/campanhas" class="top-navigation__link">Campanhas</RouterLink>
         <RouterLink to="/brasas" class="top-navigation__link">Brasas</RouterLink>
         <RouterLink to="/regras" class="top-navigation__link">Regras</RouterLink>
-        <RouterLink v-if="user?.isAdmin" to="/conduzir" class="top-navigation__link">
+        <RouterLink v-if="showConductorShortcut" to="/conduzir" class="top-navigation__link">
           Conduzir
         </RouterLink>
       </div>

--- a/client/src/components/__tests__/Backlog.spec.ts
+++ b/client/src/components/__tests__/Backlog.spec.ts
@@ -9,7 +9,7 @@ const gameServiceMocks = vi.hoisted(() => ({
   getGameBacklog: vi.fn(),
   getGameCover: vi.fn(() => ''),
   formatDurationLabel: vi.fn(() => ''),
-  deleteGameRecommendation: vi.fn(),
+  retireGameFromRotation: vi.fn(),
 }))
 const messageMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
 
@@ -25,7 +25,7 @@ describe('Backlog', () => {
   beforeEach(() => {
     pinia = createPinia()
     setActivePinia(pinia)
-    gameServiceMocks.deleteGameRecommendation.mockResolvedValue(undefined)
+    gameServiceMocks.retireGameFromRotation.mockResolvedValue(undefined)
     gameServiceMocks.getGameBacklog.mockResolvedValue({
       retirementThreshold: 3,
       targetPoolSize: 5,
@@ -167,7 +167,7 @@ describe('Backlog', () => {
     expect(waitingShelf?.text()).not.toContain('Returning Game')
   })
 
-  it('lets the recommender withdraw their guaranteed game from its card menu', async () => {
+  it('lets a historical recommender retire their catalog game without touching the current suggestion', async () => {
     const auth = useAuthStore()
     auth.user = { id: 10, name: 'Ana', isAdmin: false }
     const campaign = useCampaignStore()
@@ -181,7 +181,6 @@ describe('Backlog', () => {
       partook_in_the_meeting: false,
       tokens: 0,
     }
-    vi.spyOn(campaign, 'init').mockResolvedValue()
     gameServiceMocks.getGameBacklog
       .mockResolvedValueOnce({
         retirementThreshold: 3,
@@ -203,7 +202,7 @@ describe('Backlog', () => {
             suggestion: true,
             electionAppearances: 1,
             guaranteedNextVote: false,
-            recommendedBy: [],
+            recommendedBy: [{ id: 10, name: 'Ana', avatar: null }],
           },
         ],
       })
@@ -214,12 +213,12 @@ describe('Backlog', () => {
         rubble: [],
         games: [
           {
-            id: 2,
-            title: 'Returning Game',
+            id: 1,
+            title: 'Fresh Game',
             suggestion: true,
-            electionAppearances: 1,
-            guaranteedNextVote: false,
-            recommendedBy: [],
+            electionAppearances: 0,
+            guaranteedNextVote: true,
+            recommendedBy: [{ id: 10, name: 'Ana', avatar: null }],
           },
         ],
       })
@@ -228,16 +227,17 @@ describe('Backlog', () => {
     await flushPromises()
 
     expect(wrapper.get('.backlog-card__menu summary').attributes('aria-label')).toContain(
-      'Fresh Game',
+      'Returning Game',
     )
+    expect(wrapper.get('.backlog-card__menu > button').text()).toContain('Retirar da rotação')
     await wrapper.get('.backlog-card__menu > button').trigger('click')
     await flushPromises()
 
-    expect(gameServiceMocks.deleteGameRecommendation).toHaveBeenCalledOnce()
-    expect(campaign.init).toHaveBeenCalledOnce()
-    expect(wrapper.text()).not.toContain('Fresh Game')
+    expect(gameServiceMocks.retireGameFromRotation).toHaveBeenCalledWith(2)
+    expect(wrapper.text()).toContain('Fresh Game')
+    expect(wrapper.text()).not.toContain('Returning Game')
     expect(messageMocks.success).toHaveBeenCalledWith(
-      'Fresh Game saiu das Brasas. Os detalhes continuam guardados.',
+      'Returning Game saiu das próximas rotações. O jogo e seus detalhes continuam guardados.',
     )
   })
 

--- a/client/src/components/__tests__/Backlog.spec.ts
+++ b/client/src/components/__tests__/Backlog.spec.ts
@@ -1,6 +1,8 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
 import Backlog from '@/views/Backlog.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const gameServiceMocks = vi.hoisted(() => ({
   getGameBacklog: vi.fn(),
@@ -11,7 +13,11 @@ const gameServiceMocks = vi.hoisted(() => ({
 vi.mock('@/services/gameService', () => gameServiceMocks)
 
 describe('Backlog', () => {
+  let pinia: Pinia
+
   beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
     gameServiceMocks.getGameBacklog.mockResolvedValue({
       retirementThreshold: 3,
       targetPoolSize: 5,
@@ -39,7 +45,7 @@ describe('Backlog', () => {
   })
 
   it('separates pristine suggestions into the next-vote shelf', async () => {
-    const wrapper = mount(Backlog)
+    const wrapper = mount(Backlog, { global: { plugins: [pinia] } })
     await flushPromises()
 
     const nextVoteShelf = wrapper.get('.backlog-shelf--next-vote')
@@ -76,10 +82,28 @@ describe('Backlog', () => {
       ],
     })
 
-    const wrapper = mount(Backlog)
+    const wrapper = mount(Backlog, { global: { plugins: [pinia] } })
     await flushPromises()
 
     expect(wrapper.find('.backlog-shelf--next-vote').exists()).toBe(false)
     expect(wrapper.text()).toContain('Waiting Game')
+  })
+
+  it('shows the conductor entry only to the configured owner', async () => {
+    const auth = useAuthStore()
+    auth.user = { id: 1, name: 'Proper Pedestrian', isAdmin: true }
+    const ownerView = mount(Backlog, {
+      global: {
+        plugins: [pinia],
+        stubs: { RouterLink: { template: '<a><slot /></a>' } },
+      },
+    })
+    await flushPromises()
+
+    expect(ownerView.get('.backlog-conductor-link').text()).toContain('Conduzir o ciclo')
+
+    auth.user = { id: 2, name: 'Someone else', isAdmin: false }
+    await ownerView.vm.$nextTick()
+    expect(ownerView.find('.backlog-conductor-link').exists()).toBe(false)
   })
 })

--- a/client/src/components/__tests__/Backlog.spec.ts
+++ b/client/src/components/__tests__/Backlog.spec.ts
@@ -3,14 +3,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia, type Pinia } from 'pinia'
 import Backlog from '@/views/Backlog.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
 
 const gameServiceMocks = vi.hoisted(() => ({
   getGameBacklog: vi.fn(),
   getGameCover: vi.fn(() => ''),
   formatDurationLabel: vi.fn(() => ''),
+  deleteGameRecommendation: vi.fn(),
 }))
+const messageMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
 
 vi.mock('@/services/gameService', () => gameServiceMocks)
+vi.mock('naive-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('naive-ui')>()),
+  useMessage: () => messageMocks,
+}))
 
 describe('Backlog', () => {
   let pinia: Pinia
@@ -18,6 +25,7 @@ describe('Backlog', () => {
   beforeEach(() => {
     pinia = createPinia()
     setActivePinia(pinia)
+    gameServiceMocks.deleteGameRecommendation.mockResolvedValue(undefined)
     gameServiceMocks.getGameBacklog.mockResolvedValue({
       retirementThreshold: 3,
       targetPoolSize: 5,
@@ -55,6 +63,8 @@ describe('Backlog', () => {
     expect(nextVoteShelf.text()).toContain('+1')
     expect(nextVoteShelf.text()).toContain('jogo das Brasas')
     expect(nextVoteShelf.text()).not.toContain('Returning Game')
+    expect(wrapper.get('.backlog-overview').text()).toContain('1 jogo à espera da fogueira')
+    expect(wrapper.find('.backlog-card__menu').exists()).toBe(false)
 
     const regularShelf = wrapper
       .findAll('.backlog-shelf')
@@ -87,6 +97,148 @@ describe('Backlog', () => {
 
     expect(wrapper.find('.backlog-shelf--next-vote').exists()).toBe(false)
     expect(wrapper.text()).toContain('Waiting Game')
+  })
+
+  it('moves active pool games out of the waiting shelf while voting is open', async () => {
+    gameServiceMocks.getGameBacklog.mockResolvedValue({
+      retirementThreshold: 3,
+      targetPoolSize: 5,
+      nextVoteFillCount: 0,
+      rubble: [],
+      games: [
+        {
+          id: 1,
+          title: 'Fresh Game',
+          suggestion: true,
+          electionAppearances: 0,
+          guaranteedNextVote: true,
+          recommendedBy: [{ id: 10, name: 'Ana', avatar: null }],
+        },
+        {
+          id: 2,
+          title: 'Returning Game',
+          suggestion: true,
+          electionAppearances: 1,
+          guaranteedNextVote: false,
+          recommendedBy: [],
+        },
+        {
+          id: 3,
+          title: 'Waiting Game',
+          suggestion: true,
+          electionAppearances: 1,
+          guaranteedNextVote: false,
+          recommendedBy: [],
+        },
+      ],
+    })
+    const campaign = useCampaignStore()
+    campaign.electionActive = true
+    campaign.election = {
+      id: 9,
+      options: [
+        { id: 11, game: { id: 1, title: 'Fresh Game', suggestion: true } },
+        { id: 12, game: { id: 2, title: 'Returning Game', suggestion: true } },
+      ],
+    }
+
+    const wrapper = mount(Backlog, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(wrapper.find('.backlog-shelf--next-vote').exists()).toBe(false)
+    const currentVoteShelf = wrapper.get('.backlog-shelf--current-vote')
+    expect(currentVoteShelf.text()).toContain('Na votação atual')
+    expect(currentVoteShelf.text()).toContain('Fresh Game')
+    expect(currentVoteShelf.text()).toContain('Returning Game')
+    expect(currentVoteShelf.text()).not.toContain('Waiting Game')
+    expect(currentVoteShelf.findAll('.backlog-card--current-vote')).toHaveLength(2)
+    expect(currentVoteShelf.findAll('.backlog-card__vote-state--current')).toHaveLength(2)
+    expect(wrapper.get('.backlog-overview').text()).toContain('1 jogo à espera da fogueira')
+
+    const waitingShelf = wrapper
+      .findAll('.backlog-shelf')
+      .find(
+        (shelf) =>
+          !shelf.classes().includes('backlog-shelf--next-vote') &&
+          !shelf.classes().includes('backlog-shelf--current-vote'),
+      )
+    expect(waitingShelf?.text()).toContain('Waiting Game')
+    expect(waitingShelf?.text()).not.toContain('Fresh Game')
+    expect(waitingShelf?.text()).not.toContain('Returning Game')
+  })
+
+  it('lets the recommender withdraw their guaranteed game from its card menu', async () => {
+    const auth = useAuthStore()
+    auth.user = { id: 10, name: 'Ana', isAdmin: false }
+    const campaign = useCampaignStore()
+    campaign.campaignUser = {
+      id: 5,
+      player: auth.user,
+      played_the_game: false,
+      finished_the_game: false,
+      suggested_a_game: true,
+      suggestedGame: { id: 1, title: 'Fresh Game', suggestion: true },
+      partook_in_the_meeting: false,
+      tokens: 0,
+    }
+    vi.spyOn(campaign, 'init').mockResolvedValue()
+    gameServiceMocks.getGameBacklog
+      .mockResolvedValueOnce({
+        retirementThreshold: 3,
+        targetPoolSize: 5,
+        nextVoteFillCount: 1,
+        rubble: [],
+        games: [
+          {
+            id: 1,
+            title: 'Fresh Game',
+            suggestion: true,
+            electionAppearances: 0,
+            guaranteedNextVote: true,
+            recommendedBy: [{ id: 10, name: 'Ana', avatar: null }],
+          },
+          {
+            id: 2,
+            title: 'Returning Game',
+            suggestion: true,
+            electionAppearances: 1,
+            guaranteedNextVote: false,
+            recommendedBy: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        retirementThreshold: 3,
+        targetPoolSize: 5,
+        nextVoteFillCount: 1,
+        rubble: [],
+        games: [
+          {
+            id: 2,
+            title: 'Returning Game',
+            suggestion: true,
+            electionAppearances: 1,
+            guaranteedNextVote: false,
+            recommendedBy: [],
+          },
+        ],
+      })
+
+    const wrapper = mount(Backlog, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(wrapper.get('.backlog-card__menu summary').attributes('aria-label')).toContain(
+      'Fresh Game',
+    )
+    await wrapper.get('.backlog-card__menu > button').trigger('click')
+    await flushPromises()
+
+    expect(gameServiceMocks.deleteGameRecommendation).toHaveBeenCalledOnce()
+    expect(campaign.init).toHaveBeenCalledOnce()
+    expect(wrapper.text()).not.toContain('Fresh Game')
+    expect(messageMocks.success).toHaveBeenCalledWith(
+      'Fresh Game saiu das Brasas. Os detalhes continuam guardados.',
+    )
   })
 
   it('shows the conductor entry only to the configured owner', async () => {

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -13,6 +13,9 @@ const cycleServiceMocks = vi.hoisted(() => ({
   previewCycleTransition: vi.fn(),
   applyCycleTransition: vi.fn(),
 }))
+const gameServiceMocks = vi.hoisted(() => ({
+  getGameBacklog: vi.fn(),
+}))
 const messageMocks = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
@@ -20,7 +23,11 @@ const messageMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/services/cycleService', () => cycleServiceMocks)
-vi.mock('@/services/gameService', () => ({ getGameCover: vi.fn(() => '') }))
+vi.mock('@/services/gameService', () => ({
+  getGameBacklog: gameServiceMocks.getGameBacklog,
+  getGameCover: vi.fn(() => ''),
+  formatDurationLabel: vi.fn((label?: string | null) => label ?? ''),
+}))
 vi.mock('vue-router', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ replace: vi.fn() }),
@@ -58,6 +65,30 @@ describe('CycleConductor', () => {
       nextCampaign: { month: 'Setembro', year: '2026' },
       discordConfigured: true,
     })
+    gameServiceMocks.getGameBacklog.mockResolvedValue({
+      games: [
+        {
+          id: 1,
+          title: 'Suggested Game',
+          suggestion: true,
+          electionAppearances: 2,
+          guaranteedNextVote: true,
+          recommendedBy: [{ id: 7, name: 'Ana', avatar: null }],
+        },
+        {
+          id: 2,
+          title: 'Random Game',
+          suggestion: true,
+          electionAppearances: 1,
+          guaranteedNextVote: false,
+          recommendedBy: [{ id: 8, name: 'Bia', avatar: null }],
+        },
+      ],
+      rubble: [],
+      retirementThreshold: 3,
+      targetPoolSize: 5,
+      nextVoteFillCount: 4,
+    })
     cycleServiceMocks.drawCyclePool.mockResolvedValue({
       campaignId: 17,
       targetPoolSize: 5,
@@ -90,6 +121,8 @@ describe('CycleConductor', () => {
     expect(wrapper.text()).toContain('Formar a próxima votação')
     expect(wrapper.text()).toContain('Suggested Game')
     expect(wrapper.text()).toContain('nenhum deles será removido')
+    expect(wrapper.findAll('.backlog-card')).toHaveLength(1)
+    expect(wrapper.text()).toContain('2 / 3')
     expect(wrapper.get('[data-testid="draw-games"]').classes()).not.toContain('n-button')
     await wrapper.get('[data-testid="draw-games"]').trigger('click')
     await flushPromises()
@@ -101,12 +134,16 @@ describe('CycleConductor', () => {
 
     expect(wrapper.text()).toContain('Random Game')
     expect(wrapper.text()).toContain('Suggested Game')
+    expect(wrapper.findAll('.backlog-card')).toHaveLength(2)
     expect(wrapper.text()).toContain('A roda está formada')
 
     await wrapper.get('[data-testid="start-election"]').trigger('click')
     await flushPromises()
 
-    expect(cycleServiceMocks.startCycleElection).toHaveBeenCalledWith('signed-draw', undefined)
+    expect(cycleServiceMocks.startCycleElection).toHaveBeenCalledWith(
+      'signed-draw',
+      '2026-09-01T00:00:00-03:00',
+    )
     expect(messageMocks.success).toHaveBeenCalledWith(
       'A votação está acesa. O grupo já pode votar.',
     )
@@ -122,6 +159,7 @@ describe('CycleConductor', () => {
     await wrapper.get('.reveal-card--hidden').trigger('click')
 
     const deadlineInput = wrapper.get<HTMLInputElement>('input[type="datetime-local"]')
+    expect(deadlineInput.element.value).toBe('2026-09-01T00:00')
     const mondayButton = wrapper
       .findAll('button')
       .find((button) => button.text().includes('Virada para segunda'))
@@ -146,6 +184,7 @@ describe('CycleConductor', () => {
         current: true,
         electionActive: true,
         electionStartedAt: '2026-08-05T20:00:00-03:00',
+        meetingAt: '2026-08-27T20:00:00-03:00',
         pool: { options: [{ id: 1, game: { id: 1, title: 'Game' } }] },
       },
       guaranteedGames: [],
@@ -166,9 +205,24 @@ describe('CycleConductor', () => {
     const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
     await flushPromises()
 
+    expect(wrapper.text()).toContain('Os resultados estão ocultos')
+    expect(wrapper.text()).not.toContain('3 tokens')
+    expect(wrapper.find('.result-list').exists()).toBe(false)
+    await wrapper.get('[data-testid="reveal-results"]').trigger('click')
+    expect(wrapper.text()).toContain('3 tokens')
+    expect(wrapper.get<HTMLInputElement>('input[type="datetime-local"]').element.value).toBe(
+      '2026-09-24T20:00',
+    )
+    const hideResults = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Ocultar resultados'))
+    await hideResults?.trigger('click')
+    expect(wrapper.text()).not.toContain('3 tokens')
+    expect(wrapper.find('.result-list').exists()).toBe(false)
+
     await wrapper.get('.cycle-undo .game-links button').trigger('click')
     expect(cycleServiceMocks.cancelCycleElection).not.toHaveBeenCalled()
-    expect(wrapper.text()).toContain('1 voto será descartado')
+    expect(wrapper.text()).toContain('os votos já registrados serão descartados')
 
     await wrapper.get('[data-testid="confirm-cancel-election"]').trigger('click')
     await flushPromises()

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -192,7 +192,7 @@ describe('CycleConductor', () => {
               game: {
                 id: 1,
                 title: 'Game',
-                summary: 'Uma frase curta da Steam. O restante não entra.',
+                summary: 'Uma descrição curta da Steam. A segunda frase também permanece.',
               },
             },
           ],
@@ -222,7 +222,7 @@ describe('CycleConductor', () => {
     expect(wrapper.find('.result-list').exists()).toBe(true)
     expect(wrapper.find('.transition-form').exists()).toBe(true)
     expect(wrapper.get<HTMLTextAreaElement>('textarea').element.value).toBe(
-      'Uma frase curta da Steam.',
+      'Uma descrição curta da Steam. A segunda frase também permanece.',
     )
     expect(wrapper.findAll('.cycle-field > span').some((field) => field.text() === 'Local')).toBe(
       false,

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -9,6 +9,7 @@ const cycleServiceMocks = vi.hoisted(() => ({
   getCycleOverview: vi.fn(),
   drawCyclePool: vi.fn(),
   startCycleElection: vi.fn(),
+  cancelCycleElection: vi.fn(),
   previewCycleTransition: vi.fn(),
   applyCycleTransition: vi.fn(),
 }))
@@ -106,5 +107,44 @@ describe('CycleConductor', () => {
     expect(messageMocks.success).toHaveBeenCalledWith(
       'A votação está acesa. O grupo já pode votar.',
     )
+  })
+
+  it('requires a second click before undoing an opened election', async () => {
+    cycleServiceMocks.getCycleOverview.mockResolvedValue({
+      campaign: {
+        id: 17,
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        electionActive: true,
+        electionStartedAt: '2026-08-05T20:00:00-03:00',
+        pool: { options: [{ id: 1, game: { id: 1, title: 'Game' } }] },
+      },
+      guaranteedGames: [],
+      electionResult: [{ optionId: 1, gameId: 1, game: 'Game', tokens: 3, voters: ['Ana'] }],
+      targetPoolSize: 5,
+      nextCampaign: { month: 'Setembro', year: '2026' },
+      discordConfigured: false,
+    })
+    cycleServiceMocks.cancelCycleElection.mockResolvedValue({
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      electionActive: false,
+      electionStartedAt: null,
+      pool: null,
+    })
+    const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    await wrapper.get('.cycle-undo .cycle-quiet').trigger('click')
+    expect(cycleServiceMocks.cancelCycleElection).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('1 voto será descartado')
+
+    await wrapper.get('.cycle-danger').trigger('click')
+    await flushPromises()
+
+    expect(cycleServiceMocks.cancelCycleElection).toHaveBeenCalledOnce()
   })
 })

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -185,7 +185,18 @@ describe('CycleConductor', () => {
         electionActive: true,
         electionStartedAt: '2026-08-05T20:00:00-03:00',
         meetingAt: '2026-08-27T20:00:00-03:00',
-        pool: { options: [{ id: 1, game: { id: 1, title: 'Game' } }] },
+        pool: {
+          options: [
+            {
+              id: 1,
+              game: {
+                id: 1,
+                title: 'Game',
+                summary: 'Uma frase curta da Steam. O restante não entra.',
+              },
+            },
+          ],
+        },
       },
       guaranteedGames: [],
       electionResult: [{ optionId: 1, gameId: 1, game: 'Game', tokens: 3, voters: ['Ana'] }],
@@ -206,8 +217,16 @@ describe('CycleConductor', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Os resultados estão ocultos')
+    expect(wrapper.text()).toContain('Game')
     expect(wrapper.text()).not.toContain('3 tokens')
-    expect(wrapper.find('.result-list').exists()).toBe(false)
+    expect(wrapper.find('.result-list').exists()).toBe(true)
+    expect(wrapper.find('.transition-form').exists()).toBe(true)
+    expect(wrapper.get<HTMLTextAreaElement>('textarea').element.value).toBe(
+      'Uma frase curta da Steam.',
+    )
+    expect(wrapper.findAll('.cycle-field > span').some((field) => field.text() === 'Local')).toBe(
+      false,
+    )
     await wrapper.get('[data-testid="reveal-results"]').trigger('click')
     expect(wrapper.text()).toContain('3 tokens')
     expect(wrapper.get<HTMLInputElement>('input[type="datetime-local"]').element.value).toBe(
@@ -218,7 +237,8 @@ describe('CycleConductor', () => {
       .find((button) => button.text().includes('Ocultar resultados'))
     await hideResults?.trigger('click')
     expect(wrapper.text()).not.toContain('3 tokens')
-    expect(wrapper.find('.result-list').exists()).toBe(false)
+    expect(wrapper.find('.result-list').exists()).toBe(true)
+    expect(wrapper.find('.transition-form').exists()).toBe(true)
 
     await wrapper.get('.cycle-undo .game-links button').trigger('click')
     expect(cycleServiceMocks.cancelCycleElection).not.toHaveBeenCalled()

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia, type Pinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import CycleConductor from '@/views/CycleConductor.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useCampaignStore } from '@/stores/campaign'
@@ -63,10 +63,7 @@ describe('CycleConductor', () => {
       targetPoolSize: 5,
       guaranteedGames: [{ id: 1, title: 'Suggested Game', suggestion: true }],
       selectedFillers: [{ id: 2, title: 'Random Game', suggestion: true }],
-      revealOrder: [
-        { id: 2, title: 'Random Game', suggestion: true, mainExtraHours: 10 },
-        { id: 1, title: 'Suggested Game', suggestion: true, mainExtraHours: 12 },
-      ],
+      revealOrder: [{ id: 2, title: 'Random Game', suggestion: true, mainExtraHours: 10 }],
       excludedUnverified: [],
       selectionToken: 'signed-draw',
       warnings: [],
@@ -82,18 +79,24 @@ describe('CycleConductor', () => {
     })
   })
 
-  it('reveals a signed random selection before opening the election', async () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows guaranteed suggestions first and reveals only the random selection', async () => {
     const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
     await flushPromises()
 
     expect(wrapper.text()).toContain('Formar a próxima votação')
+    expect(wrapper.text()).toContain('Suggested Game')
+    expect(wrapper.text()).toContain('nenhum deles será removido')
+    expect(wrapper.get('[data-testid="draw-games"]').classes()).not.toContain('n-button')
     await wrapper.get('[data-testid="draw-games"]').trigger('click')
     await flushPromises()
 
     expect(cycleServiceMocks.drawCyclePool).toHaveBeenCalledOnce()
     expect(wrapper.findAll('.reveal-card')).toHaveLength(1)
 
-    await wrapper.get('.reveal-card--hidden').trigger('click')
     await wrapper.get('.reveal-card--hidden').trigger('click')
 
     expect(wrapper.text()).toContain('Random Game')
@@ -107,6 +110,31 @@ describe('CycleConductor', () => {
     expect(messageMocks.success).toHaveBeenCalledWith(
       'A votação está acesa. O grupo já pode votar.',
     )
+  })
+
+  it('sets election deadlines at the next Monday and month boundaries', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 5, 12, 0, 0))
+    const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
+    await flushPromises()
+    await wrapper.get('[data-testid="draw-games"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('.reveal-card--hidden').trigger('click')
+
+    const deadlineInput = wrapper.get<HTMLInputElement>('input[type="datetime-local"]')
+    const mondayButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Virada para segunda'))
+    const monthButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Virada do mês'))
+
+    expect(mondayButton).toBeDefined()
+    expect(monthButton).toBeDefined()
+    await mondayButton?.trigger('click')
+    expect(deadlineInput.element.value).toBe('2026-08-10T00:00')
+    await monthButton?.trigger('click')
+    expect(deadlineInput.element.value).toBe('2026-09-01T00:00')
   })
 
   it('requires a second click before undoing an opened election', async () => {
@@ -138,7 +166,7 @@ describe('CycleConductor', () => {
     const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
     await flushPromises()
 
-    await wrapper.get('.cycle-undo .n-button').trigger('click')
+    await wrapper.get('.cycle-undo .game-links button').trigger('click')
     expect(cycleServiceMocks.cancelCycleElection).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('1 voto será descartado')
 

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -87,7 +87,7 @@ describe('CycleConductor', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Formar a próxima votação')
-    await wrapper.get('.draw-hearth .cycle-primary').trigger('click')
+    await wrapper.get('[data-testid="draw-games"]').trigger('click')
     await flushPromises()
 
     expect(cycleServiceMocks.drawCyclePool).toHaveBeenCalledOnce()
@@ -100,7 +100,7 @@ describe('CycleConductor', () => {
     expect(wrapper.text()).toContain('Suggested Game')
     expect(wrapper.text()).toContain('A roda está formada')
 
-    await wrapper.get('.election-launch .cycle-primary').trigger('click')
+    await wrapper.get('[data-testid="start-election"]').trigger('click')
     await flushPromises()
 
     expect(cycleServiceMocks.startCycleElection).toHaveBeenCalledWith('signed-draw', undefined)
@@ -138,11 +138,11 @@ describe('CycleConductor', () => {
     const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
     await flushPromises()
 
-    await wrapper.get('.cycle-undo .cycle-quiet').trigger('click')
+    await wrapper.get('.cycle-undo .n-button').trigger('click')
     expect(cycleServiceMocks.cancelCycleElection).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('1 voto será descartado')
 
-    await wrapper.get('.cycle-danger').trigger('click')
+    await wrapper.get('[data-testid="confirm-cancel-election"]').trigger('click')
     await flushPromises()
 
     expect(cycleServiceMocks.cancelCycleElection).toHaveBeenCalledOnce()

--- a/client/src/components/__tests__/CycleConductor.spec.ts
+++ b/client/src/components/__tests__/CycleConductor.spec.ts
@@ -1,0 +1,110 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CycleConductor from '@/views/CycleConductor.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
+
+const cycleServiceMocks = vi.hoisted(() => ({
+  getCycleOverview: vi.fn(),
+  drawCyclePool: vi.fn(),
+  startCycleElection: vi.fn(),
+  previewCycleTransition: vi.fn(),
+  applyCycleTransition: vi.fn(),
+}))
+const messageMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+}))
+
+vi.mock('@/services/cycleService', () => cycleServiceMocks)
+vi.mock('@/services/gameService', () => ({ getGameCover: vi.fn(() => '') }))
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+vi.mock('naive-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('naive-ui')>()),
+  useMessage: () => messageMocks,
+}))
+
+describe('CycleConductor', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    const auth = useAuthStore()
+    auth.user = { id: 1, name: 'Conductor', isAdmin: true }
+    auth.isAuthenticated = true
+    auth.loading = false
+    vi.spyOn(auth, 'init').mockResolvedValue()
+    vi.spyOn(useCampaignStore(), 'init').mockResolvedValue()
+
+    cycleServiceMocks.getCycleOverview.mockResolvedValue({
+      campaign: {
+        id: 17,
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        electionActive: false,
+        pool: null,
+      },
+      guaranteedGames: [{ id: 1, title: 'Suggested Game', suggestion: true }],
+      electionResult: [],
+      targetPoolSize: 5,
+      nextCampaign: { month: 'Setembro', year: '2026' },
+      discordConfigured: true,
+    })
+    cycleServiceMocks.drawCyclePool.mockResolvedValue({
+      campaignId: 17,
+      targetPoolSize: 5,
+      guaranteedGames: [{ id: 1, title: 'Suggested Game', suggestion: true }],
+      selectedFillers: [{ id: 2, title: 'Random Game', suggestion: true }],
+      revealOrder: [
+        { id: 2, title: 'Random Game', suggestion: true, mainExtraHours: 10 },
+        { id: 1, title: 'Suggested Game', suggestion: true, mainExtraHours: 12 },
+      ],
+      excludedUnverified: [],
+      selectionToken: 'signed-draw',
+      warnings: [],
+    })
+    cycleServiceMocks.startCycleElection.mockResolvedValue({
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      electionActive: true,
+      electionStartedAt: '2026-08-05T20:00:00-03:00',
+      pool: { options: [] },
+    })
+  })
+
+  it('reveals a signed random selection before opening the election', async () => {
+    const wrapper = mount(CycleConductor, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Formar a próxima votação')
+    await wrapper.get('.draw-hearth .cycle-primary').trigger('click')
+    await flushPromises()
+
+    expect(cycleServiceMocks.drawCyclePool).toHaveBeenCalledOnce()
+    expect(wrapper.findAll('.reveal-card')).toHaveLength(1)
+
+    await wrapper.get('.reveal-card--hidden').trigger('click')
+    await wrapper.get('.reveal-card--hidden').trigger('click')
+
+    expect(wrapper.text()).toContain('Random Game')
+    expect(wrapper.text()).toContain('Suggested Game')
+    expect(wrapper.text()).toContain('A roda está formada')
+
+    await wrapper.get('.election-launch .cycle-primary').trigger('click')
+    await flushPromises()
+
+    expect(cycleServiceMocks.startCycleElection).toHaveBeenCalledWith('signed-draw', undefined)
+    expect(messageMocks.success).toHaveBeenCalledWith(
+      'A votação está acesa. O grupo já pode votar.',
+    )
+  })
+})

--- a/client/src/components/__tests__/ElectionView.spec.ts
+++ b/client/src/components/__tests__/ElectionView.spec.ts
@@ -82,7 +82,7 @@ describe('ElectionView', () => {
     expect(wrapper.findAll('.election-card')).toHaveLength(2)
     expect(wrapper.text()).toContain('The First Game')
     expect(wrapper.text()).toContain('12 horas')
-    expect(wrapper.text()).toContain('Apresentado por Bia e Caio')
+    expect(wrapper.text()).toContain('Sugerido por Bia e Caio')
     expect(wrapper.text()).not.toContain('12 tokens')
     expect(wrapper.text()).not.toContain('4 tokens')
 

--- a/client/src/components/__tests__/ElectionView.spec.ts
+++ b/client/src/components/__tests__/ElectionView.spec.ts
@@ -51,6 +51,10 @@ describe('ElectionView', () => {
             summary: 'A primeira jornada da roda.',
             durationLabel: '12 horas',
             steam: 'https://store.steampowered.com/app/1',
+            recommendedBy: [
+              { id: 17, name: 'Bia', avatar: null },
+              { id: 18, name: 'Caio', avatar: null },
+            ],
           },
         },
         {
@@ -78,6 +82,7 @@ describe('ElectionView', () => {
     expect(wrapper.findAll('.election-card')).toHaveLength(2)
     expect(wrapper.text()).toContain('The First Game')
     expect(wrapper.text()).toContain('12 horas')
+    expect(wrapper.text()).toContain('Apresentado por Bia e Caio')
     expect(wrapper.text()).not.toContain('12 tokens')
     expect(wrapper.text()).not.toContain('4 tokens')
 

--- a/client/src/components/__tests__/ElectionView.spec.ts
+++ b/client/src/components/__tests__/ElectionView.spec.ts
@@ -78,6 +78,8 @@ describe('ElectionView', () => {
   it('presents the games without exposing live vote information', async () => {
     const wrapper = mount(ElectionView, { global: { plugins: [pinia] } })
 
+    expect(wrapper.get('.election-hearth__heading > div > span').text()).toBe('Votação')
+    expect(wrapper.get('#election-heading').text()).toBe('Acesa')
     expect(wrapper.get('.election-hearth').text()).toContain('Qual jogo recebe a próxima chama?')
     expect(wrapper.findAll('.election-card')).toHaveLength(2)
     expect(wrapper.text()).toContain('The First Game')

--- a/client/src/components/__tests__/ElectionView.spec.ts
+++ b/client/src/components/__tests__/ElectionView.spec.ts
@@ -1,0 +1,107 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ElectionView from '@/components/ElectionView.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
+
+const campaignServiceMocks = vi.hoisted(() => ({
+  vote: vi.fn(),
+  undoVote: vi.fn(),
+}))
+const messageMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}))
+
+vi.mock('@/services/campaignService', () => campaignServiceMocks)
+vi.mock('@/services/gameService', () => ({
+  getGameCover: vi.fn(() => '/cover.jpg'),
+  formatDurationLabel: vi.fn((label?: string | null) => label ?? ''),
+}))
+vi.mock('naive-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('naive-ui')>()),
+  useMessage: () => messageMocks,
+}))
+
+describe('ElectionView', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+
+    const auth = useAuthStore()
+    auth.user = { id: 7, name: 'Ana', isAdmin: false }
+    auth.isAuthenticated = true
+    auth.loading = false
+
+    const campaign = useCampaignStore()
+    campaign.electionActive = true
+    campaign.election = {
+      id: 9,
+      options: [
+        {
+          id: 31,
+          tokens: 12,
+          players: [],
+          game: {
+            id: 1,
+            title: 'The First Game',
+            suggestion: true,
+            summary: 'A primeira jornada da roda.',
+            durationLabel: '12 horas',
+            steam: 'https://store.steampowered.com/app/1',
+          },
+        },
+        {
+          id: 32,
+          tokens: 4,
+          players: [],
+          game: {
+            id: 2,
+            title: 'The Second Game',
+            suggestion: true,
+            summary: 'A segunda jornada da roda.',
+          },
+        },
+      ],
+    }
+    vi.spyOn(campaign, 'init').mockResolvedValue()
+    campaignServiceMocks.vote.mockResolvedValue({ id: 17 })
+    campaignServiceMocks.undoVote.mockResolvedValue({ id: 17 })
+  })
+
+  it('presents the games without exposing live vote information', async () => {
+    const wrapper = mount(ElectionView, { global: { plugins: [pinia] } })
+
+    expect(wrapper.get('.election-hearth').text()).toContain('Qual jogo recebe a próxima chama?')
+    expect(wrapper.findAll('.election-card')).toHaveLength(2)
+    expect(wrapper.text()).toContain('The First Game')
+    expect(wrapper.text()).toContain('12 horas')
+    expect(wrapper.text()).not.toContain('12 tokens')
+    expect(wrapper.text()).not.toContain('4 tokens')
+
+    const firstVoteButton = wrapper.findAll('.game-links button')[0]
+    await firstVoteButton.trigger('click')
+    await flushPromises()
+
+    expect(campaignServiceMocks.vote).toHaveBeenCalledWith(31)
+    expect(useCampaignStore().init).toHaveBeenCalledWith({ id: 17 })
+  })
+
+  it('shows a private receipt and lets the current voter withdraw', async () => {
+    const campaign = useCampaignStore()
+    campaign.election!.options[0].players = [{ id: 7, name: 'Ana', isAdmin: false }]
+    const wrapper = mount(ElectionView, { global: { plugins: [pinia] } })
+
+    expect(wrapper.text()).toContain('Seu voto está guardado')
+    expect(wrapper.text()).toContain('Sua escolha')
+    expect(wrapper.text()).toContain('Você já escolheu outra chama.')
+
+    await wrapper.get('.election-card--selected .game-links button').trigger('click')
+    await flushPromises()
+
+    expect(campaignServiceMocks.undoVote).toHaveBeenCalledOnce()
+    expect(useCampaignStore().init).toHaveBeenCalledWith({ id: 17 })
+  })
+})

--- a/client/src/components/__tests__/ElectionView.spec.ts
+++ b/client/src/components/__tests__/ElectionView.spec.ts
@@ -80,7 +80,6 @@ describe('ElectionView', () => {
 
     expect(wrapper.get('.election-hearth__heading > div > span').text()).toBe('Votação')
     expect(wrapper.get('#election-heading').text()).toBe('Acesa')
-    expect(wrapper.get('.election-hearth').text()).toContain('Qual jogo recebe a próxima chama?')
     expect(wrapper.findAll('.election-card')).toHaveLength(2)
     expect(wrapper.text()).toContain('The First Game')
     expect(wrapper.text()).toContain('12 horas')
@@ -101,14 +100,28 @@ describe('ElectionView', () => {
     campaign.election!.options[0].players = [{ id: 7, name: 'Ana', isAdmin: false }]
     const wrapper = mount(ElectionView, { global: { plugins: [pinia] } })
 
-    expect(wrapper.text()).toContain('Seu voto está guardado')
+    expect(wrapper.text()).toContain('Seu voto foi lançado à fogueira')
     expect(wrapper.text()).toContain('Sua escolha')
-    expect(wrapper.text()).toContain('Você já escolheu outra chama.')
+    expect(wrapper.text()).not.toContain('Você já escolheu outra chama.')
 
     await wrapper.get('.election-card--selected .game-links button').trigger('click')
     await flushPromises()
 
     expect(campaignServiceMocks.undoVote).toHaveBeenCalledOnce()
     expect(useCampaignStore().init).toHaveBeenCalledWith({ id: 17 })
+  })
+
+  it('keeps anonymous voting guidance out of every game card', () => {
+    const auth = useAuthStore()
+    auth.user = null
+    auth.isAuthenticated = false
+    const wrapper = mount(ElectionView, { global: { plugins: [pinia] } })
+
+    expect(wrapper.get('.election-hearth__receipt--locked').text()).toContain(
+      'Revele-se à fogueira para lançar seu voto',
+    )
+    expect(wrapper.findAll('.election-card footer')).toHaveLength(0)
+    expect(wrapper.findAll('.election-card button')).toHaveLength(0)
+    expect(wrapper.text()).not.toContain('Revele-se pelo Discord para votar.')
   })
 })

--- a/client/src/components/__tests__/Home.spec.ts
+++ b/client/src/components/__tests__/Home.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Home from '@/views/Home.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
+
+const messageMocks = vi.hoisted(() => ({ error: vi.fn() }))
+
+vi.mock('naive-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('naive-ui')>()),
+  useMessage: () => messageMocks,
+}))
+
+describe('Home', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+
+    const auth = useAuthStore()
+    auth.user = { id: 7, name: 'Ana', isAdmin: false }
+    auth.isAuthenticated = true
+    auth.loading = false
+
+    const campaign = useCampaignStore()
+    campaign.campaign = {
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      electionActive: true,
+      pool: { options: [] },
+    }
+    vi.spyOn(campaign, 'init').mockResolvedValue()
+  })
+
+  it('keeps game recommendations off the page while voting is active', async () => {
+    const campaign = useCampaignStore()
+    const wrapper = mount(Home, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          ElectionView: { template: '<div data-testid="election" />' },
+          CurrentGameHearth: { template: '<div data-testid="current-game" />' },
+          GameRecommendation: { template: '<div data-testid="recommendation" />' },
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="recommendation"]').exists()).toBe(false)
+
+    campaign.campaign = { ...campaign.campaign!, electionActive: false }
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="recommendation"]').exists()).toBe(true)
+  })
+})

--- a/client/src/components/__tests__/TopNavigation.spec.ts
+++ b/client/src/components/__tests__/TopNavigation.spec.ts
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TopNavigation from '@/components/TopNavigation.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
+
+vi.mock('@/services/userService', () => ({
+  getUserTokenBreakdown: vi.fn(() => []),
+}))
+
+describe('TopNavigation', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+
+    const auth = useAuthStore()
+    auth.user = { id: 1, name: 'Proper Pedestrian', isAdmin: true }
+    auth.isAuthenticated = true
+    auth.loading = false
+    vi.spyOn(useCampaignStore(), 'init').mockResolvedValue()
+  })
+
+  const mountNavigation = () =>
+    mount(TopNavigation, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+          NPopover: { template: '<div><slot name="trigger" /><slot /></div>' },
+        },
+      },
+    })
+
+  it('keeps the shortcut hidden until the owner has opened an election', async () => {
+    const campaign = useCampaignStore()
+    campaign.campaign = {
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      electionActive: false,
+      electionStartedAt: null,
+      pool: null,
+    }
+    const wrapper = mountNavigation()
+
+    expect(wrapper.text()).not.toContain('Conduzir')
+
+    campaign.campaign = {
+      ...campaign.campaign,
+      electionActive: true,
+      electionStartedAt: '2026-08-05T20:00:00-03:00',
+      pool: { options: [{ id: 31, game: { id: 1, title: 'Game', suggestion: true } }] },
+    }
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Conduzir')
+  })
+
+  it('never exposes the shortcut to another user', async () => {
+    const auth = useAuthStore()
+    const campaign = useCampaignStore()
+    auth.user = { id: 2, name: 'Another traveler', isAdmin: false }
+    campaign.campaign = {
+      id: 17,
+      month: 'Agosto',
+      year: '2026',
+      current: true,
+      electionActive: true,
+      electionStartedAt: '2026-08-05T20:00:00-03:00',
+      pool: { options: [{ id: 31, game: { id: 1, title: 'Game', suggestion: true } }] },
+    }
+    const wrapper = mountNavigation()
+
+    expect(wrapper.text()).not.toContain('Conduzir')
+  })
+})

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import AuthCallbackPage from '@/views/AuthCallbackPage.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -49,6 +50,7 @@ const router = createRouter({
       meta: {
         pageTitle: 'Conduzir o ciclo',
         pageKicker: 'Da última brasa à próxima chama',
+        requiresConductor: true,
       },
     },
     {
@@ -66,6 +68,14 @@ const router = createRouter({
       },
     },
   ],
+})
+
+router.beforeEach(async (to) => {
+  if (!to.meta.requiresConductor) return true
+
+  const auth = useAuthStore()
+  await auth.init()
+  return auth.user?.isAdmin ? true : { name: 'home' }
 })
 
 export default router

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -43,6 +43,15 @@ const router = createRouter({
       redirect: '/brasas',
     },
     {
+      path: '/conduzir',
+      name: 'conduzir',
+      component: () => import('../views/CycleConductor.vue'),
+      meta: {
+        pageTitle: 'Conduzir o ciclo',
+        pageKicker: 'Da última brasa à próxima chama',
+      },
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: AuthCallbackPage,

--- a/client/src/services/cycleService.ts
+++ b/client/src/services/cycleService.ts
@@ -1,0 +1,49 @@
+import api from './api'
+import type { Campaign } from '@/types/Campaign'
+import type {
+  AppliedCycleTransition,
+  CycleDraw,
+  CycleOverview,
+  CycleTransitionInput,
+  CycleTransitionPreview,
+} from '@/types/Cycle'
+
+export const getCycleOverview = async (): Promise<CycleOverview> => {
+  const { data } = await api.get<CycleOverview>('/cycle/overview')
+  return data
+}
+
+export const drawCyclePool = async (): Promise<CycleDraw> => {
+  const { data } = await api.post<CycleDraw>('/cycle/draw')
+  return data
+}
+
+export const startCycleElection = async (
+  selectionToken: string,
+  electionEndsAt?: string,
+): Promise<Campaign> => {
+  const { data } = await api.post<Campaign>('/cycle/start-election', {
+    selectionToken,
+    electionEndsAt,
+  })
+  return data
+}
+
+export const previewCycleTransition = async (
+  input: CycleTransitionInput,
+): Promise<CycleTransitionPreview> => {
+  const { data } = await api.post<CycleTransitionPreview>('/cycle/transition/preview', input)
+  return data
+}
+
+export const applyCycleTransition = async (
+  input: CycleTransitionInput,
+  confirmationToken: string,
+): Promise<AppliedCycleTransition> => {
+  const { data } = await api.post<AppliedCycleTransition>('/cycle/transition/apply', {
+    ...input,
+    confirm: true,
+    confirmationToken,
+  })
+  return data
+}

--- a/client/src/services/cycleService.ts
+++ b/client/src/services/cycleService.ts
@@ -29,6 +29,11 @@ export const startCycleElection = async (
   return data
 }
 
+export const cancelCycleElection = async (): Promise<Campaign> => {
+  const { data } = await api.post<Campaign>('/cycle/cancel-election', { confirm: true })
+  return data
+}
+
 export const previewCycleTransition = async (
   input: CycleTransitionInput,
 ): Promise<CycleTransitionPreview> => {

--- a/client/src/services/gameService.ts
+++ b/client/src/services/gameService.ts
@@ -45,6 +45,10 @@ export const deleteGameRecommendation = async (): Promise<void> => {
   await api.delete('/games/recommendations')
 }
 
+export const retireGameFromRotation = async (gameId: number): Promise<void> => {
+  await api.delete(`/games/${gameId}/rotation`)
+}
+
 export const getGameCover = (game?: Game | null): string => {
   return game?.cover || ''
 }

--- a/client/src/types/Campaign.ts
+++ b/client/src/types/Campaign.ts
@@ -34,6 +34,9 @@ export interface Campaign {
   meetingLocation?: string | null
   meetingUrl?: string | null
   electionActive: boolean
+  electionStartedAt?: string | null
+  electionEndsAt?: string | null
+  electionClosedAt?: string | null
   pool?: Pool | null
   game?: Game | null
   players?: CampaignPlayer[]

--- a/client/src/types/Cycle.ts
+++ b/client/src/types/Cycle.ts
@@ -1,0 +1,122 @@
+import type { Campaign } from './Campaign'
+import type { Game } from './Game'
+
+export interface ElectionResultOption {
+  optionId: number
+  gameId: number
+  game: string
+  tokens: number
+  voters: string[]
+}
+
+export interface CycleOverview {
+  campaign: Campaign
+  guaranteedGames: Game[]
+  electionResult: ElectionResultOption[]
+  targetPoolSize: number
+  nextCampaign: { month: string; year: string }
+  discordConfigured: boolean
+}
+
+export interface CycleDraw {
+  campaignId: number
+  targetPoolSize: number
+  guaranteedGames: Game[]
+  selectedFillers: Game[]
+  revealOrder: Game[]
+  excludedUnverified: Game[]
+  excludedTooLong: Game[]
+  selectionToken: string
+  warnings: string[]
+}
+
+export interface DiscordChannelSummary {
+  id: string
+  name: string
+  type: number
+  parent_id: string | null
+  topic?: string | null
+}
+
+export interface DiscordTransitionInput {
+  enabled: boolean
+  oldChannelId?: string
+  discussionCategoryId?: string
+  historyCategoryId?: string
+  voiceChannelId?: string
+  newChannelName?: string
+  newChannelTopic?: string
+}
+
+export interface CycleTransitionInput {
+  winnerGameId?: number
+  month: string
+  year: string
+  description?: string
+  meetingAt?: string
+  meetingLocation?: string
+  discord?: DiscordTransitionInput
+  allowEarlyClose?: boolean
+}
+
+export interface DiscordTransitionPreview {
+  configured: boolean
+  enabled: boolean
+  guildId: string
+  channels: {
+    text: DiscordChannelSummary[]
+    categories: DiscordChannelSummary[]
+    voice: DiscordChannelSummary[]
+  }
+  plan: {
+    oldChannel: DiscordChannelSummary | null
+    discussionCategory: DiscordChannelSummary | null
+    historyCategory: DiscordChannelSummary | null
+    createHistoryCategory: boolean
+    newChannelName: string
+    newChannelTopic: string
+    existingNewChannel: DiscordChannelSummary | null
+    voiceChannel: DiscordChannelSummary | null
+    eventName: string | null
+    gameCard: {
+      title: string
+      description: string
+      url: string | null
+      imageUrl: string | null
+      details: string | null
+      marker: string
+    }
+  }
+  warnings: string[]
+  errors: string[]
+}
+
+export interface CycleTransitionPreview {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  confirmationToken: string | null
+  electionResult: ElectionResultOption[]
+  winner: Game | null
+  campaign: {
+    month: string
+    year: string
+    description: string
+    meetingAt: string | null
+    meetingLocation: string | null
+  } | null
+  discord: DiscordTransitionPreview | null
+}
+
+export interface AppliedCycleTransition {
+  campaign: Campaign
+  discord: {
+    archivedChannelId: string | null
+    historyCategoryId: string | null
+    newChannelId: string | null
+    eventId: string | null
+    eventUrl: string | null
+    gameMessageId: string | null
+    gameMessageUrl: string | null
+  }
+}

--- a/client/src/types/Game.ts
+++ b/client/src/types/Game.ts
@@ -11,6 +11,8 @@
   mainHours?: number | null
   mainExtraHours?: number | null
   howLongToBeatTitle?: string | null
+  researchCheckedAt?: string | null
+  researchStatus?: string | null
   recommendedBy?: GameRecommender[]
 }
 

--- a/client/src/types/User.ts
+++ b/client/src/types/User.ts
@@ -1,5 +1,6 @@
 ﻿export interface User {
   id: number
+  isAdmin?: boolean
   name?: string | null
   email?: string | null
   discord?: {

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import { LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
 import { NIcon, NModal, NSpin, NTooltip } from 'naive-ui'
 import { formatDurationLabel, getGameBacklog, getGameCover } from '@/services/gameService'
 import type { BacklogGame, GameBacklog, GameRecommender } from '@/types/Game'
 import BacklogGameCard from '@/components/BacklogGameCard.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const { user } = storeToRefs(useAuthStore())
 
 const backlog = ref<GameBacklog | null>(null)
 const loading = ref(true)
@@ -473,9 +478,16 @@ onBeforeUnmount(() => {
           </p>
         </div>
 
-        <div class="backlog-limit" aria-label="Limite de passagens antes de virar cinza">
-          <strong>{{ backlog.retirementThreshold }}</strong>
-          <span>passagens<br />até as cinzas</span>
+        <div class="backlog-overview__aside">
+          <div class="backlog-limit" aria-label="Limite de passagens antes de virar cinza">
+            <strong>{{ backlog.retirementThreshold }}</strong>
+            <span>passagens<br />até as cinzas</span>
+          </div>
+
+          <RouterLink v-if="user?.isAdmin" class="backlog-conductor-link" to="/conduzir">
+            <span>Próxima votação</span>
+            <strong>Conduzir o ciclo →</strong>
+          </RouterLink>
         </div>
       </header>
 

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -3,13 +3,22 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
-import { NIcon, NModal, NSpin, NTooltip } from 'naive-ui'
-import { formatDurationLabel, getGameBacklog, getGameCover } from '@/services/gameService'
-import type { BacklogGame, GameBacklog, GameRecommender } from '@/types/Game'
+import { NIcon, NModal, NSpin, NTooltip, useMessage } from 'naive-ui'
+import {
+  deleteGameRecommendation,
+  formatDurationLabel,
+  getGameBacklog,
+  getGameCover,
+} from '@/services/gameService'
+import type { BacklogGame, Game, GameBacklog, GameRecommender } from '@/types/Game'
 import BacklogGameCard from '@/components/BacklogGameCard.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
 
 const { user } = storeToRefs(useAuthStore())
+const campaignStore = useCampaignStore()
+const { campaignUser, electionActive, election } = storeToRefs(campaignStore)
+const message = useMessage()
 
 const backlog = ref<GameBacklog | null>(null)
 const loading = ref(true)
@@ -19,19 +28,57 @@ const extractedRubbleIndex = ref<number | null>(null)
 const selectedRubbleGame = ref<BacklogGame | null>(null)
 const rubbleModalOpen = ref(false)
 const failedRecommenderAvatars = ref(new Set<string>())
+const withdrawingGameId = ref<number | null>(null)
 
-const backlogCountLabel = computed(() => {
-  const count = backlog.value?.games.length ?? 0
-  return `${count} ${count === 1 ? 'jogo' : 'jogos'} à espera da fogueira`
-})
+const steamAppId = (game: Pick<Game, 'steam'>) =>
+  game.steam?.match(/store\.steampowered\.com\/app\/(\d+)/i)?.[1] ?? null
+
+const normalizedTitle = (title: string) =>
+  title
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .toLocaleLowerCase('pt-BR')
+
+const isSameGame = (left: Game, right?: Game | null) => {
+  if (!right) return false
+  if (left.id === right.id) return true
+
+  const leftSteamAppId = steamAppId(left)
+  const rightSteamAppId = steamAppId(right)
+  return leftSteamAppId && rightSteamAppId
+    ? leftSteamAppId === rightSteamAppId
+    : normalizedTitle(left.title) === normalizedTitle(right.title)
+}
 
 const isGuaranteedNextVote = (game: BacklogGame) => game.guaranteedNextVote
+const isInCurrentVote = (game: BacklogGame) =>
+  Boolean(
+    electionActive.value && election.value?.options.some((option) => isSameGame(game, option.game)),
+  )
 
-const nextVoteGames = computed(() => backlog.value?.games.filter(isGuaranteedNextVote) ?? [])
+const isCurrentUserSuggestion = (game: BacklogGame) =>
+  isSameGame(game, campaignUser.value?.suggestedGame)
+
+const currentVoteGames = computed(() =>
+  electionActive.value ? (backlog.value?.games.filter(isInCurrentVote) ?? []) : [],
+)
+
+const nextVoteGames = computed(() =>
+  electionActive.value ? [] : (backlog.value?.games.filter(isGuaranteedNextVote) ?? []),
+)
 
 const returningGames = computed(
-  () => backlog.value?.games.filter((game) => !isGuaranteedNextVote(game)) ?? [],
+  () =>
+    backlog.value?.games.filter((game) => !isGuaranteedNextVote(game) && !isInCurrentVote(game)) ??
+    [],
 )
+
+const backlogCountLabel = computed(() => {
+  const count = returningGames.value.length
+  return `${count} ${count === 1 ? 'jogo' : 'jogos'} à espera da fogueira`
+})
 
 const appearanceLabel = (count: number) => {
   if (count === 0) return 'Ainda não passou'
@@ -318,6 +365,25 @@ const loadBacklog = async () => {
   }
 }
 
+const withdrawSuggestion = async (game: BacklogGame) => {
+  if (electionActive.value || !isCurrentUserSuggestion(game) || withdrawingGameId.value) return
+
+  withdrawingGameId.value = game.id
+  try {
+    await deleteGameRecommendation()
+    const [refreshedBacklog] = await Promise.all([
+      getGameBacklog(),
+      campaignStore.init().catch(() => undefined),
+    ])
+    backlog.value = refreshedBacklog
+    message.success(`${game.title} saiu das Brasas. Os detalhes continuam guardados.`)
+  } catch {
+    message.error('Não foi possível retirar o jogo das Brasas. Tente novamente.')
+  } finally {
+    withdrawingGameId.value = null
+  }
+}
+
 onMounted(() => {
   const initialWidth = document.documentElement.clientWidth
   viewportWidth.value = initialWidth
@@ -492,6 +558,30 @@ onBeforeUnmount(() => {
       </header>
 
       <section
+        v-if="currentVoteGames.length"
+        class="backlog-shelf backlog-shelf--current-vote"
+        aria-labelledby="current-vote-heading"
+      >
+        <header class="backlog-shelf__heading">
+          <div>
+            <span class="backlog-eyebrow">Chama acesa</span>
+            <h2 id="current-vote-heading">Na votação atual</h2>
+          </div>
+          <p>Estes jogos estão recebendo os votos deste ciclo.</p>
+        </header>
+
+        <div class="backlog-grid backlog-grid--current-vote">
+          <BacklogGameCard
+            v-for="game in currentVoteGames"
+            :key="game.id"
+            :game="game"
+            :retirement-threshold="backlog.retirementThreshold"
+            current-vote
+          />
+        </div>
+      </section>
+
+      <section
         v-if="nextVoteGames.length"
         class="backlog-shelf backlog-shelf--next-vote"
         aria-labelledby="next-vote-heading"
@@ -510,7 +600,10 @@ onBeforeUnmount(() => {
             :key="game.id"
             :game="game"
             :retirement-threshold="backlog.retirementThreshold"
+            :can-withdraw="isCurrentUserSuggestion(game)"
+            :withdrawing="withdrawingGameId === game.id"
             next-vote
+            @withdraw="withdrawSuggestion"
           />
 
           <article v-if="backlog.nextVoteFillCount" class="next-vote-fill-card">
@@ -530,10 +623,19 @@ onBeforeUnmount(() => {
       <section
         v-if="returningGames.length"
         class="backlog-shelf"
-        :aria-labelledby="nextVoteGames.length ? 'returning-games-heading' : undefined"
-        :aria-label="nextVoteGames.length ? undefined : 'Jogos que ainda guardam calor'"
+        :aria-labelledby="
+          currentVoteGames.length || nextVoteGames.length ? 'returning-games-heading' : undefined
+        "
+        :aria-label="
+          currentVoteGames.length || nextVoteGames.length
+            ? undefined
+            : 'Jogos que ainda guardam calor'
+        "
       >
-        <header v-if="nextVoteGames.length" class="backlog-shelf__heading">
+        <header
+          v-if="currentVoteGames.length || nextVoteGames.length"
+          class="backlog-shelf__heading"
+        >
           <div>
             <span class="backlog-eyebrow">Ainda nas Brasas</span>
             <h2 id="returning-games-heading">Outros jogos nas Brasas</h2>
@@ -547,6 +649,9 @@ onBeforeUnmount(() => {
             :key="game.id"
             :game="game"
             :retirement-threshold="backlog.retirementThreshold"
+            :can-withdraw="!electionActive && isCurrentUserSuggestion(game)"
+            :withdrawing="withdrawingGameId === game.id"
+            @withdraw="withdrawSuggestion"
           />
         </div>
       </section>

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -5,10 +5,10 @@ import { storeToRefs } from 'pinia'
 import { LogoSteam, LogoYoutube, TimeOutline } from '@vicons/ionicons5'
 import { NIcon, NModal, NSpin, NTooltip, useMessage } from 'naive-ui'
 import {
-  deleteGameRecommendation,
   formatDurationLabel,
   getGameBacklog,
   getGameCover,
+  retireGameFromRotation,
 } from '@/services/gameService'
 import type { BacklogGame, Game, GameBacklog, GameRecommender } from '@/types/Game'
 import BacklogGameCard from '@/components/BacklogGameCard.vue'
@@ -28,7 +28,7 @@ const extractedRubbleIndex = ref<number | null>(null)
 const selectedRubbleGame = ref<BacklogGame | null>(null)
 const rubbleModalOpen = ref(false)
 const failedRecommenderAvatars = ref(new Set<string>())
-const withdrawingGameId = ref<number | null>(null)
+const retiringGameId = ref<number | null>(null)
 
 const steamAppId = (game: Pick<Game, 'steam'>) =>
   game.steam?.match(/store\.steampowered\.com\/app\/(\d+)/i)?.[1] ?? null
@@ -60,6 +60,16 @@ const isInCurrentVote = (game: BacklogGame) =>
 
 const isCurrentUserSuggestion = (game: BacklogGame) =>
   isSameGame(game, campaignUser.value?.suggestedGame)
+
+const wasRecommendedByCurrentUser = (game: BacklogGame) =>
+  Boolean(user.value && game.recommendedBy.some((recommender) => recommender.id === user.value?.id))
+
+const canRetireFromRotation = (game: BacklogGame) =>
+  game.suggestion &&
+  wasRecommendedByCurrentUser(game) &&
+  !isCurrentUserSuggestion(game) &&
+  !isGuaranteedNextVote(game) &&
+  !isInCurrentVote(game)
 
 const currentVoteGames = computed(() =>
   electionActive.value ? (backlog.value?.games.filter(isInCurrentVote) ?? []) : [],
@@ -365,22 +375,20 @@ const loadBacklog = async () => {
   }
 }
 
-const withdrawSuggestion = async (game: BacklogGame) => {
-  if (electionActive.value || !isCurrentUserSuggestion(game) || withdrawingGameId.value) return
+const retireFromRotation = async (game: BacklogGame) => {
+  if (!canRetireFromRotation(game) || retiringGameId.value) return
 
-  withdrawingGameId.value = game.id
+  retiringGameId.value = game.id
   try {
-    await deleteGameRecommendation()
-    const [refreshedBacklog] = await Promise.all([
-      getGameBacklog(),
-      campaignStore.init().catch(() => undefined),
-    ])
-    backlog.value = refreshedBacklog
-    message.success(`${game.title} saiu das Brasas. Os detalhes continuam guardados.`)
+    await retireGameFromRotation(game.id)
+    backlog.value = await getGameBacklog()
+    message.success(
+      `${game.title} saiu das próximas rotações. O jogo e seus detalhes continuam guardados.`,
+    )
   } catch {
-    message.error('Não foi possível retirar o jogo das Brasas. Tente novamente.')
+    message.error('Não foi possível retirar o jogo da rotação. Tente novamente.')
   } finally {
-    withdrawingGameId.value = null
+    retiringGameId.value = null
   }
 }
 
@@ -600,10 +608,7 @@ onBeforeUnmount(() => {
             :key="game.id"
             :game="game"
             :retirement-threshold="backlog.retirementThreshold"
-            :can-withdraw="isCurrentUserSuggestion(game)"
-            :withdrawing="withdrawingGameId === game.id"
             next-vote
-            @withdraw="withdrawSuggestion"
           />
 
           <article v-if="backlog.nextVoteFillCount" class="next-vote-fill-card">
@@ -649,9 +654,9 @@ onBeforeUnmount(() => {
             :key="game.id"
             :game="game"
             :retirement-threshold="backlog.retirementThreshold"
-            :can-withdraw="!electionActive && isCurrentUserSuggestion(game)"
-            :withdrawing="withdrawingGameId === game.id"
-            @withdraw="withdrawSuggestion"
+            :can-retire="canRetireFromRotation(game)"
+            :retiring="retiringGameId === game.id"
+            @retire="retireFromRotation"
           />
         </div>
       </section>

--- a/client/src/views/Backlog.vue
+++ b/client/src/views/Backlog.vue
@@ -382,7 +382,7 @@ onBeforeUnmount(() => {
             <div
               v-if="selectedRubbleGame.recommendedBy?.length"
               class="backlog-card__recommenders"
-              aria-label="Pessoas que apresentaram este jogo ao grupo"
+              aria-label="Pessoas que sugeriram este jogo ao grupo"
             >
               <n-tooltip
                 v-for="recommender in visibleRecommenders(selectedRubbleGame)"
@@ -393,7 +393,7 @@ onBeforeUnmount(() => {
                   <span
                     class="backlog-recommender"
                     tabindex="0"
-                    :aria-label="`Apresentado por ${recommender.name}`"
+                    :aria-label="`Sugerido por ${recommender.name}`"
                   >
                     <img
                       v-if="hasRecommenderAvatar(selectedRubbleGame, recommender)"
@@ -404,7 +404,7 @@ onBeforeUnmount(() => {
                     <span v-else aria-hidden="true">{{ recommenderInitial(recommender) }}</span>
                   </span>
                 </template>
-                Apresentado por {{ recommender.name }}
+                Sugerido por {{ recommender.name }}
               </n-tooltip>
 
               <n-tooltip v-if="selectedRubbleGame.recommendedBy.length > 3" placement="top">
@@ -412,12 +412,12 @@ onBeforeUnmount(() => {
                   <span
                     class="backlog-recommender backlog-recommender--more"
                     tabindex="0"
-                    :aria-label="`Mais ${selectedRubbleGame.recommendedBy.length - 3} pessoas apresentaram este jogo`"
+                    :aria-label="`Mais ${selectedRubbleGame.recommendedBy.length - 3} pessoas sugeriram este jogo`"
                   >
                     +{{ selectedRubbleGame.recommendedBy.length - 3 }}
                   </span>
                 </template>
-                Também apresentado por {{ hiddenRecommenderNames(selectedRubbleGame) }}
+                Também sugerido por {{ hiddenRecommenderNames(selectedRubbleGame) }}
               </n-tooltip>
             </div>
 

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -1,0 +1,612 @@
+<script setup lang="ts">
+import axios from 'axios'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMessage } from 'naive-ui'
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '@/stores/auth'
+import { useCampaignStore } from '@/stores/campaign'
+import {
+  applyCycleTransition,
+  drawCyclePool,
+  getCycleOverview,
+  previewCycleTransition,
+  startCycleElection,
+} from '@/services/cycleService'
+import { getGameCover } from '@/services/gameService'
+import type {
+  CycleDraw,
+  CycleOverview,
+  CycleTransitionInput,
+  CycleTransitionPreview,
+  ElectionResultOption,
+} from '@/types/Cycle'
+
+const auth = useAuthStore()
+const { user } = storeToRefs(auth)
+const campaignStore = useCampaignStore()
+const router = useRouter()
+const message = useMessage()
+
+const overview = ref<CycleOverview | null>(null)
+const draw = ref<CycleDraw | null>(null)
+const transitionPreview = ref<CycleTransitionPreview | null>(null)
+const loading = ref(true)
+const drawing = ref(false)
+const startingElection = ref(false)
+const previewing = ref(false)
+const applying = ref(false)
+const revealCount = ref(0)
+const electionEndsAt = ref('')
+const winnerGameId = ref<number | undefined>()
+const nextMonth = ref('')
+const nextYear = ref('')
+const meetingAt = ref('')
+const meetingLocation = ref('Discord')
+const description = ref('')
+const allowEarlyClose = ref(false)
+const discordEnabled = ref(true)
+const oldChannelId = ref('')
+const discussionCategoryId = ref('')
+const historyCategoryId = ref('')
+const voiceChannelId = ref('')
+const newChannelName = ref('')
+const newChannelTopic = ref('')
+let revealTimer: number | null = null
+
+const campaign = computed(() => overview.value?.campaign ?? null)
+const hasElection = computed(() =>
+  Boolean(campaign.value?.electionStartedAt && campaign.value?.pool?.options.length),
+)
+const revealedGames = computed(() => draw.value?.revealOrder.slice(0, revealCount.value) ?? [])
+const allRevealed = computed(() =>
+  Boolean(draw.value && revealCount.value >= draw.value.revealOrder.length),
+)
+const sortedElectionResult = computed(() =>
+  [...(overview.value?.electionResult ?? [])].sort(
+    (left, right) => right.tokens - left.tokens || left.game.localeCompare(right.game, 'pt-BR'),
+  ),
+)
+const leadingOptions = computed(() => {
+  if (!sortedElectionResult.value.length) return []
+  const max = sortedElectionResult.value[0].tokens
+  return sortedElectionResult.value.filter((option) => option.tokens === max)
+})
+const discordPreview = computed(() => transitionPreview.value?.discord ?? null)
+
+onMounted(async () => {
+  await auth.init()
+  if (!user.value?.isAdmin) {
+    message.error('Esta trilha pertence a quem conduz o ciclo.')
+    await router.replace('/')
+    return
+  }
+  await loadOverview()
+})
+
+onBeforeUnmount(stopReveal)
+
+async function loadOverview() {
+  loading.value = true
+  try {
+    overview.value = await getCycleOverview()
+    nextMonth.value = overview.value.nextCampaign.month
+    nextYear.value = overview.value.nextCampaign.year
+    discordEnabled.value = true
+    setDefaultWinner(overview.value.electionResult)
+  } catch (error) {
+    message.error(getErrorMessage(error, 'Não foi possível carregar a condução do ciclo.'))
+  } finally {
+    loading.value = false
+  }
+}
+
+function setDefaultWinner(result: ElectionResultOption[]) {
+  if (!result.length) return
+  const max = Math.max(...result.map((option) => option.tokens))
+  const leaders = result.filter((option) => option.tokens === max)
+  winnerGameId.value = leaders.length === 1 ? leaders[0].gameId : undefined
+}
+
+async function drawGames() {
+  stopReveal()
+  drawing.value = true
+  revealCount.value = 0
+  transitionPreview.value = null
+  try {
+    draw.value = await drawCyclePool()
+    draw.value.warnings.forEach((warning) => message.warning(warning))
+  } catch (error) {
+    message.error(getErrorMessage(error, 'O sorteio não pôde ser realizado.'))
+  } finally {
+    drawing.value = false
+  }
+}
+
+function revealNext() {
+  if (!draw.value || allRevealed.value) return
+  revealCount.value += 1
+}
+
+function revealAll() {
+  if (!draw.value || allRevealed.value || revealTimer !== null) return
+  revealNext()
+  revealTimer = window.setInterval(() => {
+    revealNext()
+    if (allRevealed.value) stopReveal()
+  }, 650)
+}
+
+function stopReveal() {
+  if (revealTimer !== null) {
+    window.clearInterval(revealTimer)
+    revealTimer = null
+  }
+}
+
+function isGuaranteed(gameId: number) {
+  return draw.value?.guaranteedGames.some((game) => game.id === gameId) ?? false
+}
+
+function setElectionDuration(hours: number) {
+  const date = new Date(Date.now() + hours * 60 * 60 * 1000)
+  electionEndsAt.value = toLocalDateTimeInput(date)
+}
+
+async function openElection() {
+  if (!draw.value || !allRevealed.value) return
+  startingElection.value = true
+  try {
+    const updatedCampaign = await startCycleElection(
+      draw.value.selectionToken,
+      electionEndsAt.value ? toOffsetIso(electionEndsAt.value) : undefined,
+    )
+    await campaignStore.init(updatedCampaign)
+    message.success('A votação está acesa. O grupo já pode votar.')
+    draw.value = null
+    revealCount.value = 0
+    await loadOverview()
+  } catch (error) {
+    message.error(getErrorMessage(error, 'Não foi possível abrir a votação.'))
+  } finally {
+    startingElection.value = false
+  }
+}
+
+function buildTransitionInput(): CycleTransitionInput {
+  return {
+    winnerGameId: winnerGameId.value,
+    month: nextMonth.value,
+    year: nextYear.value,
+    description: description.value.trim() || undefined,
+    meetingAt: meetingAt.value ? toOffsetIso(meetingAt.value) : undefined,
+    meetingLocation: meetingLocation.value.trim() || undefined,
+    allowEarlyClose: allowEarlyClose.value,
+    discord: {
+      enabled: discordEnabled.value,
+      oldChannelId: oldChannelId.value || undefined,
+      discussionCategoryId: discussionCategoryId.value || undefined,
+      historyCategoryId: historyCategoryId.value || undefined,
+      voiceChannelId: voiceChannelId.value || undefined,
+      newChannelName: newChannelName.value.trim() || undefined,
+      newChannelTopic: newChannelTopic.value.trim() || undefined,
+    },
+  }
+}
+
+async function prepareTransition() {
+  previewing.value = true
+  try {
+    transitionPreview.value = await previewCycleTransition(buildTransitionInput())
+    syncDiscordSelections(transitionPreview.value)
+    if (transitionPreview.value.valid) {
+      message.success('A passagem está pronta para sua confirmação.')
+    }
+  } catch (error) {
+    message.error(getErrorMessage(error, 'Não foi possível preparar a passagem.'))
+  } finally {
+    previewing.value = false
+  }
+}
+
+function syncDiscordSelections(preview: CycleTransitionPreview) {
+  const plan = preview.discord?.plan
+  if (!plan) return
+  oldChannelId.value ||= plan.oldChannel?.id ?? ''
+  discussionCategoryId.value ||= plan.discussionCategory?.id ?? ''
+  historyCategoryId.value ||= plan.historyCategory?.id ?? ''
+  voiceChannelId.value ||= plan.voiceChannel?.id ?? ''
+  newChannelName.value ||= plan.newChannelName
+  newChannelTopic.value ||= plan.newChannelTopic
+}
+
+async function finishTransition() {
+  const token = transitionPreview.value?.confirmationToken
+  if (!token) return
+  applying.value = true
+  try {
+    const result = await applyCycleTransition(buildTransitionInput(), token)
+    await campaignStore.init(result.campaign)
+    message.success(`A campanha de ${result.campaign.month} começou.`)
+    transitionPreview.value = null
+    await loadOverview()
+  } catch (error) {
+    message.error(getErrorMessage(error, 'A passagem não pôde ser concluída.'))
+  } finally {
+    applying.value = false
+  }
+}
+
+function toLocalDateTimeInput(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function toOffsetIso(localValue: string): string {
+  const date = new Date(localValue)
+  const pad = (value: number) => String(Math.abs(value)).padStart(2, '0')
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60)
+  const offsetRemainder = Math.abs(offsetMinutes) % 60
+  return `${localValue}:00${sign}${pad(offsetHours)}:${pad(offsetRemainder)}`
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (!axios.isAxiosError(error)) return fallback
+  const payload = error.response?.data as
+    | { message?: string | string[]; games?: Array<{ title: string }> }
+    | undefined
+  const messageValue = Array.isArray(payload?.message)
+    ? payload.message.join(' ')
+    : payload?.message
+  const games = payload?.games?.map((game) => game.title).join(', ')
+  return [messageValue || fallback, games].filter(Boolean).join(' ')
+}
+</script>
+
+<template>
+  <section class="cycle-conductor" aria-labelledby="cycle-conductor-heading">
+    <div v-if="loading" class="cycle-loading" role="status">Reunindo as brasas do ciclo…</div>
+
+    <template v-else-if="overview && campaign">
+      <header class="cycle-hero">
+        <div>
+          <span class="cycle-eyebrow">{{ campaign.month }} · {{ campaign.year }}</span>
+          <h2 id="cycle-conductor-heading">Conduzir a passagem</h2>
+          <p>Da última conversa ao próximo jogo, cada passo fica visível antes de ganhar vida.</p>
+        </div>
+        <div class="cycle-status" :class="{ 'cycle-status--active': campaign.electionActive }">
+          <span></span>
+          {{
+            campaign.electionActive
+              ? 'Votação acesa'
+              : hasElection
+                ? 'Votação encerrada'
+                : 'Aguardando sorteio'
+          }}
+        </div>
+      </header>
+
+      <ol class="cycle-steps" aria-label="Etapas da passagem de ciclo">
+        <li :class="{ active: !hasElection }"><span>1</span> Compor</li>
+        <li :class="{ active: campaign.electionActive }"><span>2</span> Votar</li>
+        <li :class="{ active: hasElection && !campaign.electionActive }">
+          <span>3</span> Passar a chama
+        </li>
+      </ol>
+
+      <section v-if="!hasElection" class="cycle-panel cycle-draw-panel">
+        <div class="cycle-panel__heading">
+          <div>
+            <span class="cycle-eyebrow">O sorteio das Brasas</span>
+            <h3>Formar a próxima votação</h3>
+          </div>
+          <strong
+            >{{ overview.guaranteedGames.length }} sugeridos · até
+            {{ overview.targetPoolSize }}</strong
+          >
+        </div>
+
+        <p class="cycle-panel__copy">
+          Todas as sugestões desta reunião entram primeiro. Os lugares que faltarem são sorteados
+          entre jogos elegíveis do catálogo. Na primeira vez, a duração dos jogos sorteados pode ser
+          pesquisada antes da revelação.
+        </p>
+
+        <div v-if="!draw" class="draw-hearth">
+          <div class="draw-hearth__flame" aria-hidden="true"></div>
+          <button class="cycle-primary" type="button" :disabled="drawing" @click="drawGames">
+            {{ drawing ? 'Pesquisando e misturando as brasas…' : 'Sortear os jogos' }}
+          </button>
+        </div>
+
+        <template v-else>
+          <div class="reveal-grid" aria-live="polite">
+            <article
+              v-for="(game, index) in revealedGames"
+              :key="game.id"
+              class="reveal-card"
+              :style="{ '--reveal-index': index }"
+            >
+              <div
+                class="reveal-card__art"
+                :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
+              >
+                <span>{{
+                  isGuaranteed(game.id) ? 'Sugestão da roda' : 'Sorteado das Brasas'
+                }}</span>
+              </div>
+              <div class="reveal-card__body">
+                <small>{{ String(index + 1).padStart(2, '0') }}</small>
+                <h4>{{ game.title }}</h4>
+                <p>{{ game.durationLabel || `${game.mainExtraHours} h` }}</p>
+              </div>
+            </article>
+
+            <button
+              v-if="!allRevealed"
+              class="reveal-card reveal-card--hidden"
+              type="button"
+              @click="revealNext"
+            >
+              <span>?</span>
+              <strong>Revelar a próxima brasa</strong>
+            </button>
+          </div>
+
+          <div class="draw-actions">
+            <button v-if="!allRevealed" type="button" class="cycle-secondary" @click="revealAll">
+              Revelar em sequência
+            </button>
+            <button type="button" class="cycle-quiet" :disabled="drawing" @click="drawGames">
+              Sortear novamente
+            </button>
+          </div>
+
+          <div v-if="allRevealed" class="election-launch">
+            <div>
+              <span class="cycle-eyebrow">A roda está formada</span>
+              <h3>Quando as urnas se fecham?</h3>
+              <p>Você pode deixar sem prazo e encerrar manualmente depois.</p>
+            </div>
+            <div class="duration-presets">
+              <button type="button" @click="setElectionDuration(24)">24 h</button>
+              <button type="button" @click="setElectionDuration(48)">48 h</button>
+              <button type="button" @click="setElectionDuration(72)">3 dias</button>
+              <button type="button" @click="setElectionDuration(168)">1 semana</button>
+            </div>
+            <label class="cycle-field">
+              <span>Encerramento opcional</span>
+              <input v-model="electionEndsAt" type="datetime-local" />
+            </label>
+            <button
+              class="cycle-primary cycle-primary--wide"
+              type="button"
+              :disabled="startingElection"
+              @click="openElection"
+            >
+              {{ startingElection ? 'Acendendo a votação…' : 'Começar a eleição' }}
+            </button>
+          </div>
+        </template>
+      </section>
+
+      <section v-else class="cycle-panel cycle-transition-panel">
+        <div class="cycle-panel__heading">
+          <div>
+            <span class="cycle-eyebrow">O pulso da votação</span>
+            <h3>Preparar a próxima campanha</h3>
+          </div>
+          <strong v-if="campaign.electionEndsAt && campaign.electionActive">
+            até {{ new Date(campaign.electionEndsAt).toLocaleString('pt-BR') }}
+          </strong>
+          <strong v-else-if="campaign.electionActive">encerramento manual</strong>
+          <strong v-else>votação encerrada</strong>
+        </div>
+
+        <div class="result-list">
+          <label
+            v-for="(option, index) in sortedElectionResult"
+            :key="option.gameId"
+            class="result-row"
+            :class="{ 'result-row--leader': index === 0 }"
+          >
+            <input
+              v-if="leadingOptions.length > 1 && option.tokens === leadingOptions[0]?.tokens"
+              v-model="winnerGameId"
+              type="radio"
+              :value="option.gameId"
+            />
+            <span class="result-row__rank">{{ index + 1 }}</span>
+            <strong>{{ option.game }}</strong>
+            <span>{{ option.tokens }} {{ option.tokens === 1 ? 'token' : 'tokens' }}</span>
+            <small>{{ option.voters.length }} votos</small>
+          </label>
+        </div>
+
+        <p v-if="leadingOptions.length > 1" class="cycle-warning">
+          Empate na liderança. Escolha acima qual jogo recebe a chama.
+        </p>
+
+        <form class="transition-form" @submit.prevent="prepareTransition">
+          <div class="transition-form__grid">
+            <label class="cycle-field">
+              <span>Mês</span>
+              <input v-model="nextMonth" required />
+            </label>
+            <label class="cycle-field">
+              <span>Ano</span>
+              <input v-model="nextYear" required />
+            </label>
+            <label class="cycle-field">
+              <span>Próximo encontro</span>
+              <input v-model="meetingAt" type="datetime-local" />
+            </label>
+            <label class="cycle-field">
+              <span>Local</span>
+              <input v-model="meetingLocation" placeholder="Discord" />
+            </label>
+          </div>
+
+          <label class="cycle-field">
+            <span>Texto da campanha <small>opcional, a fogueira pode compor por você</small></span>
+            <textarea v-model="description" rows="5"></textarea>
+          </label>
+
+          <label class="cycle-check">
+            <input v-model="discordEnabled" type="checkbox" />
+            <span>
+              <strong>Organizar o Discord junto</strong>
+              Arquivar a conversa atual, abrir a nova e criar o evento do encontro.
+            </span>
+          </label>
+
+          <p v-if="discordEnabled && !overview.discordConfigured" class="cycle-warning">
+            O bot ainda não está configurado no servidor. A prévia mostrará o que falta.
+          </p>
+
+          <label
+            v-if="campaign.electionActive && campaign.electionEndsAt"
+            class="cycle-check cycle-check--caution"
+          >
+            <input v-model="allowEarlyClose" type="checkbox" />
+            <span>Permitir encerrar antes do horário programado.</span>
+          </label>
+
+          <button class="cycle-primary" type="submit" :disabled="previewing || !winnerGameId">
+            {{ previewing ? 'Lendo a passagem…' : 'Revisar a passagem' }}
+          </button>
+        </form>
+
+        <div v-if="discordPreview && discordEnabled" class="discord-controls">
+          <h4>Ajustes do Discord</h4>
+          <div class="transition-form__grid">
+            <label class="cycle-field">
+              <span>Conversa atual</span>
+              <select v-model="oldChannelId">
+                <option value="">Selecionar</option>
+                <option
+                  v-for="channel in discordPreview.channels.text"
+                  :key="channel.id"
+                  :value="channel.id"
+                >
+                  #{{ channel.name }}
+                </option>
+              </select>
+            </label>
+            <label class="cycle-field">
+              <span>Categoria das conversas</span>
+              <select v-model="discussionCategoryId">
+                <option value="">Manter posição atual</option>
+                <option
+                  v-for="category in discordPreview.channels.categories"
+                  :key="category.id"
+                  :value="category.id"
+                >
+                  {{ category.name }}
+                </option>
+              </select>
+            </label>
+            <label class="cycle-field">
+              <span>Histórias da Fogueira</span>
+              <select v-model="historyCategoryId">
+                <option value="">Criar automaticamente</option>
+                <option
+                  v-for="category in discordPreview.channels.categories"
+                  :key="category.id"
+                  :value="category.id"
+                >
+                  {{ category.name }}
+                </option>
+              </select>
+            </label>
+            <label class="cycle-field">
+              <span>Canal de voz</span>
+              <select v-model="voiceChannelId">
+                <option value="">Selecionar</option>
+                <option
+                  v-for="channel in discordPreview.channels.voice"
+                  :key="channel.id"
+                  :value="channel.id"
+                >
+                  {{ channel.name }}
+                </option>
+              </select>
+            </label>
+            <label class="cycle-field">
+              <span>Novo canal</span>
+              <input v-model="newChannelName" />
+            </label>
+            <label class="cycle-field">
+              <span>Tópico</span>
+              <input v-model="newChannelTopic" />
+            </label>
+          </div>
+          <button
+            class="cycle-secondary"
+            type="button"
+            :disabled="previewing"
+            @click="prepareTransition"
+          >
+            Atualizar prévia
+          </button>
+        </div>
+
+        <section v-if="transitionPreview" class="transition-preview" aria-live="polite">
+          <div
+            v-if="transitionPreview.errors.length"
+            class="preview-notices preview-notices--error"
+          >
+            <strong>A passagem ainda precisa de atenção</strong>
+            <ul>
+              <li v-for="error in transitionPreview.errors" :key="error">{{ error }}</li>
+            </ul>
+          </div>
+          <div v-if="transitionPreview.warnings.length" class="preview-notices">
+            <strong>Antes de confirmar</strong>
+            <ul>
+              <li v-for="warning in transitionPreview.warnings" :key="warning">{{ warning }}</li>
+            </ul>
+          </div>
+
+          <template v-if="transitionPreview.campaign">
+            <span class="cycle-eyebrow">Prévia da nova chama</span>
+            <h3>{{ transitionPreview.campaign.month }} · {{ transitionPreview.winner?.title }}</h3>
+            <pre>{{ transitionPreview.campaign.description }}</pre>
+
+            <ul v-if="transitionPreview.discord?.enabled" class="discord-plan-list">
+              <li>
+                Arquivar #{{
+                  transitionPreview.discord.plan.oldChannel?.name || 'canal a selecionar'
+                }}
+              </li>
+              <li>
+                {{ transitionPreview.discord.plan.createHistoryCategory ? 'Criar' : 'Usar' }}
+                Histórias da Fogueira
+              </li>
+              <li>Abrir #{{ transitionPreview.discord.plan.newChannelName }}</li>
+              <li>
+                Publicar o card “{{ transitionPreview.discord.plan.gameCard.title }}” com:
+                {{ transitionPreview.discord.plan.gameCard.description }}
+              </li>
+              <li v-if="transitionPreview.discord.plan.eventName">
+                Agendar “{{ transitionPreview.discord.plan.eventName }}”
+              </li>
+            </ul>
+          </template>
+
+          <button
+            v-if="transitionPreview.valid && transitionPreview.confirmationToken"
+            class="cycle-primary cycle-primary--wide"
+            type="button"
+            :disabled="applying"
+            @click="finishTransition"
+          >
+            {{ applying ? 'Passando a chama…' : 'Encerrar este ciclo e começar o próximo' }}
+          </button>
+        </section>
+      </section>
+    </template>
+  </section>
+</template>

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useCampaignStore } from '@/stores/campaign'
 import {
   applyCycleTransition,
+  cancelCycleElection,
   drawCyclePool,
   getCycleOverview,
   previewCycleTransition,
@@ -34,6 +35,8 @@ const transitionPreview = ref<CycleTransitionPreview | null>(null)
 const loading = ref(true)
 const drawing = ref(false)
 const startingElection = ref(false)
+const cancellingElection = ref(false)
+const confirmingCancellation = ref(false)
 const previewing = ref(false)
 const applying = ref(false)
 const revealCount = ref(0)
@@ -72,6 +75,9 @@ const leadingOptions = computed(() => {
   const max = sortedElectionResult.value[0].tokens
   return sortedElectionResult.value.filter((option) => option.tokens === max)
 })
+const totalVotes = computed(() =>
+  (overview.value?.electionResult ?? []).reduce((total, option) => total + option.voters.length, 0),
+)
 const discordPreview = computed(() => transitionPreview.value?.discord ?? null)
 
 onMounted(async () => {
@@ -92,7 +98,7 @@ async function loadOverview() {
     overview.value = await getCycleOverview()
     nextMonth.value = overview.value.nextCampaign.month
     nextYear.value = overview.value.nextCampaign.year
-    discordEnabled.value = true
+    discordEnabled.value = overview.value.discordConfigured
     setDefaultWinner(overview.value.electionResult)
   } catch (error) {
     message.error(getErrorMessage(error, 'Não foi possível carregar a condução do ciclo.'))
@@ -170,6 +176,22 @@ async function openElection() {
     message.error(getErrorMessage(error, 'Não foi possível abrir a votação.'))
   } finally {
     startingElection.value = false
+  }
+}
+
+async function undoElection() {
+  cancellingElection.value = true
+  try {
+    const updatedCampaign = await cancelCycleElection()
+    await campaignStore.init(updatedCampaign)
+    confirmingCancellation.value = false
+    transitionPreview.value = null
+    message.success('A votação foi desfeita. As Brasas voltaram ao lugar.')
+    await loadOverview()
+  } catch (error) {
+    message.error(getErrorMessage(error, 'Não foi possível desfazer a votação.'))
+  } finally {
+    cancellingElection.value = false
   }
 }
 
@@ -272,9 +294,9 @@ function getErrorMessage(error: unknown, fallback: string): string {
     <template v-else-if="overview && campaign">
       <header class="cycle-hero">
         <div>
-          <span class="cycle-eyebrow">{{ campaign.month }} · {{ campaign.year }}</span>
-          <h2 id="cycle-conductor-heading">Conduzir a passagem</h2>
-          <p>Da última conversa ao próximo jogo, cada passo fica visível antes de ganhar vida.</p>
+          <span class="cycle-eyebrow">Ciclo atual</span>
+          <h2 id="cycle-conductor-heading">{{ campaign.month }} de {{ campaign.year }}</h2>
+          <p>Componha a votação, acompanhe o resultado e prepare a próxima fogueira.</p>
         </div>
         <div class="cycle-status" :class="{ 'cycle-status--active': campaign.electionActive }">
           <span></span>
@@ -425,6 +447,49 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </label>
         </div>
 
+        <aside class="cycle-undo" :class="{ 'cycle-undo--open': confirmingCancellation }">
+          <template v-if="!confirmingCancellation">
+            <div>
+              <strong>Abriu a votação sem querer?</strong>
+              <span>Você pode voltar às Brasas e fazer outro sorteio.</span>
+            </div>
+            <button type="button" class="cycle-quiet" @click="confirmingCancellation = true">
+              Desfazer abertura
+            </button>
+          </template>
+          <template v-else>
+            <div>
+              <strong>Apagar esta votação?</strong>
+              <span>
+                O pool será removido e
+                {{
+                  totalVotes === 1
+                    ? '1 voto será descartado'
+                    : `${totalVotes} votos serão descartados`
+                }}.
+              </span>
+            </div>
+            <div class="cycle-undo__actions">
+              <button
+                type="button"
+                class="cycle-quiet"
+                :disabled="cancellingElection"
+                @click="confirmingCancellation = false"
+              >
+                Manter votação
+              </button>
+              <button
+                type="button"
+                class="cycle-danger"
+                :disabled="cancellingElection"
+                @click="undoElection"
+              >
+                {{ cancellingElection ? 'Desfazendo…' : 'Sim, desfazer' }}
+              </button>
+            </div>
+          </template>
+        </aside>
+
         <p v-if="leadingOptions.length > 1" class="cycle-warning">
           Empate na liderança. Escolha acima qual jogo recebe a chama.
         </p>
@@ -450,8 +515,13 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
 
           <label class="cycle-field">
-            <span>Texto da campanha <small>opcional, a fogueira pode compor por você</small></span>
-            <textarea v-model="description" rows="5"></textarea>
+            <span>Frase da campanha <small>opcional, usamos o resumo curto do jogo</small></span>
+            <textarea
+              v-model="description"
+              rows="3"
+              maxlength="240"
+              placeholder="Uma frase curta sobre esta jornada."
+            ></textarea>
           </label>
 
           <label class="cycle-check">

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { NButton, useMessage } from 'naive-ui'
+import { useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useCampaignStore } from '@/stores/campaign'
@@ -61,10 +61,18 @@ const campaign = computed(() => overview.value?.campaign ?? null)
 const hasElection = computed(() =>
   Boolean(campaign.value?.electionStartedAt && campaign.value?.pool?.options.length),
 )
+const guaranteedGames = computed(
+  () => draw.value?.guaranteedGames ?? overview.value?.guaranteedGames ?? [],
+)
+const fillerSlotsNeeded = computed(() =>
+  Math.max(0, (overview.value?.targetPoolSize ?? 0) - guaranteedGames.value.length),
+)
 const revealedGames = computed(() => draw.value?.revealOrder.slice(0, revealCount.value) ?? [])
 const allRevealed = computed(() =>
   Boolean(draw.value && revealCount.value >= draw.value.revealOrder.length),
 )
+const nextMondayDeadline = computed(() => getNextMondayBoundary())
+const nextMonthDeadline = computed(() => getNextMonthBoundary())
 const sortedElectionResult = computed(() =>
   [...(overview.value?.electionResult ?? [])].sort(
     (left, right) => right.tokens - left.tokens || left.game.localeCompare(right.game, 'pt-BR'),
@@ -150,13 +158,10 @@ function stopReveal() {
   }
 }
 
-function isGuaranteed(gameId: number) {
-  return draw.value?.guaranteedGames.some((game) => game.id === gameId) ?? false
-}
-
-function setElectionDuration(hours: number) {
-  const date = new Date(Date.now() + hours * 60 * 60 * 1000)
-  electionEndsAt.value = toLocalDateTimeInput(date)
+function setElectionBoundary(boundary: 'monday' | 'month') {
+  electionEndsAt.value = toLocalDateTimeInput(
+    boundary === 'monday' ? nextMondayDeadline.value : nextMonthDeadline.value,
+  )
 }
 
 async function openElection() {
@@ -264,6 +269,28 @@ function toLocalDateTimeInput(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
 }
 
+function getNextMondayBoundary(from = new Date()): Date {
+  const boundary = new Date(from)
+  boundary.setHours(0, 0, 0, 0)
+  const daysUntilMonday = (8 - boundary.getDay()) % 7 || 7
+  boundary.setDate(boundary.getDate() + daysUntilMonday)
+  return boundary
+}
+
+function getNextMonthBoundary(from = new Date()): Date {
+  return new Date(from.getFullYear(), from.getMonth() + 1, 1, 0, 0, 0, 0)
+}
+
+function formatDeadline(date: Date): string {
+  return new Intl.DateTimeFormat('pt-BR', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
 function toOffsetIso(localValue: string): string {
   const date = new Date(localValue)
   const pad = (value: number) => String(Math.abs(value)).padStart(2, '0')
@@ -324,72 +351,141 @@ function getErrorMessage(error: unknown, fallback: string): string {
             <span class="cycle-eyebrow">O sorteio das Brasas</span>
             <h3>Formar a próxima votação</h3>
           </div>
-          <strong
-            >{{ overview.guaranteedGames.length }} sugeridos · até
-            {{ overview.targetPoolSize }}</strong
-          >
+          <strong>
+            {{ guaranteedGames.length }}
+            {{ guaranteedGames.length === 1 ? 'jogo garantido' : 'jogos garantidos' }}
+          </strong>
         </div>
 
         <p class="cycle-panel__copy">
-          Todas as sugestões desta reunião entram primeiro. Os lugares que faltarem são sorteados
-          entre jogos elegíveis do catálogo. Na primeira vez, a duração dos jogos sorteados pode ser
-          pesquisada antes da revelação.
+          Toda sugestão aceita nesta reunião entra na votação, sem limite e sem sorteio. Se houver
+          menos de {{ overview.targetPoolSize }}, completamos a roda com jogos elegíveis das Brasas.
+        </p>
+
+        <section v-if="guaranteedGames.length" class="guaranteed-selection">
+          <header>
+            <div>
+              <span class="cycle-eyebrow">Presenças confirmadas</span>
+              <h4>Estes jogos já estão na próxima votação</h4>
+            </div>
+            <strong>nenhum deles será removido</strong>
+          </header>
+          <div class="guaranteed-grid">
+            <article v-for="game in guaranteedGames" :key="game.id" class="guaranteed-game">
+              <div
+                class="guaranteed-game__art"
+                :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
+              ></div>
+              <div>
+                <small>Sugestão da roda</small>
+                <h5>{{ game.title }}</h5>
+                <span>
+                  {{
+                    game.durationLabel ||
+                    (game.mainExtraHours != null ? `${game.mainExtraHours} h` : 'Duração pendente')
+                  }}
+                </span>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <p v-else class="guaranteed-empty">
+          Ainda não há sugestões nesta reunião. As cinco vagas virão das Brasas.
         </p>
 
         <div v-if="!draw" class="draw-hearth">
-          <n-button
-            data-testid="draw-games"
-            size="large"
-            type="primary"
-            :loading="drawing"
-            @click="drawGames"
-          >
-            {{ drawing ? 'Pesquisando e misturando as brasas…' : 'Sortear os jogos' }}
-          </n-button>
+          <div class="mystery-draw">
+            <div v-if="fillerSlotsNeeded" class="mystery-stack" aria-hidden="true">
+              <span>?</span><span>?</span><span>?</span>
+            </div>
+            <span class="cycle-eyebrow">
+              {{ fillerSlotsNeeded ? `${fillerSlotsNeeded} lugares em aberto` : 'Roda completa' }}
+            </span>
+            <h4>
+              {{ fillerSlotsNeeded ? 'Quem vem das Brasas?' : 'Nenhum sorteio é necessário' }}
+            </h4>
+            <p v-if="fillerSlotsNeeded">
+              Só estes lugares são surpresa. Os jogos acima já estão a salvo na votação.
+            </p>
+            <p v-else>As sugestões já formam toda a roda. Vamos apenas conferir e continuar.</p>
+            <div class="game-links">
+              <button data-testid="draw-games" type="button" :disabled="drawing" @click="drawGames">
+                {{
+                  drawing
+                    ? 'Pesquisando as Brasas…'
+                    : fillerSlotsNeeded
+                      ? `Sortear ${fillerSlotsNeeded} ${fillerSlotsNeeded === 1 ? 'jogo' : 'jogos'}`
+                      : 'Continuar com os sugeridos'
+                }}
+              </button>
+            </div>
+          </div>
         </div>
 
         <template v-else>
-          <div class="reveal-grid" aria-live="polite">
-            <article
-              v-for="(game, index) in revealedGames"
-              :key="game.id"
-              class="reveal-card"
-              :style="{ '--reveal-index': index }"
-            >
-              <div
-                class="reveal-card__art"
-                :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
+          <section v-if="draw.selectedFillers.length" class="random-selection">
+            <header>
+              <span class="cycle-eyebrow">Vindos das Brasas</span>
+              <strong>
+                {{ draw.selectedFillers.length }}
+                {{ draw.selectedFillers.length === 1 ? 'jogo sorteado' : 'jogos sorteados' }}
+              </strong>
+            </header>
+            <div class="reveal-grid" aria-live="polite">
+              <article
+                v-for="(game, index) in revealedGames"
+                :key="game.id"
+                class="reveal-card"
+                :style="{ '--reveal-index': index }"
               >
-                <span>{{
-                  isGuaranteed(game.id) ? 'Sugestão da roda' : 'Sorteado das Brasas'
-                }}</span>
-              </div>
-              <div class="reveal-card__body">
-                <small>{{ String(index + 1).padStart(2, '0') }}</small>
-                <h4>{{ game.title }}</h4>
-                <p>{{ game.durationLabel || `${game.mainExtraHours} h` }}</p>
-              </div>
-            </article>
+                <div
+                  class="reveal-card__art"
+                  :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
+                >
+                  <span>Sorteado das Brasas</span>
+                </div>
+                <div class="reveal-card__body">
+                  <small>{{ String(index + 1).padStart(2, '0') }}</small>
+                  <h4>{{ game.title }}</h4>
+                  <p>
+                    {{
+                      game.durationLabel ||
+                      (game.mainExtraHours != null
+                        ? `${game.mainExtraHours} h`
+                        : 'Duração pendente')
+                    }}
+                  </p>
+                </div>
+              </article>
 
-            <button
-              v-if="!allRevealed"
-              class="reveal-card reveal-card--hidden"
-              type="button"
-              @click="revealNext"
-            >
-              <span>?</span>
-              <strong>Revelar a próxima brasa</strong>
-            </button>
-          </div>
+              <button
+                v-if="!allRevealed"
+                class="reveal-card reveal-card--hidden"
+                type="button"
+                @click="revealNext"
+              >
+                <span>?</span>
+                <strong>
+                  Qual é a
+                  {{ revealedGames.length ? 'próxima' : 'primeira' }} brasa?
+                </strong>
+              </button>
+            </div>
 
-          <div class="draw-actions">
-            <n-button v-if="!allRevealed" secondary @click="revealAll">
-              Revelar em sequência
-            </n-button>
-            <n-button quaternary :loading="drawing" @click="drawGames">
-              Sortear novamente
-            </n-button>
-          </div>
+            <div class="draw-actions game-links">
+              <button v-if="!allRevealed" type="button" @click="revealAll">
+                Revelar em sequência
+              </button>
+              <button type="button" :disabled="drawing" @click="drawGames">
+                {{ drawing ? 'Sorteando…' : 'Sortear novamente' }}
+              </button>
+            </div>
+          </section>
+
+          <p v-else class="random-selection__empty">
+            A votação será formada somente pelas sugestões confirmadas acima.
+          </p>
 
           <div v-if="allRevealed" class="election-launch">
             <div>
@@ -397,28 +493,28 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <h3>Quando as urnas se fecham?</h3>
               <p>Você pode deixar sem prazo e encerrar manualmente depois.</p>
             </div>
-            <div class="duration-presets">
-              <n-button size="small" secondary @click="setElectionDuration(24)">24 h</n-button>
-              <n-button size="small" secondary @click="setElectionDuration(48)">48 h</n-button>
-              <n-button size="small" secondary @click="setElectionDuration(72)"> 3 dias </n-button>
-              <n-button size="small" secondary @click="setElectionDuration(168)">
-                1 semana
-              </n-button>
+            <div class="duration-presets game-links">
+              <button type="button" @click="setElectionBoundary('monday')">
+                Virada para segunda · {{ formatDeadline(nextMondayDeadline) }}
+              </button>
+              <button type="button" @click="setElectionBoundary('month')">
+                Virada do mês · {{ formatDeadline(nextMonthDeadline) }}
+              </button>
             </div>
             <label class="cycle-field">
               <span>Encerramento opcional</span>
               <input v-model="electionEndsAt" type="datetime-local" />
             </label>
-            <n-button
-              data-testid="start-election"
-              block
-              size="large"
-              type="primary"
-              :loading="startingElection"
-              @click="openElection"
-            >
-              {{ startingElection ? 'Acendendo a votação…' : 'Começar a eleição' }}
-            </n-button>
+            <div class="game-links">
+              <button
+                data-testid="start-election"
+                type="button"
+                :disabled="startingElection"
+                @click="openElection"
+              >
+                {{ startingElection ? 'Acendendo a votação…' : 'Começar a eleição' }}
+              </button>
+            </div>
           </div>
         </template>
       </section>
@@ -462,9 +558,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <strong>Abriu a votação sem querer?</strong>
               <span>Você pode voltar às Brasas e fazer outro sorteio.</span>
             </div>
-            <n-button quaternary @click="confirmingCancellation = true">
-              Desfazer abertura
-            </n-button>
+            <div class="game-links">
+              <button type="button" @click="confirmingCancellation = true">
+                Desfazer abertura
+              </button>
+            </div>
           </template>
           <template v-else>
             <div>
@@ -478,23 +576,22 @@ function getErrorMessage(error: unknown, fallback: string): string {
                 }}.
               </span>
             </div>
-            <div class="cycle-undo__actions">
-              <n-button
-                quaternary
+            <div class="cycle-undo__actions game-links">
+              <button
+                type="button"
                 :disabled="cancellingElection"
                 @click="confirmingCancellation = false"
               >
                 Manter votação
-              </n-button>
-              <n-button
+              </button>
+              <button
                 data-testid="confirm-cancel-election"
-                secondary
-                type="error"
-                :loading="cancellingElection"
+                type="button"
+                :disabled="cancellingElection"
                 @click="undoElection"
               >
                 {{ cancellingElection ? 'Desfazendo…' : 'Sim, desfazer' }}
-              </n-button>
+              </button>
             </div>
           </template>
         </aside>
@@ -553,15 +650,10 @@ function getErrorMessage(error: unknown, fallback: string): string {
             <span>Permitir encerrar antes do horário programado.</span>
           </label>
 
-          <div class="transition-form__actions">
-            <n-button
-              attr-type="submit"
-              type="primary"
-              :loading="previewing"
-              :disabled="!winnerGameId"
-            >
+          <div class="transition-form__actions game-links">
+            <button type="submit" :disabled="previewing || !winnerGameId">
               {{ previewing ? 'Lendo a passagem…' : 'Revisar a passagem' }}
-            </n-button>
+            </button>
           </div>
         </form>
 
@@ -629,9 +721,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <input v-model="newChannelTopic" />
             </label>
           </div>
-          <n-button secondary :loading="previewing" @click="prepareTransition">
-            Atualizar prévia
-          </n-button>
+          <div class="game-links">
+            <button type="button" :disabled="previewing" @click="prepareTransition">
+              {{ previewing ? 'Atualizando…' : 'Atualizar prévia' }}
+            </button>
+          </div>
         </div>
 
         <section v-if="transitionPreview" class="transition-preview" aria-live="polite">
@@ -677,16 +771,14 @@ function getErrorMessage(error: unknown, fallback: string): string {
             </ul>
           </template>
 
-          <n-button
+          <div
             v-if="transitionPreview.valid && transitionPreview.confirmationToken"
-            block
-            size="large"
-            type="primary"
-            :loading="applying"
-            @click="finishTransition"
+            class="game-links"
           >
-            {{ applying ? 'Passando a chama…' : 'Encerrar este ciclo e começar o próximo' }}
-          </n-button>
+            <button type="button" :disabled="applying" @click="finishTransition">
+              {{ applying ? 'Passando a chama…' : 'Encerrar este ciclo e começar o próximo' }}
+            </button>
+          </div>
         </section>
       </section>
     </template>

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { useMessage } from 'naive-ui'
+import { NButton, useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useCampaignStore } from '@/stores/campaign'
@@ -337,10 +337,15 @@ function getErrorMessage(error: unknown, fallback: string): string {
         </p>
 
         <div v-if="!draw" class="draw-hearth">
-          <div class="draw-hearth__flame" aria-hidden="true"></div>
-          <button class="cycle-primary" type="button" :disabled="drawing" @click="drawGames">
+          <n-button
+            data-testid="draw-games"
+            size="large"
+            type="primary"
+            :loading="drawing"
+            @click="drawGames"
+          >
             {{ drawing ? 'Pesquisando e misturando as brasas…' : 'Sortear os jogos' }}
-          </button>
+          </n-button>
         </div>
 
         <template v-else>
@@ -378,12 +383,12 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
 
           <div class="draw-actions">
-            <button v-if="!allRevealed" type="button" class="cycle-secondary" @click="revealAll">
+            <n-button v-if="!allRevealed" secondary @click="revealAll">
               Revelar em sequência
-            </button>
-            <button type="button" class="cycle-quiet" :disabled="drawing" @click="drawGames">
+            </n-button>
+            <n-button quaternary :loading="drawing" @click="drawGames">
               Sortear novamente
-            </button>
+            </n-button>
           </div>
 
           <div v-if="allRevealed" class="election-launch">
@@ -393,23 +398,27 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <p>Você pode deixar sem prazo e encerrar manualmente depois.</p>
             </div>
             <div class="duration-presets">
-              <button type="button" @click="setElectionDuration(24)">24 h</button>
-              <button type="button" @click="setElectionDuration(48)">48 h</button>
-              <button type="button" @click="setElectionDuration(72)">3 dias</button>
-              <button type="button" @click="setElectionDuration(168)">1 semana</button>
+              <n-button size="small" secondary @click="setElectionDuration(24)">24 h</n-button>
+              <n-button size="small" secondary @click="setElectionDuration(48)">48 h</n-button>
+              <n-button size="small" secondary @click="setElectionDuration(72)"> 3 dias </n-button>
+              <n-button size="small" secondary @click="setElectionDuration(168)">
+                1 semana
+              </n-button>
             </div>
             <label class="cycle-field">
               <span>Encerramento opcional</span>
               <input v-model="electionEndsAt" type="datetime-local" />
             </label>
-            <button
-              class="cycle-primary cycle-primary--wide"
-              type="button"
-              :disabled="startingElection"
+            <n-button
+              data-testid="start-election"
+              block
+              size="large"
+              type="primary"
+              :loading="startingElection"
               @click="openElection"
             >
               {{ startingElection ? 'Acendendo a votação…' : 'Começar a eleição' }}
-            </button>
+            </n-button>
           </div>
         </template>
       </section>
@@ -453,9 +462,9 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <strong>Abriu a votação sem querer?</strong>
               <span>Você pode voltar às Brasas e fazer outro sorteio.</span>
             </div>
-            <button type="button" class="cycle-quiet" @click="confirmingCancellation = true">
+            <n-button quaternary @click="confirmingCancellation = true">
               Desfazer abertura
-            </button>
+            </n-button>
           </template>
           <template v-else>
             <div>
@@ -470,22 +479,22 @@ function getErrorMessage(error: unknown, fallback: string): string {
               </span>
             </div>
             <div class="cycle-undo__actions">
-              <button
-                type="button"
-                class="cycle-quiet"
+              <n-button
+                quaternary
                 :disabled="cancellingElection"
                 @click="confirmingCancellation = false"
               >
                 Manter votação
-              </button>
-              <button
-                type="button"
-                class="cycle-danger"
-                :disabled="cancellingElection"
+              </n-button>
+              <n-button
+                data-testid="confirm-cancel-election"
+                secondary
+                type="error"
+                :loading="cancellingElection"
                 @click="undoElection"
               >
                 {{ cancellingElection ? 'Desfazendo…' : 'Sim, desfazer' }}
-              </button>
+              </n-button>
             </div>
           </template>
         </aside>
@@ -544,9 +553,16 @@ function getErrorMessage(error: unknown, fallback: string): string {
             <span>Permitir encerrar antes do horário programado.</span>
           </label>
 
-          <button class="cycle-primary" type="submit" :disabled="previewing || !winnerGameId">
-            {{ previewing ? 'Lendo a passagem…' : 'Revisar a passagem' }}
-          </button>
+          <div class="transition-form__actions">
+            <n-button
+              attr-type="submit"
+              type="primary"
+              :loading="previewing"
+              :disabled="!winnerGameId"
+            >
+              {{ previewing ? 'Lendo a passagem…' : 'Revisar a passagem' }}
+            </n-button>
+          </div>
         </form>
 
         <div v-if="discordPreview && discordEnabled" class="discord-controls">
@@ -613,14 +629,9 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <input v-model="newChannelTopic" />
             </label>
           </div>
-          <button
-            class="cycle-secondary"
-            type="button"
-            :disabled="previewing"
-            @click="prepareTransition"
-          >
+          <n-button secondary :loading="previewing" @click="prepareTransition">
             Atualizar prévia
-          </button>
+          </n-button>
         </div>
 
         <section v-if="transitionPreview" class="transition-preview" aria-live="polite">
@@ -666,15 +677,16 @@ function getErrorMessage(error: unknown, fallback: string): string {
             </ul>
           </template>
 
-          <button
+          <n-button
             v-if="transitionPreview.valid && transitionPreview.confirmationToken"
-            class="cycle-primary cycle-primary--wide"
-            type="button"
-            :disabled="applying"
+            block
+            size="large"
+            type="primary"
+            :loading="applying"
             @click="finishTransition"
           >
             {{ applying ? 'Passando a chama…' : 'Encerrar este ciclo e começar o próximo' }}
-          </button>
+          </n-button>
         </section>
       </section>
     </template>

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -6,6 +6,7 @@ import { useMessage } from 'naive-ui'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useCampaignStore } from '@/stores/campaign'
+import BacklogGameCard from '@/components/BacklogGameCard.vue'
 import {
   applyCycleTransition,
   cancelCycleElection,
@@ -14,7 +15,7 @@ import {
   previewCycleTransition,
   startCycleElection,
 } from '@/services/cycleService'
-import { getGameCover } from '@/services/gameService'
+import { getGameBacklog } from '@/services/gameService'
 import type {
   CycleDraw,
   CycleOverview,
@@ -22,6 +23,22 @@ import type {
   CycleTransitionPreview,
   ElectionResultOption,
 } from '@/types/Cycle'
+import type { BacklogGame, Game, GameBacklog } from '@/types/Game'
+
+const PORTUGUESE_MONTHS = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro',
+]
 
 const auth = useAuthStore()
 const { user } = storeToRefs(auth)
@@ -30,6 +47,7 @@ const router = useRouter()
 const message = useMessage()
 
 const overview = ref<CycleOverview | null>(null)
+const backlog = ref<GameBacklog | null>(null)
 const draw = ref<CycleDraw | null>(null)
 const transitionPreview = ref<CycleTransitionPreview | null>(null)
 const loading = ref(true)
@@ -39,6 +57,7 @@ const cancellingElection = ref(false)
 const confirmingCancellation = ref(false)
 const previewing = ref(false)
 const applying = ref(false)
+const resultsRevealed = ref(false)
 const revealCount = ref(0)
 const electionEndsAt = ref('')
 const winnerGameId = ref<number | undefined>()
@@ -72,7 +91,23 @@ const allRevealed = computed(() =>
   Boolean(draw.value && revealCount.value >= draw.value.revealOrder.length),
 )
 const nextMondayDeadline = computed(() => getNextMondayBoundary())
-const nextMonthDeadline = computed(() => getNextMonthBoundary())
+const nextMonthDeadline = computed(
+  () =>
+    getCampaignMonthBoundary(
+      overview.value?.nextCampaign.month,
+      overview.value?.nextCampaign.year,
+    ) ?? getNextMonthBoundary(),
+)
+const catalogGamesById = computed(
+  () =>
+    new Map(
+      [...(backlog.value?.games ?? []), ...(backlog.value?.rubble ?? [])].map((game) => [
+        game.id,
+        game,
+      ]),
+    ),
+)
+const retirementThreshold = computed(() => backlog.value?.retirementThreshold ?? 3)
 const sortedElectionResult = computed(() =>
   [...(overview.value?.electionResult ?? [])].sort(
     (left, right) => right.tokens - left.tokens || left.game.localeCompare(right.game, 'pt-BR'),
@@ -83,9 +118,6 @@ const leadingOptions = computed(() => {
   const max = sortedElectionResult.value[0].tokens
   return sortedElectionResult.value.filter((option) => option.tokens === max)
 })
-const totalVotes = computed(() =>
-  (overview.value?.electionResult ?? []).reduce((total, option) => total + option.voters.length, 0),
-)
 const discordPreview = computed(() => transitionPreview.value?.discord ?? null)
 
 onMounted(async () => {
@@ -103,16 +135,45 @@ onBeforeUnmount(stopReveal)
 async function loadOverview() {
   loading.value = true
   try {
-    overview.value = await getCycleOverview()
-    nextMonth.value = overview.value.nextCampaign.month
-    nextYear.value = overview.value.nextCampaign.year
-    discordEnabled.value = overview.value.discordConfigured
-    setDefaultWinner(overview.value.electionResult)
+    const [loadedOverview, loadedBacklog] = await Promise.all([
+      getCycleOverview(),
+      getGameBacklog(),
+    ])
+    overview.value = loadedOverview
+    backlog.value = loadedBacklog
+    nextMonth.value = loadedOverview.nextCampaign.month
+    nextYear.value = loadedOverview.nextCampaign.year
+    discordEnabled.value = loadedOverview.discordConfigured
+    resultsRevealed.value = false
+    setDefaultWinner(loadedOverview.electionResult)
+
+    if (!loadedOverview.campaign.electionStartedAt) {
+      electionEndsAt.value = toLocalDateTimeInput(nextMonthDeadline.value)
+    }
+    if (!meetingAt.value) {
+      const nextMeeting = getLastThursdayOfMonth(
+        loadedOverview.nextCampaign.month,
+        loadedOverview.nextCampaign.year,
+        loadedOverview.campaign.meetingAt,
+      )
+      meetingAt.value = nextMeeting ? toLocalDateTimeInput(nextMeeting) : ''
+    }
   } catch (error) {
     message.error(getErrorMessage(error, 'Não foi possível carregar a condução do ciclo.'))
   } finally {
     loading.value = false
   }
+}
+
+function asBacklogGame(game: Game): BacklogGame {
+  return (
+    catalogGamesById.value.get(game.id) ?? {
+      ...game,
+      electionAppearances: 0,
+      guaranteedNextVote: guaranteedGames.value.some((guaranteed) => guaranteed.id === game.id),
+      recommendedBy: game.recommendedBy ?? [],
+    }
+  )
 }
 
 function setDefaultWinner(result: ElectionResultOption[]) {
@@ -281,6 +342,33 @@ function getNextMonthBoundary(from = new Date()): Date {
   return new Date(from.getFullYear(), from.getMonth() + 1, 1, 0, 0, 0, 0)
 }
 
+function getCampaignMonthBoundary(month?: string, year?: string): Date | null {
+  const monthIndex = PORTUGUESE_MONTHS.findIndex(
+    (candidate) =>
+      candidate.toLocaleLowerCase('pt-BR') === month?.trim().toLocaleLowerCase('pt-BR'),
+  )
+  const numericYear = Number(year)
+  if (monthIndex < 0 || !Number.isInteger(numericYear)) return null
+  return new Date(numericYear, monthIndex, 1, 0, 0, 0, 0)
+}
+
+function getLastThursdayOfMonth(
+  month: string,
+  year: string,
+  previousMeetingAt?: string | null,
+): Date | null {
+  const monthStart = getCampaignMonthBoundary(month, year)
+  if (!monthStart) return null
+  const meeting = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0, 20, 0, 0, 0)
+  while (meeting.getDay() !== 4) meeting.setDate(meeting.getDate() - 1)
+
+  const previousMeeting = previousMeetingAt ? new Date(previousMeetingAt) : null
+  if (previousMeeting && Number.isFinite(previousMeeting.getTime())) {
+    meeting.setHours(previousMeeting.getHours(), previousMeeting.getMinutes(), 0, 0)
+  }
+  return meeting
+}
+
 function formatDeadline(date: Date): string {
   return new Intl.DateTimeFormat('pt-BR', {
     weekday: 'short',
@@ -370,23 +458,14 @@ function getErrorMessage(error: unknown, fallback: string): string {
             </div>
             <strong>nenhum deles será removido</strong>
           </header>
-          <div class="guaranteed-grid">
-            <article v-for="game in guaranteedGames" :key="game.id" class="guaranteed-game">
-              <div
-                class="guaranteed-game__art"
-                :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
-              ></div>
-              <div>
-                <small>Sugestão da roda</small>
-                <h5>{{ game.title }}</h5>
-                <span>
-                  {{
-                    game.durationLabel ||
-                    (game.mainExtraHours != null ? `${game.mainExtraHours} h` : 'Duração pendente')
-                  }}
-                </span>
-              </div>
-            </article>
+          <div class="backlog-grid cycle-catalog-grid">
+            <BacklogGameCard
+              v-for="game in guaranteedGames"
+              :key="game.id"
+              :game="asBacklogGame(game)"
+              :retirement-threshold="retirementThreshold"
+              next-vote
+            />
           </div>
         </section>
 
@@ -432,36 +511,25 @@ function getErrorMessage(error: unknown, fallback: string): string {
                 {{ draw.selectedFillers.length === 1 ? 'jogo sorteado' : 'jogos sorteados' }}
               </strong>
             </header>
-            <div class="reveal-grid" aria-live="polite">
-              <article
+            <div
+              class="backlog-grid cycle-catalog-grid cycle-catalog-grid--reveal"
+              aria-live="polite"
+            >
+              <div
                 v-for="(game, index) in revealedGames"
                 :key="game.id"
-                class="reveal-card"
+                class="cycle-catalog-card"
                 :style="{ '--reveal-index': index }"
               >
-                <div
-                  class="reveal-card__art"
-                  :style="{ backgroundImage: `url('${getGameCover(game)}')` }"
-                >
-                  <span>Sorteado das Brasas</span>
-                </div>
-                <div class="reveal-card__body">
-                  <small>{{ String(index + 1).padStart(2, '0') }}</small>
-                  <h4>{{ game.title }}</h4>
-                  <p>
-                    {{
-                      game.durationLabel ||
-                      (game.mainExtraHours != null
-                        ? `${game.mainExtraHours} h`
-                        : 'Duração pendente')
-                    }}
-                  </p>
-                </div>
-              </article>
+                <BacklogGameCard
+                  :game="asBacklogGame(game)"
+                  :retirement-threshold="retirementThreshold"
+                />
+              </div>
 
               <button
                 v-if="!allRevealed"
-                class="reveal-card reveal-card--hidden"
+                class="reveal-card reveal-card--hidden cycle-catalog-mystery"
                 type="button"
                 @click="revealNext"
               >
@@ -532,7 +600,27 @@ function getErrorMessage(error: unknown, fallback: string): string {
           <strong v-else>votação encerrada</strong>
         </div>
 
-        <div class="result-list">
+        <div v-if="!resultsRevealed" class="results-privacy">
+          <div>
+            <span class="cycle-eyebrow">Contagem protegida</span>
+            <h4>Os resultados estão ocultos</h4>
+            <p>
+              Nenhum jogo, voto ou token aparece até você decidir revelar. Assim a tela pode ser
+              compartilhada sem entregar quem está na frente.
+            </p>
+          </div>
+          <div class="game-links">
+            <button data-testid="reveal-results" type="button" @click="resultsRevealed = true">
+              Revelar resultados
+            </button>
+          </div>
+        </div>
+
+        <div v-if="resultsRevealed" class="results-revealed-actions game-links">
+          <button type="button" @click="resultsRevealed = false">Ocultar resultados</button>
+        </div>
+
+        <div v-if="resultsRevealed" class="result-list">
           <label
             v-for="(option, index) in sortedElectionResult"
             :key="option.gameId"
@@ -567,14 +655,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
           <template v-else>
             <div>
               <strong>Apagar esta votação?</strong>
-              <span>
-                O pool será removido e
-                {{
-                  totalVotes === 1
-                    ? '1 voto será descartado'
-                    : `${totalVotes} votos serão descartados`
-                }}.
-              </span>
+              <span>O pool será removido e os votos já registrados serão descartados.</span>
             </div>
             <div class="cycle-undo__actions game-links">
               <button
@@ -596,11 +677,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </template>
         </aside>
 
-        <p v-if="leadingOptions.length > 1" class="cycle-warning">
+        <p v-if="resultsRevealed && leadingOptions.length > 1" class="cycle-warning">
           Empate na liderança. Escolha acima qual jogo recebe a chama.
         </p>
 
-        <form class="transition-form" @submit.prevent="prepareTransition">
+        <form v-if="resultsRevealed" class="transition-form" @submit.prevent="prepareTransition">
           <div class="transition-form__grid">
             <label class="cycle-field">
               <span>Mês</span>
@@ -657,7 +738,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
         </form>
 
-        <div v-if="discordPreview && discordEnabled" class="discord-controls">
+        <div v-if="resultsRevealed && discordPreview && discordEnabled" class="discord-controls">
           <h4>Ajustes do Discord</h4>
           <div class="transition-form__grid">
             <label class="cycle-field">
@@ -728,7 +809,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
         </div>
 
-        <section v-if="transitionPreview" class="transition-preview" aria-live="polite">
+        <section
+          v-if="resultsRevealed && transitionPreview"
+          class="transition-preview"
+          aria-live="polite"
+        >
           <div
             v-if="transitionPreview.errors.length"
             class="preview-notices preview-notices--error"

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -64,8 +64,8 @@ const winnerGameId = ref<number | undefined>()
 const nextMonth = ref('')
 const nextYear = ref('')
 const meetingAt = ref('')
-const meetingLocation = ref('Discord')
 const description = ref('')
+const descriptionEdited = ref(false)
 const allowEarlyClose = ref(false)
 const discordEnabled = ref(true)
 const oldChannelId = ref('')
@@ -113,6 +113,11 @@ const sortedElectionResult = computed(() =>
     (left, right) => right.tokens - left.tokens || left.game.localeCompare(right.game, 'pt-BR'),
   ),
 )
+const neutralElectionResult = computed(() =>
+  [...(overview.value?.electionResult ?? [])].sort((left, right) =>
+    left.game.localeCompare(right.game, 'pt-BR'),
+  ),
+)
 const leadingOptions = computed(() => {
   if (!sortedElectionResult.value.length) return []
   const max = sortedElectionResult.value[0].tokens
@@ -146,6 +151,7 @@ async function loadOverview() {
     discordEnabled.value = loadedOverview.discordConfigured
     resultsRevealed.value = false
     setDefaultWinner(loadedOverview.electionResult)
+    syncDescriptionWithWinner()
 
     if (!loadedOverview.campaign.electionStartedAt) {
       electionEndsAt.value = toLocalDateTimeInput(nextMonthDeadline.value)
@@ -181,6 +187,14 @@ function setDefaultWinner(result: ElectionResultOption[]) {
   const max = Math.max(...result.map((option) => option.tokens))
   const leaders = result.filter((option) => option.tokens === max)
   winnerGameId.value = leaders.length === 1 ? leaders[0].gameId : undefined
+}
+
+function syncDescriptionWithWinner() {
+  if (descriptionEdited.value) return
+  const winner = campaign.value?.pool?.options.find(
+    (option) => option.game.id === winnerGameId.value,
+  )?.game
+  description.value = winner ? buildCampaignPhrase(winner) : ''
 }
 
 async function drawGames() {
@@ -252,6 +266,8 @@ async function undoElection() {
     await campaignStore.init(updatedCampaign)
     confirmingCancellation.value = false
     transitionPreview.value = null
+    description.value = ''
+    descriptionEdited.value = false
     message.success('A votação foi desfeita. As Brasas voltaram ao lugar.')
     await loadOverview()
   } catch (error) {
@@ -268,7 +284,7 @@ function buildTransitionInput(): CycleTransitionInput {
     year: nextYear.value,
     description: description.value.trim() || undefined,
     meetingAt: meetingAt.value ? toOffsetIso(meetingAt.value) : undefined,
-    meetingLocation: meetingLocation.value.trim() || undefined,
+    meetingLocation: 'Discord',
     allowEarlyClose: allowEarlyClose.value,
     discord: {
       enabled: discordEnabled.value,
@@ -317,6 +333,8 @@ async function finishTransition() {
     await campaignStore.init(result.campaign)
     message.success(`A campanha de ${result.campaign.month} começou.`)
     transitionPreview.value = null
+    description.value = ''
+    descriptionEdited.value = false
     await loadOverview()
   } catch (error) {
     message.error(getErrorMessage(error, 'A passagem não pôde ser concluída.'))
@@ -377,6 +395,18 @@ function formatDeadline(date: Date): string {
     hour: '2-digit',
     minute: '2-digit',
   }).format(date)
+}
+
+function buildCampaignPhrase(game: Game): string {
+  const summary =
+    game.summary?.replace(/\s+/g, ' ').trim() || 'Uma nova jornada escolhida ao redor da fogueira.'
+  const firstSentence = summary.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim()
+  const phrase = firstSentence || summary
+  if (phrase.length <= 220) return phrase
+
+  const shortened = phrase.slice(0, 219)
+  const lastSpace = shortened.lastIndexOf(' ')
+  return `${shortened.slice(0, lastSpace > 160 ? lastSpace : 219).trim()}…`
 }
 
 function toOffsetIso(localValue: string): string {
@@ -605,8 +635,8 @@ function getErrorMessage(error: unknown, fallback: string): string {
             <span class="cycle-eyebrow">Contagem protegida</span>
             <h4>Os resultados estão ocultos</h4>
             <p>
-              Nenhum jogo, voto ou token aparece até você decidir revelar. Assim a tela pode ser
-              compartilhada sem entregar quem está na frente.
+              Os jogos continuam visíveis em ordem alfabética. Ranking, tokens, votos e liderança só
+              aparecem quando você decidir revelar.
             </p>
           </div>
           <div class="game-links">
@@ -620,23 +650,32 @@ function getErrorMessage(error: unknown, fallback: string): string {
           <button type="button" @click="resultsRevealed = false">Ocultar resultados</button>
         </div>
 
-        <div v-if="resultsRevealed" class="result-list">
+        <div class="result-list">
           <label
-            v-for="(option, index) in sortedElectionResult"
+            v-for="(option, index) in resultsRevealed
+              ? sortedElectionResult
+              : neutralElectionResult"
             :key="option.gameId"
             class="result-row"
-            :class="{ 'result-row--leader': index === 0 }"
+            :class="{ 'result-row--leader': resultsRevealed && index === 0 }"
           >
             <input
-              v-if="leadingOptions.length > 1 && option.tokens === leadingOptions[0]?.tokens"
+              v-if="
+                resultsRevealed &&
+                leadingOptions.length > 1 &&
+                option.tokens === leadingOptions[0]?.tokens
+              "
               v-model="winnerGameId"
               type="radio"
               :value="option.gameId"
+              @change="syncDescriptionWithWinner"
             />
-            <span class="result-row__rank">{{ index + 1 }}</span>
+            <span v-if="resultsRevealed" class="result-row__rank">{{ index + 1 }}</span>
             <strong>{{ option.game }}</strong>
-            <span>{{ option.tokens }} {{ option.tokens === 1 ? 'token' : 'tokens' }}</span>
-            <small>{{ option.voters.length }} votos</small>
+            <template v-if="resultsRevealed">
+              <span>{{ option.tokens }} {{ option.tokens === 1 ? 'token' : 'tokens' }}</span>
+              <small>{{ option.voters.length }} votos</small>
+            </template>
           </label>
         </div>
 
@@ -681,7 +720,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
           Empate na liderança. Escolha acima qual jogo recebe a chama.
         </p>
 
-        <form v-if="resultsRevealed" class="transition-form" @submit.prevent="prepareTransition">
+        <form class="transition-form" @submit.prevent="prepareTransition">
           <div class="transition-form__grid">
             <label class="cycle-field">
               <span>Mês</span>
@@ -695,19 +734,19 @@ function getErrorMessage(error: unknown, fallback: string): string {
               <span>Próximo encontro</span>
               <input v-model="meetingAt" type="datetime-local" />
             </label>
-            <label class="cycle-field">
-              <span>Local</span>
-              <input v-model="meetingLocation" placeholder="Discord" />
-            </label>
           </div>
 
           <label class="cycle-field">
-            <span>Frase da campanha <small>opcional, usamos o resumo curto do jogo</small></span>
+            <span>
+              Frase da campanha
+              <small>preenchida com o resumo curto salvo do jogo vencedor</small>
+            </span>
             <textarea
               v-model="description"
               rows="3"
               maxlength="240"
               placeholder="Uma frase curta sobre esta jornada."
+              @input="descriptionEdited = true"
             ></textarea>
           </label>
 
@@ -738,7 +777,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
         </form>
 
-        <div v-if="resultsRevealed && discordPreview && discordEnabled" class="discord-controls">
+        <div v-if="discordPreview && discordEnabled" class="discord-controls">
           <h4>Ajustes do Discord</h4>
           <div class="transition-form__grid">
             <label class="cycle-field">
@@ -809,11 +848,7 @@ function getErrorMessage(error: unknown, fallback: string): string {
           </div>
         </div>
 
-        <section
-          v-if="resultsRevealed && transitionPreview"
-          class="transition-preview"
-          aria-live="polite"
-        >
+        <section v-if="transitionPreview" class="transition-preview" aria-live="polite">
           <div
             v-if="transitionPreview.errors.length"
             class="preview-notices preview-notices--error"

--- a/client/src/views/CycleConductor.vue
+++ b/client/src/views/CycleConductor.vue
@@ -194,7 +194,7 @@ function syncDescriptionWithWinner() {
   const winner = campaign.value?.pool?.options.find(
     (option) => option.game.id === winnerGameId.value,
   )?.game
-  description.value = winner ? buildCampaignPhrase(winner) : ''
+  description.value = winner ? buildCampaignDescription(winner) : ''
 }
 
 async function drawGames() {
@@ -397,16 +397,14 @@ function formatDeadline(date: Date): string {
   }).format(date)
 }
 
-function buildCampaignPhrase(game: Game): string {
+function buildCampaignDescription(game: Game): string {
   const summary =
     game.summary?.replace(/\s+/g, ' ').trim() || 'Uma nova jornada escolhida ao redor da fogueira.'
-  const firstSentence = summary.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim()
-  const phrase = firstSentence || summary
-  if (phrase.length <= 220) return phrase
+  if (summary.length <= 1000) return summary
 
-  const shortened = phrase.slice(0, 219)
+  const shortened = summary.slice(0, 999)
   const lastSpace = shortened.lastIndexOf(' ')
-  return `${shortened.slice(0, lastSpace > 160 ? lastSpace : 219).trim()}…`
+  return `${shortened.slice(0, lastSpace > 900 ? lastSpace : 999).trim()}…`
 }
 
 function toOffsetIso(localValue: string): string {
@@ -738,14 +736,14 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
           <label class="cycle-field">
             <span>
-              Frase da campanha
-              <small>preenchida com o resumo curto salvo do jogo vencedor</small>
+              Descrição da campanha
+              <small>descrição curta salva diretamente da Steam</small>
             </span>
             <textarea
               v-model="description"
               rows="3"
-              maxlength="240"
-              placeholder="Uma frase curta sobre esta jornada."
+              maxlength="1000"
+              placeholder="A descrição curta do jogo vencedor aparecerá aqui."
               @input="descriptionEdited = true"
             ></textarea>
           </label>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -116,6 +116,9 @@ const recalculateElection = async () => {
       @change-journey="changeJourney"
     />
 
-    <GameRecommendation v-if="campaign && isAuthenticated" :campaign-user="campaignUser" />
+    <GameRecommendation
+      v-if="campaign && isAuthenticated && !campaign.electionActive"
+      :campaign-user="campaignUser"
+    />
   </div>
 </template>

--- a/server/.env.example
+++ b/server/.env.example
@@ -24,6 +24,15 @@ DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
 DISCORD_GUILD_ID=1534325844619821170
 
+# Comma-separated Discord user IDs allowed to conduct campaign transitions in the website.
+BONFIRE_ADMIN_DISCORD_IDS=replace-with-owner-discord-id
+
+# Private bot credential used only by the server for idempotent channel/event transitions.
+DISCORD_BOT_TOKEN=replace-with-private-bot-token
+
+# Optional. Defaults to JWT_SECRET and signs short-lived draw/transition previews.
+CYCLE_AUTOMATION_SECRET=replace-with-a-separate-long-random-secret
+
 # Cloudflare R2 media storage. Leave all five required values blank to use original media URLs locally.
 R2_ENDPOINT=https://account-id.r2.cloudflarestorage.com
 R2_BUCKET=sob-a-luz-do-bonfire

--- a/server/.env.example
+++ b/server/.env.example
@@ -24,8 +24,8 @@ DISCORD_CLIENT_SECRET=replace-with-discord-client-secret
 DISCORD_CALLBACK_URL=http://localhost:3000/auth/discord/callback
 DISCORD_GUILD_ID=1534325844619821170
 
-# Comma-separated Discord user IDs allowed to conduct campaign transitions in the website.
-BONFIRE_ADMIN_DISCORD_IDS=replace-with-owner-discord-id
+# The single Discord user ID allowed to conduct campaign transitions in the website.
+BONFIRE_CONDUCTOR_DISCORD_ID=replace-with-owner-discord-id
 
 # Private bot credential used only by the server for idempotent channel/event transitions.
 DISCORD_BOT_TOKEN=replace-with-private-bot-token

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -14,6 +14,7 @@ import { SiteContent } from '../content/entities/site-content.entity';
 import { Game } from '../games/entities/game.entity';
 import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { buildNextVotePoolGames } from '../games/games.service';
+import { normalizeTrailerPageUrl } from '../games/trailer-url';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -888,7 +889,13 @@ export class AdminService {
       }
 
       if (input.trailer !== undefined) {
-        game.trailer = input.trailer ?? null;
+        const trailer = normalizeTrailerPageUrl(input.trailer);
+        if (input.trailer && !trailer) {
+          throw new BadRequestException(
+            'Trailer must be a navigable page, not a direct video or HLS playlist.',
+          );
+        }
+        game.trailer = trailer;
       }
 
       if (input.summary !== undefined) {

--- a/server/src/admin/dto/monthly-plan.dto.ts
+++ b/server/src/admin/dto/monthly-plan.dto.ts
@@ -12,6 +12,7 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { IsTrailerPageUrl } from '../../games/trailer-url';
 
 export class AdminGameInputDto {
   @IsOptional()
@@ -39,6 +40,7 @@ export class AdminGameInputDto {
 
   @IsOptional()
   @IsString()
+  @IsTrailerPageUrl()
   trailer?: string;
 
   @IsOptional()

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -10,6 +10,7 @@ import { PoolModule } from './pool/pool.module';
 import { AdminModule } from './admin/admin.module';
 import { createTypeOrmModuleOptions } from './db/database.config';
 import { ContentModule } from './content/content.module';
+import { CycleModule } from './cycle/cycle.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { ContentModule } from './content/content.module';
     PoolModule,
     ContentModule,
     AdminModule,
+    CycleModule,
   ],
   controllers: [],
   providers: [],

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -11,6 +11,8 @@ import { JwtStrategy } from './strategies/jwt.strategy'; // assumes you have thi
 import { MediaModule } from '../media/media.module';
 import { DiscordMembershipService } from './discord-membership.service';
 import { DiscordCallbackGuard } from './guards/discord-callback.guard';
+import { BonfireAdminAccessService } from './bonfire-admin-access.service';
+import { BonfireAdminGuard } from './guards/bonfire-admin.guard';
 
 @Module({
   imports: [
@@ -34,7 +36,9 @@ import { DiscordCallbackGuard } from './guards/discord-callback.guard';
     DiscordMembershipService,
     DiscordCallbackGuard,
     JwtStrategy,
+    BonfireAdminAccessService,
+    BonfireAdminGuard,
   ],
-  exports: [AuthService],
+  exports: [AuthService, BonfireAdminAccessService, BonfireAdminGuard],
 })
 export class AuthModule {}

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import type { Profile } from 'passport-discord';
 import { Player } from '../players/entities/player.entity';
 import { DiscordMembershipService } from './discord-membership.service';
 import { BONFIRE_AUTH_VERSION } from './auth.constants';
+import { BonfireAdminAccessService } from './bonfire-admin-access.service';
 
 describe('AuthService', () => {
   it('does not include the Discord access token in the signed JWT payload', async () => {
@@ -22,6 +23,10 @@ describe('AuthService', () => {
         {
           provide: DiscordMembershipService,
           useValue: { assertBonfireMember: jest.fn() },
+        },
+        {
+          provide: BonfireAdminAccessService,
+          useValue: { isAdmin: jest.fn().mockReturnValue(true) },
         },
       ],
     }).compile();
@@ -40,6 +45,7 @@ describe('AuthService', () => {
       email: player.email,
       name: player.name,
       discord: player.discord,
+      isAdmin: true,
       authVersion: BONFIRE_AUTH_VERSION,
     });
     expect(signAsync.mock.calls[0][0]).not.toHaveProperty('accessToken');
@@ -70,6 +76,9 @@ describe('AuthService', () => {
       {} as JwtService,
       mediaStorageService as unknown as MediaStorageService,
       discordMembershipService as unknown as DiscordMembershipService,
+      {
+        isAdmin: jest.fn().mockReturnValue(false),
+      } as unknown as BonfireAdminAccessService,
     );
     const profile = {
       id: '1234',
@@ -109,6 +118,9 @@ describe('AuthService', () => {
       {} as JwtService,
       {} as MediaStorageService,
       discordMembershipService as unknown as DiscordMembershipService,
+      {
+        isAdmin: jest.fn().mockReturnValue(false),
+      } as unknown as BonfireAdminAccessService,
     );
     const profile = {
       id: 'outsider-id',

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import { Player } from '../players/entities/player.entity';
 import { MediaStorageService } from '../media/media-storage.service';
 import { DiscordMembershipService } from './discord-membership.service';
 import { BONFIRE_AUTH_VERSION } from './auth.constants';
+import { BonfireAdminAccessService } from './bonfire-admin-access.service';
 
 export type AuthPlayer = Player;
 
@@ -24,6 +25,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly mediaStorageService: MediaStorageService,
     private readonly discordMembershipService: DiscordMembershipService,
+    private readonly adminAccess: BonfireAdminAccessService,
   ) {}
 
   async validateDiscordUser(
@@ -79,6 +81,7 @@ export class AuthService {
       email,
       name,
       discord,
+      isAdmin: this.adminAccess.isAdmin(player),
       authVersion: BONFIRE_AUTH_VERSION,
     });
   }

--- a/server/src/auth/bonfire-admin-access.service.spec.ts
+++ b/server/src/auth/bonfire-admin-access.service.spec.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from '@nestjs/config';
+import { BonfireAdminAccessService } from './bonfire-admin-access.service';
+
+describe('BonfireAdminAccessService', () => {
+  it('allows only the single configured conductor Discord identity', () => {
+    const service = new BonfireAdminAccessService(
+      new ConfigService({ BONFIRE_CONDUCTOR_DISCORD_ID: 'owner-id' }),
+    );
+
+    expect(service.isAdmin({ discord: { id: 'owner-id' } })).toBe(true);
+    expect(service.isAdmin({ discord: { id: 'other-id' } })).toBe(false);
+    expect(service.isAdmin(undefined)).toBe(false);
+  });
+
+  it('fails closed when no conductor is configured', () => {
+    const service = new BonfireAdminAccessService(new ConfigService({}));
+
+    expect(service.isAdmin({ discord: { id: 'owner-id' } })).toBe(false);
+  });
+});

--- a/server/src/auth/bonfire-admin-access.service.ts
+++ b/server/src/auth/bonfire-admin-access.service.ts
@@ -4,19 +4,19 @@ import { Player } from '../players/entities/player.entity';
 
 @Injectable()
 export class BonfireAdminAccessService {
-  private readonly discordIds: Set<string>;
+  private readonly conductorDiscordId: string;
 
   constructor(config: ConfigService) {
-    this.discordIds = new Set(
-      (config.get<string>('BONFIRE_ADMIN_DISCORD_IDS') ?? '')
-        .split(',')
-        .map((id) => id.trim())
-        .filter(Boolean),
-    );
+    this.conductorDiscordId =
+      config.get<string>('BONFIRE_CONDUCTOR_DISCORD_ID')?.trim() ?? '';
   }
 
   isAdmin(player: Pick<Player, 'discord'> | null | undefined): boolean {
     const discordId = player?.discord?.id?.trim();
-    return Boolean(discordId && this.discordIds.has(discordId));
+    return Boolean(
+      discordId &&
+        this.conductorDiscordId &&
+        discordId === this.conductorDiscordId,
+    );
   }
 }

--- a/server/src/auth/bonfire-admin-access.service.ts
+++ b/server/src/auth/bonfire-admin-access.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Player } from '../players/entities/player.entity';
+
+@Injectable()
+export class BonfireAdminAccessService {
+  private readonly discordIds: Set<string>;
+
+  constructor(config: ConfigService) {
+    this.discordIds = new Set(
+      (config.get<string>('BONFIRE_ADMIN_DISCORD_IDS') ?? '')
+        .split(',')
+        .map((id) => id.trim())
+        .filter(Boolean),
+    );
+  }
+
+  isAdmin(player: Pick<Player, 'discord'> | null | undefined): boolean {
+    const discordId = player?.discord?.id?.trim();
+    return Boolean(discordId && this.discordIds.has(discordId));
+  }
+}

--- a/server/src/auth/guards/bonfire-admin.guard.ts
+++ b/server/src/auth/guards/bonfire-admin.guard.ts
@@ -1,0 +1,28 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { Player } from '../../players/entities/player.entity';
+import { BonfireAdminAccessService } from '../bonfire-admin-access.service';
+
+type AuthenticatedRequest = Request & { user?: Player };
+
+@Injectable()
+export class BonfireAdminGuard implements CanActivate {
+  constructor(private readonly access: BonfireAdminAccessService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+
+    if (!this.access.isAdmin(request.user)) {
+      throw new ForbiddenException(
+        'Only a cycle conductor can perform this action',
+      );
+    }
+
+    return true;
+  }
+}

--- a/server/src/campaign/campaign.module.ts
+++ b/server/src/campaign/campaign.module.ts
@@ -4,9 +4,12 @@ import { CampaignController } from './campaign.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Campaign } from './entities/campaign.entity';
 import { CampaignPlayer } from './entities/campaign-player.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Campaign, CampaignPlayer])],
+  imports: [
+    TypeOrmModule.forFeature([Campaign, CampaignPlayer, GameRecommendation]),
+  ],
   controllers: [CampaignController],
   providers: [CampaignService],
 })

--- a/server/src/campaign/campaign.service.spec.ts
+++ b/server/src/campaign/campaign.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { Game } from '../games/entities/game.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -17,7 +18,15 @@ describe('CampaignService voting', () => {
   beforeEach(async () => {
     dataSource = new DataSource({
       type: 'sqljs',
-      entities: [Campaign, CampaignPlayer, Game, Player, Pool, PoolOption],
+      entities: [
+        Campaign,
+        CampaignPlayer,
+        Game,
+        GameRecommendation,
+        Player,
+        Pool,
+        PoolOption,
+      ],
       synchronize: true,
     });
     await dataSource.initialize();
@@ -25,6 +34,7 @@ describe('CampaignService voting', () => {
     service = new CampaignService(
       dataSource.getRepository(Campaign),
       dataSource.getRepository(CampaignPlayer),
+      dataSource.getRepository(GameRecommendation),
       dataSource,
     );
 
@@ -85,6 +95,24 @@ describe('CampaignService voting', () => {
     expect(campaign.pool?.options[0].players).toHaveLength(0);
     expect(campaign.pool?.options[1].players.map((voter) => voter.id)).toEqual([
       player.id,
+    ]);
+  });
+
+  it('includes public recommenders with each current election game', async () => {
+    await dataSource.getRepository(GameRecommendation).save(
+      dataSource.getRepository(GameRecommendation).create({
+        game: options[0].game,
+        player,
+      }),
+    );
+
+    const campaign = await service.current();
+    const game = campaign.pool?.options[0].game as Game & {
+      recommendedBy: Array<{ id: number; name: string; avatar: string | null }>;
+    };
+
+    expect(game.recommendedBy).toEqual([
+      { id: player.id, name: 'Player', avatar: null },
     ]);
   });
 

--- a/server/src/campaign/campaign.service.spec.ts
+++ b/server/src/campaign/campaign.service.spec.ts
@@ -100,6 +100,24 @@ describe('CampaignService voting', () => {
     expect(campaign.pool?.options[1].players).toHaveLength(0);
   });
 
+  it('closes an expired election and rejects late votes', async () => {
+    const campaignRepository = dataSource.getRepository(Campaign);
+    const campaign = await campaignRepository.findOneByOrFail({
+      current: true,
+    });
+    campaign.electionStartedAt = '2026-08-01T20:00:00-03:00';
+    campaign.electionEndsAt = '2026-08-02T20:00:00-03:00';
+    await campaignRepository.save(campaign);
+
+    await expect(service.vote(player, options[1].id)).rejects.toThrow(
+      'A votação desta campanha está encerrada',
+    );
+
+    const current = await service.current();
+    expect(current.electionActive).toBe(false);
+    expect(current.electionClosedAt).toBeTruthy();
+  });
+
   it('handles concurrent first visits without duplicating campaign membership', async () => {
     await expect(
       Promise.all([service.current(player), service.current(player)]),

--- a/server/src/campaign/campaign.service.ts
+++ b/server/src/campaign/campaign.service.ts
@@ -205,6 +205,16 @@ export class CampaignService {
         relations: this.defaultRelations,
       });
 
+    if (this.isElectionExpired(currentCampaign)) {
+      const closedAt = new Date().toISOString();
+      await this.campaignRepository.update(currentCampaign.id, {
+        electionActive: false,
+        electionClosedAt: closedAt,
+      });
+      currentCampaign.electionActive = false;
+      currentCampaign.electionClosedAt = closedAt;
+    }
+
     if (!player) {
       return currentCampaign;
     }
@@ -257,6 +267,7 @@ export class CampaignService {
   async undoVote(player: Player): Promise<Campaign> {
     await this.dataSource.transaction(async (manager) => {
       const currentCampaign = await this.findCurrentCampaignOrFail(manager);
+      this.assertElectionOpen(currentCampaign);
       const pool = currentCampaign.pool;
 
       if (!pool) {
@@ -282,6 +293,7 @@ export class CampaignService {
   async vote(player: Player, optionId: number): Promise<Campaign> {
     await this.dataSource.transaction(async (manager) => {
       const currentCampaign = await this.findCurrentCampaignOrFail(manager);
+      this.assertElectionOpen(currentCampaign);
       const pool = currentCampaign.pool;
 
       if (!pool) {
@@ -356,6 +368,10 @@ export class CampaignService {
     const campaign = await manager.getRepository(Campaign).findOne({
       where: { current: true },
       relations: this.defaultRelations,
+      lock:
+        manager.connection.options.type === 'postgres'
+          ? { mode: 'pessimistic_write' }
+          : undefined,
     });
 
     if (!campaign) {
@@ -363,5 +379,16 @@ export class CampaignService {
     }
 
     return campaign;
+  }
+
+  private assertElectionOpen(campaign: Campaign): void {
+    if (!campaign.electionActive || this.isElectionExpired(campaign)) {
+      throw new BadRequestException('A votação desta campanha está encerrada');
+    }
+  }
+
+  private isElectionExpired(campaign: Campaign): boolean {
+    if (!campaign.electionEndsAt) return false;
+    return new Date(campaign.electionEndsAt).getTime() <= Date.now();
   }
 }

--- a/server/src/campaign/campaign.service.ts
+++ b/server/src/campaign/campaign.service.ts
@@ -18,6 +18,8 @@ import { CampaignPlayer } from './entities/campaign-player.entity';
 import { Player } from '../players/entities/player.entity';
 import { UpdateGameInformationDto } from './dto/update-game-information.dto';
 import { PoolOption } from '../pool/entities/pool-option.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
+import { GameRecommender, normalizeGameIdentity } from '../games/games.service';
 
 const normalizeMonth = (month: string): string =>
   month
@@ -76,6 +78,8 @@ export class CampaignService {
     private campaignRepository: Repository<Campaign>,
     @InjectRepository(CampaignPlayer)
     private campaignPlayerRepository: Repository<CampaignPlayer>,
+    @InjectRepository(GameRecommendation)
+    private gameRecommendationRepository: Repository<GameRecommendation>,
     private readonly dataSource: DataSource,
   ) {}
 
@@ -215,20 +219,60 @@ export class CampaignService {
       currentCampaign.electionClosedAt = closedAt;
     }
 
-    if (!player) {
-      return currentCampaign;
+    if (player) {
+      const wasPlayerAdded = await this.addPlayer(currentCampaign, player);
+
+      if (wasPlayerAdded) {
+        const reloadedCampaign = await this.campaignRepository.findOneOrFail({
+          where: { current: true },
+          relations: this.defaultRelations,
+        });
+        return this.attachPoolRecommenders(reloadedCampaign);
+      }
     }
 
-    const wasPlayerAdded = await this.addPlayer(currentCampaign, player);
+    return this.attachPoolRecommenders(currentCampaign);
+  }
 
-    if (wasPlayerAdded) {
-      return this.campaignRepository.findOneOrFail({
-        where: { current: true },
-        relations: this.defaultRelations,
+  private async attachPoolRecommenders(campaign: Campaign): Promise<Campaign> {
+    if (!campaign.pool?.options.length) return campaign;
+
+    const recommendations = await this.gameRecommendationRepository.find({
+      relations: ['game', 'player'],
+    });
+    const recommendersByIdentity = new Map<
+      string,
+      Map<number, GameRecommender>
+    >();
+
+    for (const recommendation of recommendations) {
+      const identity = normalizeGameIdentity(recommendation.game);
+      const recommenders =
+        recommendersByIdentity.get(identity) ??
+        new Map<number, GameRecommender>();
+      const player = recommendation.player;
+      recommenders.set(player.id, {
+        id: player.id,
+        name:
+          player.discord?.globalName ??
+          player.name ??
+          player.discord?.username ??
+          'Participante',
+        avatar: player.discord?.avatar ?? null,
       });
+      recommendersByIdentity.set(identity, recommenders);
     }
 
-    return currentCampaign;
+    for (const option of campaign.pool.options) {
+      const recommenders = Array.from(
+        recommendersByIdentity
+          .get(normalizeGameIdentity(option.game))
+          ?.values() ?? [],
+      ).sort((left, right) => left.name.localeCompare(right.name, 'pt-BR'));
+      Object.assign(option.game, { recommendedBy: recommenders });
+    }
+
+    return campaign;
   }
 
   getPlayerCampaign(campaign: Campaign, player: Player): CampaignPlayer | null {

--- a/server/src/campaign/entities/campaign.entity.ts
+++ b/server/src/campaign/entities/campaign.entity.ts
@@ -50,6 +50,15 @@ export class Campaign {
   @Column({ default: false })
   electionActive: boolean;
 
+  @Column({ name: 'election_started_at', type: 'varchar', nullable: true })
+  electionStartedAt: string | null;
+
+  @Column({ name: 'election_ends_at', type: 'varchar', nullable: true })
+  electionEndsAt: string | null;
+
+  @Column({ name: 'election_closed_at', type: 'varchar', nullable: true })
+  electionClosedAt: string | null;
+
   @ManyToOne(() => Pool, { nullable: true, onDelete: 'SET NULL' })
   @JoinColumn({ name: 'pool_id' })
   pool?: Pool | null;

--- a/server/src/cycle/cycle.controller.ts
+++ b/server/src/cycle/cycle.controller.ts
@@ -7,6 +7,7 @@ import { Player } from '../players/entities/player.entity';
 import { CycleService } from './cycle.service';
 import {
   ApplyCycleTransitionDto,
+  CancelElectionDto,
   PreviewCycleTransitionDto,
   StartElectionDto,
 } from './dto/cycle-transition.dto';
@@ -34,6 +35,14 @@ export class CycleController {
     @CurrentPlayer() player: Player,
   ) {
     return this.cycleService.startElection(body, player);
+  }
+
+  @Post('cancel-election')
+  cancelElection(
+    @Body() body: CancelElectionDto,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.cycleService.cancelElection(body, player);
   }
 
   @Post('transition/preview')

--- a/server/src/cycle/cycle.controller.ts
+++ b/server/src/cycle/cycle.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { CurrentPlayer } from '../auth/decorators/current-player.decorator';
+import { BonfireAdminGuard } from '../auth/guards/bonfire-admin.guard';
+import { Player } from '../players/entities/player.entity';
+import { CycleService } from './cycle.service';
+import {
+  ApplyCycleTransitionDto,
+  PreviewCycleTransitionDto,
+  StartElectionDto,
+} from './dto/cycle-transition.dto';
+
+@ApiTags('cycle')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'), BonfireAdminGuard)
+@Controller('cycle')
+export class CycleController {
+  constructor(private readonly cycleService: CycleService) {}
+
+  @Get('overview')
+  getOverview() {
+    return this.cycleService.getOverview();
+  }
+
+  @Post('draw')
+  drawPool() {
+    return this.cycleService.drawPool();
+  }
+
+  @Post('start-election')
+  startElection(
+    @Body() body: StartElectionDto,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.cycleService.startElection(body, player);
+  }
+
+  @Post('transition/preview')
+  previewTransition(@Body() body: PreviewCycleTransitionDto) {
+    return this.cycleService.previewTransition(body);
+  }
+
+  @Post('transition/apply')
+  applyTransition(
+    @Body() body: ApplyCycleTransitionDto,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.cycleService.applyTransition(body, player);
+  }
+}

--- a/server/src/cycle/cycle.module.ts
+++ b/server/src/cycle/cycle.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
+import { AuthModule } from '../auth/auth.module';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { Game } from '../games/entities/game.entity';
+import { GamesModule } from '../games/games.module';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Pool } from '../pool/entities/pool.entity';
+import { CycleController } from './cycle.controller';
+import { CycleService } from './cycle.service';
+import { DiscordCycleService } from './discord-cycle.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    AuthModule,
+    GamesModule,
+    TypeOrmModule.forFeature([AdminAuditLog, Campaign, Game, Pool, PoolOption]),
+  ],
+  controllers: [CycleController],
+  providers: [CycleService, DiscordCycleService],
+})
+export class CycleModule {}

--- a/server/src/cycle/cycle.module.ts
+++ b/server/src/cycle/cycle.module.ts
@@ -5,7 +5,6 @@ import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
 import { AuthModule } from '../auth/auth.module';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { Game } from '../games/entities/game.entity';
-import { GamesModule } from '../games/games.module';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
 import { CycleController } from './cycle.controller';
@@ -16,7 +15,6 @@ import { DiscordCycleService } from './discord-cycle.service';
   imports: [
     ConfigModule,
     AuthModule,
-    GamesModule,
     TypeOrmModule.forFeature([AdminAuditLog, Campaign, Game, Pool, PoolOption]),
   ],
   controllers: [CycleController],

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -268,6 +268,7 @@ describe('CycleService', () => {
     await expect(
       dataSource.getRepository(Pool).findOneBy({ id: poolId }),
     ).resolves.toBeNull();
+    await expect(dataSource.getRepository(PoolOption).count()).resolves.toBe(0);
     const cancellationLog = (
       await dataSource.getRepository(AdminAuditLog).find()
     ).find((entry) => entry.action === 'cycle_election_cancelled');

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -185,7 +185,10 @@ describe('CycleService', () => {
       (game) => !fillerTitles.has(game.title),
     );
     expect(unexpectedFillers).toEqual([]);
-    expect(draw.revealOrder).toHaveLength(5);
+    expect(draw.revealOrder).toHaveLength(4);
+    expect(draw.revealOrder).toEqual(
+      expect.arrayContaining(draw.selectedFillers),
+    );
     expect(
       draw.excludedUnverified.every(
         (game) => game.title === 'Unchecked filler',
@@ -210,6 +213,55 @@ describe('CycleService', () => {
         actor: `player:${actor.id}`,
       }),
     ]);
+  });
+
+  it('keeps every meeting suggestion when the group suggests more than five games', async () => {
+    const suggestions: Game[] = [];
+    for (const index of Array.from({ length: 7 }, (_, value) => value)) {
+      const game = await saveGame({
+        title: `Meeting Suggestion ${index + 1}`,
+        suggestion: true,
+        mainExtraHours: 8 + index,
+      });
+      const playerRepository = dataSource.getRepository(Player);
+      const player = await playerRepository.save(
+        playerRepository.create({ name: `Recommender ${index + 1}` }),
+      );
+      await dataSource.getRepository(CampaignPlayer).save(
+        dataSource.getRepository(CampaignPlayer).create({
+          campaign,
+          player,
+          suggested_a_game: true,
+          suggestedGame: game,
+        }),
+      );
+      suggestions.push(game);
+    }
+    await saveGame({
+      title: 'Catalog game that must not displace a suggestion',
+      suggestion: true,
+      mainExtraHours: 6,
+    });
+
+    const draw = (await service.drawPool()) as {
+      guaranteedGames: Game[];
+      selectedFillers: Game[];
+      revealOrder: Game[];
+      selectionToken: string;
+    };
+
+    expect(draw.guaranteedGames).toHaveLength(7);
+    expect(draw.guaranteedGames.map((game) => game.id)).toEqual(
+      expect.arrayContaining(suggestions.map((game) => game.id)),
+    );
+    expect(draw.selectedFillers).toEqual([]);
+    expect(draw.revealOrder).toEqual([]);
+
+    const started = await service.startElection(
+      { selectionToken: draw.selectionToken },
+      actor,
+    );
+    expect(started.pool?.options).toHaveLength(7);
   });
 
   it('researches an unchecked catalog game and fails closed when no duration is found', async () => {

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -235,6 +235,47 @@ describe('CycleService', () => {
     ]);
   });
 
+  it('undoes an accidentally started election without counting its pool appearances', async () => {
+    await Promise.all(
+      ['One', 'Two', 'Three', 'Four', 'Five'].map((title) =>
+        saveGame({ title, suggestion: true, mainExtraHours: 8 }),
+      ),
+    );
+    const voter = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Early voter' }));
+    const draw = (await service.drawPool()) as { selectionToken: string };
+    const started = await service.startElection(
+      { selectionToken: draw.selectionToken },
+      actor,
+    );
+    const poolId = started.pool?.id;
+    const firstOption = started.pool?.options[0];
+    if (!poolId || !firstOption) throw new Error('Expected a started pool');
+    firstOption.players = [voter];
+    await dataSource.getRepository(PoolOption).save(firstOption);
+
+    const cancelled = await service.cancelElection({ confirm: true }, actor);
+
+    expect(cancelled).toMatchObject({
+      id: campaign.id,
+      electionActive: false,
+      electionStartedAt: null,
+      electionEndsAt: null,
+      electionClosedAt: null,
+      pool: null,
+    });
+    await expect(
+      dataSource.getRepository(Pool).findOneBy({ id: poolId }),
+    ).resolves.toBeNull();
+    const cancellationLog = (
+      await dataSource.getRepository(AdminAuditLog).find()
+    ).find((entry) => entry.action === 'cycle_election_cancelled');
+    expect(cancellationLog?.result).toMatchObject({
+      discardedVotes: 1,
+    });
+  });
+
   it('rejects a draw token after its selection is modified', async () => {
     await Promise.all(
       ['One', 'Two', 'Three', 'Four', 'Five'].map((title) =>
@@ -314,7 +355,11 @@ describe('CycleService', () => {
     expect(preview).toMatchObject({
       valid: true,
       winner: { id: winner.id, title: winner.title },
-      campaign: { month: 'Setembro', year: '2026' },
+      campaign: {
+        month: 'Setembro',
+        year: '2026',
+        description: 'Uma jornada curta.',
+      },
     });
     expect(preview.confirmationToken).toBeTruthy();
 

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -1,0 +1,367 @@
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
+import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { GameRecommendation } from '../games/entities/game-recommendation.entity';
+import { Game } from '../games/entities/game.entity';
+import {
+  CatalogGameResearchInput,
+  GameResearchService,
+} from '../games/game-research.service';
+import { Player } from '../players/entities/player.entity';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Pool } from '../pool/entities/pool.entity';
+import { CycleService } from './cycle.service';
+import {
+  DiscordCyclePreview,
+  DiscordCycleService,
+} from './discord-cycle.service';
+
+const disabledDiscordPreview: DiscordCyclePreview = {
+  configured: false,
+  enabled: false,
+  guildId: 'guild',
+  channels: { text: [], categories: [], voice: [] },
+  plan: {
+    oldChannel: null,
+    discussionCategory: null,
+    historyCategory: null,
+    createHistoryCategory: false,
+    newChannelName: 'next-game',
+    newChannelTopic: 'Next game',
+    existingNewChannel: null,
+    voiceChannel: null,
+    eventName: null,
+    gameCard: {
+      title: 'Next Game',
+      description: 'Next game',
+      url: null,
+      imageUrl: null,
+      details: null,
+      marker: 'Sob a Luz do Bonfire · Setembro 2026',
+    },
+  },
+  warnings: [],
+  errors: [],
+};
+
+describe('CycleService', () => {
+  let dataSource: DataSource;
+  let service: CycleService;
+  let discord: jest.Mocked<
+    Pick<DiscordCycleService, 'isConfigured' | 'preview' | 'apply'>
+  >;
+  let actor: Player;
+  let currentGame: Game;
+  let campaign: Campaign;
+  let gameResearch: jest.Mocked<Pick<GameResearchService, 'assessCatalogGame'>>;
+  let assessCatalogGame: jest.MockedFunction<
+    GameResearchService['assessCatalogGame']
+  >;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqljs',
+      entities: [
+        AdminAuditLog,
+        Campaign,
+        CampaignPlayer,
+        Game,
+        GameRecommendation,
+        Player,
+        Pool,
+        PoolOption,
+      ],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+
+    discord = {
+      isConfigured: jest.fn().mockReturnValue(false),
+      preview: jest.fn().mockResolvedValue(disabledDiscordPreview),
+      apply: jest.fn().mockResolvedValue({
+        archivedChannelId: null,
+        historyCategoryId: null,
+        newChannelId: null,
+        eventId: null,
+        eventUrl: null,
+        gameMessageId: null,
+        gameMessageUrl: null,
+      }),
+    };
+    assessCatalogGame = jest
+      .fn()
+      .mockImplementation((game: CatalogGameResearchInput) =>
+        Promise.resolve({
+          eligible: false,
+          reason: 'duration_unavailable',
+          limitHours: 20,
+          game: {
+            steamAppId: 0,
+            title: game.title,
+            cover: game.cover ?? null,
+            steam: game.steam ?? '',
+            trailer: game.trailer ?? null,
+            summary: game.summary ?? null,
+            howLongToBeatUrl: null,
+            durationLabel: null,
+            mainHours: null,
+            mainExtraHours: null,
+            howLongToBeatTitle: null,
+          },
+        }),
+      );
+    gameResearch = { assessCatalogGame };
+    service = new CycleService(
+      dataSource.getRepository(Campaign),
+      dataSource.getRepository(Game),
+      dataSource,
+      new ConfigService({ JWT_SECRET: 'cycle-test-secret' }),
+      discord as unknown as DiscordCycleService,
+      gameResearch as unknown as GameResearchService,
+    );
+
+    actor = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Conductor' }));
+    currentGame = await saveGame({
+      title: 'Current Game',
+      suggestion: false,
+      mainExtraHours: 12,
+    });
+    campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        game: currentGame,
+        players: [],
+        electionActive: false,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('draws all meeting suggestions and fills the pool with verified eligible games', async () => {
+    const suggestion = await saveGame({
+      title: 'Meeting Suggestion',
+      suggestion: true,
+      mainExtraHours: 14,
+    });
+    await attachSuggestion(suggestion);
+    const fillers = await Promise.all(
+      ['A', 'B', 'C', 'D', 'E'].map((title) =>
+        saveGame({
+          title: `Filler ${title}`,
+          suggestion: true,
+          mainExtraHours: 10,
+        }),
+      ),
+    );
+    await saveGame({
+      title: 'Unchecked filler',
+      suggestion: true,
+      mainExtraHours: null,
+    });
+
+    const draw = (await service.drawPool()) as {
+      guaranteedGames: Game[];
+      selectedFillers: Game[];
+      revealOrder: Game[];
+      excludedUnverified: Game[];
+      selectionToken: string;
+    };
+
+    expect(draw.guaranteedGames.map((game) => game.id)).toEqual([
+      suggestion.id,
+    ]);
+    expect(draw.selectedFillers).toHaveLength(4);
+    const fillerTitles = new Set(fillers.map((game) => game.title));
+    const unexpectedFillers = draw.selectedFillers.filter(
+      (game) => !fillerTitles.has(game.title),
+    );
+    expect(unexpectedFillers).toEqual([]);
+    expect(draw.revealOrder).toHaveLength(5);
+    expect(
+      draw.excludedUnverified.every(
+        (game) => game.title === 'Unchecked filler',
+      ),
+    ).toBe(true);
+
+    const started = await service.startElection(
+      { selectionToken: draw.selectionToken },
+      actor,
+    );
+    expect(started).toMatchObject({
+      id: campaign.id,
+      electionActive: true,
+      electionEndsAt: null,
+    });
+    expect(started.pool?.options).toHaveLength(5);
+    await expect(
+      dataSource.getRepository(AdminAuditLog).find(),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        action: 'cycle_election_started',
+        actor: `player:${actor.id}`,
+      }),
+    ]);
+  });
+
+  it('researches an unchecked catalog game and fails closed when no duration is found', async () => {
+    await saveGame({
+      title: 'Unchecked filler',
+      suggestion: true,
+      steam: 'https://store.steampowered.com/app/42/',
+      mainExtraHours: null,
+    });
+
+    const draw = (await service.drawPool()) as {
+      selectedFillers: Game[];
+      excludedUnverified: Game[];
+    };
+
+    expect(assessCatalogGame).toHaveBeenCalledTimes(1);
+    expect(draw.selectedFillers).toEqual([]);
+    expect(draw.excludedUnverified).toEqual([
+      expect.objectContaining({
+        title: 'Unchecked filler',
+        researchStatus: 'duration_unavailable',
+      }),
+    ]);
+  });
+
+  it('rejects a draw token after its selection is modified', async () => {
+    await Promise.all(
+      ['One', 'Two', 'Three', 'Four', 'Five'].map((title) =>
+        saveGame({ title, suggestion: true, mainExtraHours: 8 }),
+      ),
+    );
+    const draw = (await service.drawPool()) as { selectionToken: string };
+    const tampered = `${draw.selectionToken.slice(0, -1)}x`;
+
+    await expect(
+      service.startElection({ selectionToken: tampered }, actor),
+    ).rejects.toThrow('Token de confirmação inválido');
+    await expect(dataSource.getRepository(Pool).count()).resolves.toBe(0);
+  });
+
+  it('closes the old election and creates the next current campaign without replacing history', async () => {
+    const winner = await saveGame({
+      title: 'Winning Game',
+      suggestion: true,
+      mainExtraHours: 9,
+      summary: 'Uma jornada curta.',
+      steam: 'https://store.steampowered.com/app/42/',
+    });
+    const runnerUp = await saveGame({
+      title: 'Runner Up',
+      suggestion: true,
+      mainExtraHours: 11,
+    });
+    const voter = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Voter' }));
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player: voter,
+        played_the_game: true,
+        finished_the_game: true,
+        partook_in_the_meeting: true,
+        suggested_a_game: false,
+      }),
+    );
+    const pool = await dataSource.getRepository(Pool).save(
+      dataSource.getRepository(Pool).create({
+        options: [
+          dataSource.getRepository(PoolOption).create({
+            game: winner,
+            players: [voter],
+          }),
+          dataSource.getRepository(PoolOption).create({
+            game: runnerUp,
+            players: [],
+          }),
+        ],
+      }),
+    );
+    campaign.pool = pool;
+    campaign.electionActive = true;
+    await dataSource.getRepository(Campaign).save(campaign);
+    const winnerOption = await dataSource
+      .getRepository(PoolOption)
+      .findOneOrFail({
+        where: { pool: { id: pool.id }, game: { id: winner.id } },
+        relations: ['players'],
+      });
+    winnerOption.players = [voter];
+    await dataSource.getRepository(PoolOption).save(winnerOption);
+
+    const input = {
+      winnerGameId: winner.id,
+      month: 'Setembro',
+      year: '2026',
+      discord: { enabled: false },
+    };
+    const preview = await service.previewTransition(input);
+
+    expect(preview.errors).toEqual([]);
+    expect(preview).toMatchObject({
+      valid: true,
+      winner: { id: winner.id, title: winner.title },
+      campaign: { month: 'Setembro', year: '2026' },
+    });
+    expect(preview.confirmationToken).toBeTruthy();
+
+    const applied = (await service.applyTransition(
+      {
+        ...input,
+        confirm: true,
+        confirmationToken: preview.confirmationToken ?? '',
+      },
+      actor,
+    )) as { campaign: Campaign };
+
+    expect(applied.campaign).toMatchObject({
+      month: 'Setembro',
+      year: '2026',
+      current: true,
+      game: { id: winner.id, title: winner.title },
+      electionActive: false,
+    });
+    await expect(
+      dataSource.getRepository(Campaign).findOneOrFail({
+        where: { id: campaign.id },
+        relations: ['game'],
+      }),
+    ).resolves.toMatchObject({
+      current: false,
+      game: { id: currentGame.id, title: currentGame.title },
+      electionActive: false,
+    });
+    expect(discord.apply).toHaveBeenCalledTimes(1);
+  });
+
+  async function saveGame(
+    game: Partial<Game> & Pick<Game, 'title'>,
+  ): Promise<Game> {
+    const repository = dataSource.getRepository(Game);
+    return repository.save(repository.create(game));
+  }
+
+  async function attachSuggestion(game: Game): Promise<void> {
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player: actor,
+        suggested_a_game: true,
+        suggestedGame: game,
+      }),
+    );
+  }
+});

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -5,10 +5,6 @@ import { CampaignPlayer } from '../campaign/entities/campaign-player.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { GameRecommendation } from '../games/entities/game-recommendation.entity';
 import { Game } from '../games/entities/game.entity';
-import {
-  CatalogGameResearchInput,
-  GameResearchService,
-} from '../games/game-research.service';
 import { Player } from '../players/entities/player.entity';
 import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
@@ -55,10 +51,6 @@ describe('CycleService', () => {
   let actor: Player;
   let currentGame: Game;
   let campaign: Campaign;
-  let gameResearch: jest.Mocked<Pick<GameResearchService, 'assessCatalogGame'>>;
-  let assessCatalogGame: jest.MockedFunction<
-    GameResearchService['assessCatalogGame']
-  >;
 
   beforeEach(async () => {
     dataSource = new DataSource({
@@ -90,36 +82,12 @@ describe('CycleService', () => {
         gameMessageUrl: null,
       }),
     };
-    assessCatalogGame = jest
-      .fn()
-      .mockImplementation((game: CatalogGameResearchInput) =>
-        Promise.resolve({
-          eligible: false,
-          reason: 'duration_unavailable',
-          limitHours: 20,
-          game: {
-            steamAppId: 0,
-            title: game.title,
-            cover: game.cover ?? null,
-            steam: game.steam ?? '',
-            trailer: game.trailer ?? null,
-            summary: game.summary ?? null,
-            howLongToBeatUrl: null,
-            durationLabel: null,
-            mainHours: null,
-            mainExtraHours: null,
-            howLongToBeatTitle: null,
-          },
-        }),
-      );
-    gameResearch = { assessCatalogGame };
     service = new CycleService(
       dataSource.getRepository(Campaign),
       dataSource.getRepository(Game),
       dataSource,
       new ConfigService({ JWT_SECRET: 'cycle-test-secret' }),
       discord as unknown as DiscordCycleService,
-      gameResearch as unknown as GameResearchService,
     );
 
     actor = await dataSource
@@ -146,27 +114,19 @@ describe('CycleService', () => {
     await dataSource.destroy();
   });
 
-  it('draws all meeting suggestions and fills the pool with verified eligible games', async () => {
+  it('draws all meeting suggestions and fills the pool from the curated catalog', async () => {
     const suggestion = await saveGame({
       title: 'Meeting Suggestion',
       suggestion: true,
       mainExtraHours: 14,
     });
     await attachSuggestion(suggestion);
-    const fillers = await Promise.all(
-      ['A', 'B', 'C', 'D', 'E'].map((title) =>
-        saveGame({
-          title: `Filler ${title}`,
-          suggestion: true,
-          mainExtraHours: 10,
-        }),
-      ),
-    );
-    await saveGame({
-      title: 'Unchecked filler',
-      suggestion: true,
-      mainExtraHours: null,
-    });
+    const fillers = await Promise.all([
+      saveGame({ title: 'Filler A', suggestion: true, mainExtraHours: 10 }),
+      saveGame({ title: 'Filler B', suggestion: true, mainExtraHours: null }),
+      saveGame({ title: 'Filler C', suggestion: true, mainExtraHours: 99 }),
+      saveGame({ title: 'Filler D', suggestion: true, mainExtraHours: 8 }),
+    ]);
 
     const draw = (await service.drawPool()) as {
       guaranteedGames: Game[];
@@ -189,11 +149,7 @@ describe('CycleService', () => {
     expect(draw.revealOrder).toEqual(
       expect.arrayContaining(draw.selectedFillers),
     );
-    expect(
-      draw.excludedUnverified.every(
-        (game) => game.title === 'Unchecked filler',
-      ),
-    ).toBe(true);
+    expect(draw.excludedUnverified).toEqual([]);
 
     const started = await service.startElection(
       { selectionToken: draw.selectionToken },
@@ -264,8 +220,8 @@ describe('CycleService', () => {
     expect(started.pool?.options).toHaveLength(7);
   });
 
-  it('researches an unchecked catalog game and fails closed when no duration is found', async () => {
-    await saveGame({
+  it('uses an admitted catalog game without checking its duration again', async () => {
+    const unchecked = await saveGame({
       title: 'Unchecked filler',
       suggestion: true,
       steam: 'https://store.steampowered.com/app/42/',
@@ -275,16 +231,20 @@ describe('CycleService', () => {
     const draw = (await service.drawPool()) as {
       selectedFillers: Game[];
       excludedUnverified: Game[];
+      selectionToken: string;
     };
 
-    expect(assessCatalogGame).toHaveBeenCalledTimes(1);
-    expect(draw.selectedFillers).toEqual([]);
-    expect(draw.excludedUnverified).toEqual([
-      expect.objectContaining({
-        title: 'Unchecked filler',
-        researchStatus: 'duration_unavailable',
-      }),
+    expect(draw.selectedFillers).toEqual([
+      expect.objectContaining({ id: unchecked.id, title: unchecked.title }),
     ]);
+    expect(draw.excludedUnverified).toEqual([]);
+
+    const started = await service.startElection(
+      { selectionToken: draw.selectionToken },
+      actor,
+    );
+    expect(started.pool?.options).toHaveLength(1);
+    expect(started.pool?.options[0]?.game.id).toBe(unchecked.id);
   });
 
   it('undoes an accidentally started election without counting its pool appearances', async () => {

--- a/server/src/cycle/cycle.service.spec.ts
+++ b/server/src/cycle/cycle.service.spec.ts
@@ -309,7 +309,7 @@ describe('CycleService', () => {
       title: 'Winning Game',
       suggestion: true,
       mainExtraHours: 9,
-      summary: 'Uma jornada curta.',
+      summary: 'Uma jornada curta. A descrição completa continua aqui.',
       steam: 'https://store.steampowered.com/app/42/',
     });
     const runnerUp = await saveGame({
@@ -371,7 +371,7 @@ describe('CycleService', () => {
       campaign: {
         month: 'Setembro',
         year: '2026',
-        description: 'Uma jornada curta.',
+        description: 'Uma jornada curta. A descrição completa continua aqui.',
       },
     });
     expect(preview.confirmationToken).toBeTruthy();

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -22,6 +22,7 @@ import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
 import {
   ApplyCycleTransitionDto,
+  CancelElectionDto,
   PreviewCycleTransitionDto,
   StartElectionDto,
 } from './dto/cycle-transition.dto';
@@ -353,6 +354,48 @@ export class CycleService {
     return campaign;
   }
 
+  async cancelElection(
+    dto: CancelElectionDto,
+    actor: Player,
+  ): Promise<Campaign> {
+    if (!dto.confirm) {
+      throw new BadRequestException('Confirme que deseja desfazer a votação.');
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      const current = await this.findCurrentCampaignOrFail(manager);
+      if (!current.pool || !current.electionStartedAt) {
+        throw new BadRequestException(
+          'Não há uma votação iniciada pelo condutor para desfazer.',
+        );
+      }
+
+      const poolId = current.pool.id;
+      const gameIds = current.pool.options.map((option) => option.game.id);
+      const discardedVotes = current.pool.options.reduce(
+        (total, option) => total + option.players.length,
+        0,
+      );
+
+      current.pool = null;
+      current.electionActive = false;
+      current.electionStartedAt = null;
+      current.electionEndsAt = null;
+      current.electionClosedAt = null;
+      await manager.getRepository(Campaign).save(current);
+      await manager.getRepository(Pool).delete(poolId);
+      await this.writeAudit(
+        manager,
+        'cycle_election_cancelled',
+        actor,
+        { confirm: true },
+        { campaignId: current.id, poolId, gameIds, discardedVotes },
+      );
+
+      return this.findCurrentCampaignOrFail(manager);
+    });
+  }
+
   async previewTransition(
     dto: PreviewCycleTransitionDto,
   ): Promise<CycleTransitionPreview> {
@@ -395,8 +438,7 @@ export class CycleService {
     }
 
     const description = winner
-      ? dto.description?.trim() ||
-        this.buildCampaignDescription(winner, dto.month, dto.meetingAt)
+      ? dto.description?.trim() || this.buildCampaignDescription(winner)
       : '';
     const discordPreview = winner
       ? await this.discord.preview({
@@ -685,40 +727,17 @@ export class CycleService {
     return selected;
   }
 
-  private buildCampaignDescription(
-    game: Game,
-    month: string,
-    meetingAt?: string,
-  ): string {
-    const links = [
-      game.steam ? `[Steam](${game.steam})` : null,
-      game.trailer ? `[Trailer](${game.trailer})` : null,
-      game.howLongToBeatUrl
-        ? `[HowLongToBeat](${game.howLongToBeatUrl})${game.durationLabel ? ` ${game.durationLabel}` : ''}`
-        : null,
-    ].filter(Boolean);
-    const meeting = meetingAt
-      ? `\n\nO nosso próximo encontro será em ${new Intl.DateTimeFormat(
-          'pt-BR',
-          {
-            dateStyle: 'long',
-            timeStyle: 'short',
-            timeZone: 'America/Sao_Paulo',
-          },
-        ).format(new Date(meetingAt))}.`
-      : '';
+  private buildCampaignDescription(game: Game): string {
+    const summary =
+      game.summary?.replace(/\s+/g, ' ').trim() ||
+      'Uma nova jornada escolhida ao redor da fogueira.';
+    const firstSentence = summary.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim();
+    const phrase = firstSentence || summary;
+    if (phrase.length <= 220) return phrase;
 
-    return (
-      [
-        `O jogo do mês de ${month.trim()} é:`,
-        `**${game.title}**`,
-        game.summary?.trim() ||
-          'Uma nova jornada escolhida ao redor da fogueira.',
-        links.join(' · '),
-      ]
-        .filter(Boolean)
-        .join('\n\n') + meeting
-    );
+    const shortened = phrase.slice(0, 219);
+    const lastSpace = shortened.lastIndexOf(' ');
+    return `${shortened.slice(0, lastSpace > 160 ? lastSpace : 219).trim()}…`;
   }
 
   private getNextCampaignDefaults(campaign: Campaign): {

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -371,6 +371,7 @@ export class CycleService {
       }
 
       const poolId = current.pool.id;
+      const optionIds = current.pool.options.map((option) => option.id);
       const gameIds = current.pool.options.map((option) => option.game.id);
       const discardedVotes = current.pool.options.reduce(
         (total, option) => total + option.players.length,
@@ -383,6 +384,15 @@ export class CycleService {
       current.electionEndsAt = null;
       current.electionClosedAt = null;
       await manager.getRepository(Campaign).save(current);
+      if (optionIds.length > 0) {
+        await manager
+          .createQueryBuilder()
+          .delete()
+          .from('pool_option_players')
+          .where('pool_option_id IN (:...optionIds)', { optionIds })
+          .execute();
+        await manager.getRepository(PoolOption).delete(optionIds);
+      }
       await manager.getRepository(Pool).delete(poolId);
       await this.writeAudit(
         manager,

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -10,7 +10,6 @@ import { DataSource, EntityManager, Repository } from 'typeorm';
 import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
 import { Campaign } from '../campaign/entities/campaign.entity';
 import { Game } from '../games/entities/game.entity';
-import { GameResearchService } from '../games/game-research.service';
 import {
   TARGET_POOL_SIZE,
   findEligibleBacklogGames,
@@ -111,7 +110,6 @@ export class CycleService {
     private readonly dataSource: DataSource,
     config: ConfigService,
     private readonly discord: DiscordCycleService,
-    private readonly gameResearch: GameResearchService,
   ) {
     this.signingSecret =
       config.get<string>('CYCLE_AUTOMATION_SECRET')?.trim() ||
@@ -158,24 +156,6 @@ export class CycleService {
     const guaranteedGames = await findGuaranteedNextVoteGames(
       this.dataSource.manager,
     );
-    for (const game of guaranteedGames) {
-      await this.refreshResearch(game);
-    }
-    const invalidGuaranteed = guaranteedGames.filter(
-      (game) => !this.isDurationEligible(game),
-    );
-    if (invalidGuaranteed.length > 0) {
-      throw new BadRequestException({
-        message:
-          'Há sugestões sem uma duração válida no HowLongToBeat. Pesquise-as antes do sorteio.',
-        games: invalidGuaranteed.map((game) => ({
-          id: game.id,
-          title: game.title,
-          mainExtraHours: game.mainExtraHours,
-        })),
-      });
-    }
-
     const guaranteedIdentities = new Set(
       guaranteedGames.map(normalizeGameIdentity),
     );
@@ -184,31 +164,9 @@ export class CycleService {
       guaranteedIdentities,
     );
     const fillCount = Math.max(0, TARGET_POOL_SIZE - guaranteedGames.length);
-    const selectedFillers: Game[] = [];
-    const rejectedCandidates: Game[] = [];
-    const shuffledCandidates = this.shuffle(backlogCandidates);
-    for (
-      let index = 0;
-      index < shuffledCandidates.length && selectedFillers.length < fillCount;
-      index += 2
-    ) {
-      const batch = shuffledCandidates.slice(index, index + 2);
-      await Promise.all(batch.map((game) => this.refreshResearch(game)));
-      for (const game of batch) {
-        if (selectedFillers.length >= fillCount) break;
-        if (this.isDurationEligible(game)) {
-          selectedFillers.push(game);
-        } else {
-          rejectedCandidates.push(game);
-        }
-      }
-    }
-    const excludedUnverified = rejectedCandidates.filter(
-      (game) => !this.hasKnownDuration(game),
-    );
-    const excludedTooLong = rejectedCandidates.filter(
-      (game) => this.hasKnownDuration(game) && !this.isDurationEligible(game),
-    );
+    const selectedFillers = this.shuffle(backlogCandidates).slice(0, fillCount);
+    const excludedUnverified: Game[] = [];
+    const excludedTooLong: Game[] = [];
     const selection = [...guaranteedGames, ...selectedFillers];
     const revealOrder = this.shuffle(selectedFillers);
     const warnings: string[] = [];
@@ -218,17 +176,6 @@ export class CycleService {
         `Só há ${selectedFillers.length} jogos elegíveis nas Brasas para ${fillCount} espaços.`,
       );
     }
-    if (excludedUnverified.length > 0) {
-      warnings.push(
-        `${excludedUnverified.length} jogos sorteados ficaram fora porque a duração não pôde ser verificada.`,
-      );
-    }
-    if (excludedTooLong.length > 0) {
-      warnings.push(
-        `${excludedTooLong.length} jogos sorteados ficaram fora por passarem de 20 horas.`,
-      );
-    }
-
     const token = this.signToken<DrawTokenPayload>({
       kind: 'cycle-draw',
       campaignId: campaign.id,
@@ -292,21 +239,12 @@ export class CycleService {
           'Um dos jogos sorteados não está mais disponível.',
         );
       }
-      if (games.some((game) => !this.isDurationEligible(game))) {
-        throw new BadRequestException(
-          'Um dos jogos sorteados perdeu a verificação de duração.',
-        );
-      }
-
       const allowedFillers = await findEligibleBacklogGames(
         manager,
         new Set(guaranteedGames.map(normalizeGameIdentity)),
       );
       const allowedIdentities = new Set(
-        [
-          ...guaranteedGames,
-          ...allowedFillers.filter((game) => this.isDurationEligible(game)),
-        ].map(normalizeGameIdentity),
+        [...guaranteedGames, ...allowedFillers].map(normalizeGameIdentity),
       );
       if (
         games.some(
@@ -650,46 +588,6 @@ export class CycleService {
     });
 
     return { campaign: nextCampaign, discord: discordResult };
-  }
-
-  private hasKnownDuration(game: Game): boolean {
-    return (
-      typeof game.mainExtraHours === 'number' &&
-      Number.isFinite(game.mainExtraHours)
-    );
-  }
-
-  private isDurationEligible(game: Game): boolean {
-    return (
-      this.hasKnownDuration(game) &&
-      (game.mainExtraHours ?? Number.POSITIVE_INFINITY) >= 0 &&
-      (game.mainExtraHours ?? Number.POSITIVE_INFINITY) <= 20
-    );
-  }
-
-  private async refreshResearch(game: Game): Promise<void> {
-    if (this.hasKnownDuration(game)) return;
-    const checkedAt = game.researchCheckedAt
-      ? new Date(game.researchCheckedAt).getTime()
-      : 0;
-    if (checkedAt > Date.now() - 5 * 60 * 1000) return;
-
-    try {
-      const assessment = await this.gameResearch.assessCatalogGame(game);
-      game.cover ||= assessment.game.cover;
-      game.trailer ||= assessment.game.trailer;
-      game.summary ||= assessment.game.summary;
-      game.howLongToBeatUrl = assessment.game.howLongToBeatUrl;
-      game.durationLabel = assessment.game.durationLabel;
-      game.mainHours = assessment.game.mainHours;
-      game.mainExtraHours = assessment.game.mainExtraHours;
-      game.howLongToBeatTitle = assessment.game.howLongToBeatTitle;
-      game.researchStatus = assessment.reason;
-    } catch {
-      game.researchStatus = 'duration_unavailable';
-    }
-    game.researchCheckedAt = new Date().toISOString();
-    await this.gameRepository.save(game);
   }
 
   private calculateElectionResult(campaign: Campaign): ElectionResultOption[] {

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -210,7 +210,7 @@ export class CycleService {
       (game) => this.hasKnownDuration(game) && !this.isDurationEligible(game),
     );
     const selection = [...guaranteedGames, ...selectedFillers];
-    const revealOrder = this.shuffle(selection);
+    const revealOrder = this.shuffle(selectedFillers);
     const warnings: string[] = [];
 
     if (selectedFillers.length < fillCount) {

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -1,0 +1,915 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHmac, randomInt, timingSafeEqual } from 'node:crypto';
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
+import { Campaign } from '../campaign/entities/campaign.entity';
+import { Game } from '../games/entities/game.entity';
+import { GameResearchService } from '../games/game-research.service';
+import {
+  TARGET_POOL_SIZE,
+  findEligibleBacklogGames,
+  findGuaranteedNextVoteGames,
+  normalizeGameIdentity,
+} from '../games/games.service';
+import { Player } from '../players/entities/player.entity';
+import { PoolOption } from '../pool/entities/pool-option.entity';
+import { Pool } from '../pool/entities/pool.entity';
+import {
+  ApplyCycleTransitionDto,
+  PreviewCycleTransitionDto,
+  StartElectionDto,
+} from './dto/cycle-transition.dto';
+import {
+  DiscordCyclePreview,
+  DiscordCycleService,
+} from './discord-cycle.service';
+
+const campaignRelations = [
+  'game',
+  'players',
+  'players.player',
+  'players.suggestedGame',
+  'pool',
+  'pool.options',
+  'pool.options.game',
+  'pool.options.players',
+];
+const PORTUGUESE_MONTHS = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro',
+];
+
+interface DrawTokenPayload {
+  kind: 'cycle-draw';
+  campaignId: number;
+  gameIds: number[];
+  guaranteedGameIds: number[];
+  expiresAt: number;
+}
+
+interface TransitionTokenPayload {
+  kind: 'cycle-transition';
+  campaignId: number;
+  winnerGameId: number;
+  voteFingerprint: string;
+  inputFingerprint: string;
+  discordFingerprint: string;
+  expiresAt: number;
+}
+
+export interface ElectionResultOption {
+  optionId: number;
+  gameId: number;
+  game: string;
+  tokens: number;
+  voters: string[];
+}
+
+export interface CycleTransitionPreview {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  confirmationToken: string | null;
+  electionResult: ElectionResultOption[];
+  winner: Game | null;
+  campaign: {
+    month: string;
+    year: string;
+    description: string;
+    meetingAt: string | null;
+    meetingLocation: string | null;
+  } | null;
+  discord: DiscordCyclePreview | null;
+}
+
+@Injectable()
+export class CycleService {
+  private readonly signingSecret: string;
+
+  constructor(
+    @InjectRepository(Campaign)
+    private readonly campaignRepository: Repository<Campaign>,
+    @InjectRepository(Game)
+    private readonly gameRepository: Repository<Game>,
+    private readonly dataSource: DataSource,
+    config: ConfigService,
+    private readonly discord: DiscordCycleService,
+    private readonly gameResearch: GameResearchService,
+  ) {
+    this.signingSecret =
+      config.get<string>('CYCLE_AUTOMATION_SECRET')?.trim() ||
+      config.getOrThrow<string>('JWT_SECRET');
+  }
+
+  async getOverview(): Promise<Record<string, unknown>> {
+    const campaign = await this.findCurrentCampaignOrFail();
+    if (
+      campaign.electionActive &&
+      campaign.electionEndsAt &&
+      new Date(campaign.electionEndsAt).getTime() <= Date.now()
+    ) {
+      campaign.electionActive = false;
+      campaign.electionClosedAt = new Date().toISOString();
+      await this.campaignRepository.update(campaign.id, {
+        electionActive: false,
+        electionClosedAt: campaign.electionClosedAt,
+      });
+    }
+    const guaranteedGames = await findGuaranteedNextVoteGames(
+      this.dataSource.manager,
+    );
+
+    return {
+      campaign,
+      guaranteedGames,
+      electionResult: campaign.pool
+        ? this.calculateElectionResult(campaign)
+        : [],
+      targetPoolSize: TARGET_POOL_SIZE,
+      nextCampaign: this.getNextCampaignDefaults(campaign),
+      discordConfigured: this.discord.isConfigured(),
+    };
+  }
+
+  async drawPool(): Promise<Record<string, unknown>> {
+    const campaign = await this.findCurrentCampaignOrFail();
+
+    if (campaign.electionActive) {
+      throw new BadRequestException('A votação deste ciclo já está aberta.');
+    }
+
+    const guaranteedGames = await findGuaranteedNextVoteGames(
+      this.dataSource.manager,
+    );
+    for (const game of guaranteedGames) {
+      await this.refreshResearch(game);
+    }
+    const invalidGuaranteed = guaranteedGames.filter(
+      (game) => !this.isDurationEligible(game),
+    );
+    if (invalidGuaranteed.length > 0) {
+      throw new BadRequestException({
+        message:
+          'Há sugestões sem uma duração válida no HowLongToBeat. Pesquise-as antes do sorteio.',
+        games: invalidGuaranteed.map((game) => ({
+          id: game.id,
+          title: game.title,
+          mainExtraHours: game.mainExtraHours,
+        })),
+      });
+    }
+
+    const guaranteedIdentities = new Set(
+      guaranteedGames.map(normalizeGameIdentity),
+    );
+    const backlogCandidates = await findEligibleBacklogGames(
+      this.dataSource.manager,
+      guaranteedIdentities,
+    );
+    const fillCount = Math.max(0, TARGET_POOL_SIZE - guaranteedGames.length);
+    const selectedFillers: Game[] = [];
+    const rejectedCandidates: Game[] = [];
+    const shuffledCandidates = this.shuffle(backlogCandidates);
+    for (
+      let index = 0;
+      index < shuffledCandidates.length && selectedFillers.length < fillCount;
+      index += 2
+    ) {
+      const batch = shuffledCandidates.slice(index, index + 2);
+      await Promise.all(batch.map((game) => this.refreshResearch(game)));
+      for (const game of batch) {
+        if (selectedFillers.length >= fillCount) break;
+        if (this.isDurationEligible(game)) {
+          selectedFillers.push(game);
+        } else {
+          rejectedCandidates.push(game);
+        }
+      }
+    }
+    const excludedUnverified = rejectedCandidates.filter(
+      (game) => !this.hasKnownDuration(game),
+    );
+    const excludedTooLong = rejectedCandidates.filter(
+      (game) => this.hasKnownDuration(game) && !this.isDurationEligible(game),
+    );
+    const selection = [...guaranteedGames, ...selectedFillers];
+    const revealOrder = this.shuffle(selection);
+    const warnings: string[] = [];
+
+    if (selectedFillers.length < fillCount) {
+      warnings.push(
+        `Só há ${selectedFillers.length} jogos elegíveis nas Brasas para ${fillCount} espaços.`,
+      );
+    }
+    if (excludedUnverified.length > 0) {
+      warnings.push(
+        `${excludedUnverified.length} jogos sorteados ficaram fora porque a duração não pôde ser verificada.`,
+      );
+    }
+    if (excludedTooLong.length > 0) {
+      warnings.push(
+        `${excludedTooLong.length} jogos sorteados ficaram fora por passarem de 20 horas.`,
+      );
+    }
+
+    const token = this.signToken<DrawTokenPayload>({
+      kind: 'cycle-draw',
+      campaignId: campaign.id,
+      gameIds: selection.map((game) => game.id),
+      guaranteedGameIds: guaranteedGames.map((game) => game.id),
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    });
+
+    return {
+      campaignId: campaign.id,
+      targetPoolSize: TARGET_POOL_SIZE,
+      guaranteedGames,
+      selectedFillers,
+      revealOrder,
+      excludedUnverified,
+      excludedTooLong,
+      selectionToken: token,
+      warnings,
+    };
+  }
+
+  async startElection(dto: StartElectionDto, actor: Player): Promise<Campaign> {
+    const token = this.verifyToken<DrawTokenPayload>(
+      dto.selectionToken,
+      'cycle-draw',
+    );
+
+    if (
+      dto.electionEndsAt &&
+      new Date(dto.electionEndsAt).getTime() <= Date.now()
+    ) {
+      throw new BadRequestException(
+        'O encerramento da votação precisa estar no futuro.',
+      );
+    }
+
+    const campaign = await this.dataSource.transaction(async (manager) => {
+      const current = await this.findCurrentCampaignOrFail(manager);
+      if (current.id !== token.campaignId) {
+        throw new BadRequestException(
+          'A campanha mudou desde o sorteio. Sorteie novamente.',
+        );
+      }
+      if (current.electionActive) {
+        throw new BadRequestException('A votação já está aberta.');
+      }
+
+      const guaranteedGames = await findGuaranteedNextVoteGames(manager);
+      const guaranteedIds = guaranteedGames.map((game) => game.id).sort();
+      if (
+        !this.sameNumbers(guaranteedIds, [...token.guaranteedGameIds].sort())
+      ) {
+        throw new BadRequestException(
+          'As sugestões mudaram desde o sorteio. Sorteie novamente.',
+        );
+      }
+
+      const games = await manager.getRepository(Game).findByIds(token.gameIds);
+      if (games.length !== new Set(token.gameIds).size) {
+        throw new BadRequestException(
+          'Um dos jogos sorteados não está mais disponível.',
+        );
+      }
+      if (games.some((game) => !this.isDurationEligible(game))) {
+        throw new BadRequestException(
+          'Um dos jogos sorteados perdeu a verificação de duração.',
+        );
+      }
+
+      const allowedFillers = await findEligibleBacklogGames(
+        manager,
+        new Set(guaranteedGames.map(normalizeGameIdentity)),
+      );
+      const allowedIdentities = new Set(
+        [
+          ...guaranteedGames,
+          ...allowedFillers.filter((game) => this.isDurationEligible(game)),
+        ].map(normalizeGameIdentity),
+      );
+      if (
+        games.some(
+          (game) => !allowedIdentities.has(normalizeGameIdentity(game)),
+        )
+      ) {
+        throw new BadRequestException(
+          'Um dos jogos sorteados deixou de ser elegível. Sorteie novamente.',
+        );
+      }
+
+      const optionRepository = manager.getRepository(PoolOption);
+      const pool = manager.getRepository(Pool).create({
+        options: token.gameIds.map((gameId) => {
+          const game = games.find((candidate) => candidate.id === gameId);
+          if (!game) {
+            throw new BadRequestException(`Jogo #${gameId} não encontrado.`);
+          }
+          return optionRepository.create({ game, players: [] });
+        }),
+      });
+      const savedPool = await manager.getRepository(Pool).save(pool);
+
+      current.pool = savedPool;
+      current.electionActive = true;
+      current.electionStartedAt = new Date().toISOString();
+      current.electionEndsAt = dto.electionEndsAt ?? null;
+      current.electionClosedAt = null;
+      await manager.getRepository(Campaign).save(current);
+      await this.writeAudit(
+        manager,
+        'cycle_election_started',
+        actor,
+        { electionEndsAt: dto.electionEndsAt ?? null },
+        {
+          campaignId: current.id,
+          poolId: savedPool.id,
+          gameIds: token.gameIds,
+        },
+      );
+
+      return this.findCurrentCampaignOrFail(manager);
+    });
+
+    return campaign;
+  }
+
+  async previewTransition(
+    dto: PreviewCycleTransitionDto,
+  ): Promise<CycleTransitionPreview> {
+    const campaign = await this.findCurrentCampaignOrFail();
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const result = campaign.pool ? this.calculateElectionResult(campaign) : [];
+
+    if (!campaign.pool || result.length === 0) {
+      errors.push('A campanha atual ainda não tem uma votação para encerrar.');
+    }
+
+    if (
+      campaign.electionEndsAt &&
+      new Date(campaign.electionEndsAt).getTime() > Date.now() &&
+      !dto.allowEarlyClose
+    ) {
+      errors.push(
+        `A votação está programada para terminar em ${campaign.electionEndsAt}.`,
+      );
+    }
+
+    const winningOption = this.resolveWinner(result, dto.winnerGameId, errors);
+    const winner = winningOption
+      ? await this.gameRepository.findOneBy({ id: winningOption.gameId })
+      : null;
+    if (winningOption && !winner) {
+      errors.push('O jogo vencedor não está mais disponível no catálogo.');
+    }
+    const duplicateCampaign = await this.findCampaignByMonthAndYear(
+      dto.month,
+      dto.year,
+    );
+    if (duplicateCampaign?.id === campaign.id) {
+      errors.push('A próxima campanha precisa ter outro mês ou ano.');
+    } else if (duplicateCampaign) {
+      warnings.push(
+        `A campanha ${duplicateCampaign.month} ${duplicateCampaign.year} já existe e será atualizada.`,
+      );
+    }
+
+    const description = winner
+      ? dto.description?.trim() ||
+        this.buildCampaignDescription(winner, dto.month, dto.meetingAt)
+      : '';
+    const discordPreview = winner
+      ? await this.discord.preview({
+          currentGameTitle: campaign.game?.title ?? null,
+          nextGame: winner,
+          nextMonth: dto.month.trim(),
+          nextYear: dto.year.trim(),
+          meetingAt: dto.meetingAt,
+          discord: dto.discord,
+        })
+      : null;
+    if (discordPreview) {
+      errors.push(...discordPreview.errors);
+      warnings.push(...discordPreview.warnings);
+    }
+
+    const valid = errors.length === 0 && Boolean(winner);
+    const transitionToken =
+      valid && winner && discordPreview
+        ? this.signToken<TransitionTokenPayload>({
+            kind: 'cycle-transition',
+            campaignId: campaign.id,
+            winnerGameId: winner.id,
+            voteFingerprint: this.fingerprint(result),
+            inputFingerprint: this.fingerprint(this.transitionInput(dto)),
+            discordFingerprint: this.fingerprint(
+              this.discordPlanFingerprint(discordPreview),
+            ),
+            expiresAt: Date.now() + 30 * 60 * 1000,
+          })
+        : null;
+
+    return {
+      valid,
+      errors,
+      warnings,
+      confirmationToken: transitionToken,
+      electionResult: result,
+      winner,
+      campaign: winner
+        ? {
+            month: dto.month.trim(),
+            year: dto.year.trim(),
+            description,
+            meetingAt: dto.meetingAt ?? null,
+            meetingLocation: dto.meetingLocation?.trim() || 'Discord',
+          }
+        : null,
+      discord: discordPreview,
+    };
+  }
+
+  async applyTransition(
+    dto: ApplyCycleTransitionDto,
+    actor: Player,
+  ): Promise<Record<string, unknown>> {
+    if (!dto.confirm) {
+      throw new BadRequestException('confirm must be true');
+    }
+
+    const preview = await this.previewTransition(dto);
+    if (
+      !preview.valid ||
+      !preview.winner ||
+      !preview.campaign ||
+      !preview.discord
+    ) {
+      throw new BadRequestException({
+        message: 'A transição ainda contém problemas',
+        errors: preview.errors,
+      });
+    }
+
+    const campaignDraft = preview.campaign;
+    const discordPreview = preview.discord;
+
+    const token = this.verifyToken<TransitionTokenPayload>(
+      dto.confirmationToken,
+      'cycle-transition',
+    );
+    const current = await this.findCurrentCampaignOrFail();
+    const expected = {
+      campaignId: current.id,
+      winnerGameId: preview.winner.id,
+      voteFingerprint: this.fingerprint(preview.electionResult),
+      inputFingerprint: this.fingerprint(this.transitionInput(dto)),
+      discordFingerprint: this.fingerprint(
+        this.discordPlanFingerprint(preview.discord),
+      ),
+    };
+    if (
+      token.campaignId !== expected.campaignId ||
+      token.winnerGameId !== expected.winnerGameId ||
+      token.voteFingerprint !== expected.voteFingerprint ||
+      token.inputFingerprint !== expected.inputFingerprint ||
+      token.discordFingerprint !== expected.discordFingerprint
+    ) {
+      throw new BadRequestException(
+        'A votação ou o plano mudou desde a prévia. Revise a transição novamente.',
+      );
+    }
+
+    await this.dataSource.transaction(async (manager) => {
+      const campaignToClose = await this.findCurrentCampaignOrFail(manager);
+      if (campaignToClose.id !== token.campaignId) {
+        throw new BadRequestException(
+          'A campanha atual mudou durante a transição.',
+        );
+      }
+      const freshResult = this.calculateElectionResult(campaignToClose);
+      if (this.fingerprint(freshResult) !== token.voteFingerprint) {
+        throw new BadRequestException(
+          'Os votos mudaram desde a prévia. Revise a transição novamente.',
+        );
+      }
+
+      campaignToClose.electionActive = false;
+      campaignToClose.electionClosedAt ??= new Date().toISOString();
+      await manager.getRepository(Campaign).save(campaignToClose);
+    });
+
+    const discordResult = await this.discord.apply(
+      discordPreview,
+      dto.meetingAt,
+      campaignDraft.description,
+    );
+
+    const nextCampaign = await this.dataSource.transaction(async (manager) => {
+      const currentCampaign = await this.findCurrentCampaignOrFail(manager);
+      if (currentCampaign.id !== token.campaignId) {
+        throw new BadRequestException(
+          'A campanha atual mudou durante a transição.',
+        );
+      }
+      const freshResult = this.calculateElectionResult(currentCampaign);
+      if (this.fingerprint(freshResult) !== token.voteFingerprint) {
+        throw new BadRequestException('Os votos mudaram durante a transição.');
+      }
+
+      const game = await manager.getRepository(Game).findOneByOrFail({
+        id: token.winnerGameId,
+      });
+      let next = await this.findCampaignByMonthAndYear(
+        dto.month,
+        dto.year,
+        manager,
+      );
+      next ??= manager.getRepository(Campaign).create({
+        month: dto.month.trim(),
+        year: dto.year.trim(),
+        players: [],
+      });
+      next.month = dto.month.trim();
+      next.year = dto.year.trim();
+      next.game = game;
+      next.description = campaignDraft.description;
+      next.meetingAt = dto.meetingAt ?? null;
+      next.meetingLocation =
+        dto.meetingLocation?.trim() ||
+        discordPreview.plan.voiceChannel?.name ||
+        'Discord';
+      next.meetingUrl = discordResult.eventUrl;
+      next.pool = null;
+      next.electionActive = false;
+      next.electionStartedAt = null;
+      next.electionEndsAt = null;
+      next.electionClosedAt = null;
+
+      currentCampaign.electionActive = false;
+      currentCampaign.electionClosedAt ??= new Date().toISOString();
+      currentCampaign.current = false;
+      await manager.getRepository(Campaign).save(currentCampaign);
+      await manager
+        .createQueryBuilder()
+        .update(Campaign)
+        .set({ current: false })
+        .where('current = :current', { current: true })
+        .execute();
+      next.current = true;
+      next = await manager.getRepository(Campaign).save(next);
+
+      await this.writeAudit(
+        manager,
+        'cycle_transition_applied',
+        actor,
+        this.transitionInput(dto),
+        {
+          previousCampaignId: currentCampaign.id,
+          nextCampaignId: next.id,
+          winningGameId: game.id,
+          discord: discordResult,
+        },
+      );
+
+      return manager.getRepository(Campaign).findOneOrFail({
+        where: { id: next.id },
+        relations: campaignRelations,
+      });
+    });
+
+    return { campaign: nextCampaign, discord: discordResult };
+  }
+
+  private hasKnownDuration(game: Game): boolean {
+    return (
+      typeof game.mainExtraHours === 'number' &&
+      Number.isFinite(game.mainExtraHours)
+    );
+  }
+
+  private isDurationEligible(game: Game): boolean {
+    return (
+      this.hasKnownDuration(game) &&
+      (game.mainExtraHours ?? Number.POSITIVE_INFINITY) >= 0 &&
+      (game.mainExtraHours ?? Number.POSITIVE_INFINITY) <= 20
+    );
+  }
+
+  private async refreshResearch(game: Game): Promise<void> {
+    if (this.hasKnownDuration(game)) return;
+    const checkedAt = game.researchCheckedAt
+      ? new Date(game.researchCheckedAt).getTime()
+      : 0;
+    if (checkedAt > Date.now() - 5 * 60 * 1000) return;
+
+    try {
+      const assessment = await this.gameResearch.assessCatalogGame(game);
+      game.cover ||= assessment.game.cover;
+      game.trailer ||= assessment.game.trailer;
+      game.summary ||= assessment.game.summary;
+      game.howLongToBeatUrl = assessment.game.howLongToBeatUrl;
+      game.durationLabel = assessment.game.durationLabel;
+      game.mainHours = assessment.game.mainHours;
+      game.mainExtraHours = assessment.game.mainExtraHours;
+      game.howLongToBeatTitle = assessment.game.howLongToBeatTitle;
+      game.researchStatus = assessment.reason;
+    } catch {
+      game.researchStatus = 'duration_unavailable';
+    }
+    game.researchCheckedAt = new Date().toISOString();
+    await this.gameRepository.save(game);
+  }
+
+  private calculateElectionResult(campaign: Campaign): ElectionResultOption[] {
+    if (!campaign.pool) return [];
+    return campaign.pool.options.map((option) => ({
+      optionId: option.id,
+      gameId: option.game.id,
+      game: option.game.title,
+      tokens: option.players.reduce((total, player) => {
+        const campaignPlayer = campaign.players.find(
+          (entry) => entry.player.id === player.id,
+        );
+        return total + (campaignPlayer?.tokens ?? 0);
+      }, 0),
+      voters: option.players.map(
+        (player) =>
+          player.name ?? player.discord?.globalName ?? `#${player.id}`,
+      ),
+    }));
+  }
+
+  private resolveWinner(
+    result: ElectionResultOption[],
+    requestedGameId: number | undefined,
+    errors: string[],
+  ): ElectionResultOption | null {
+    if (result.length === 0) return null;
+    const highestTokens = Math.max(...result.map((option) => option.tokens));
+    const leaders = result.filter((option) => option.tokens === highestTokens);
+    const selected = requestedGameId
+      ? leaders.find((option) => option.gameId === requestedGameId)
+      : leaders.length === 1
+        ? leaders[0]
+        : null;
+
+    if (!selected) {
+      errors.push(
+        leaders.length > 1
+          ? 'A votação terminou empatada. Escolha explicitamente um dos jogos empatados.'
+          : 'O jogo escolhido não lidera a votação.',
+      );
+      return null;
+    }
+
+    return selected;
+  }
+
+  private buildCampaignDescription(
+    game: Game,
+    month: string,
+    meetingAt?: string,
+  ): string {
+    const links = [
+      game.steam ? `[Steam](${game.steam})` : null,
+      game.trailer ? `[Trailer](${game.trailer})` : null,
+      game.howLongToBeatUrl
+        ? `[HowLongToBeat](${game.howLongToBeatUrl})${game.durationLabel ? ` ${game.durationLabel}` : ''}`
+        : null,
+    ].filter(Boolean);
+    const meeting = meetingAt
+      ? `\n\nO nosso próximo encontro será em ${new Intl.DateTimeFormat(
+          'pt-BR',
+          {
+            dateStyle: 'long',
+            timeStyle: 'short',
+            timeZone: 'America/Sao_Paulo',
+          },
+        ).format(new Date(meetingAt))}.`
+      : '';
+
+    return (
+      [
+        `O jogo do mês de ${month.trim()} é:`,
+        `**${game.title}**`,
+        game.summary?.trim() ||
+          'Uma nova jornada escolhida ao redor da fogueira.',
+        links.join(' · '),
+      ]
+        .filter(Boolean)
+        .join('\n\n') + meeting
+    );
+  }
+
+  private getNextCampaignDefaults(campaign: Campaign): {
+    month: string;
+    year: string;
+  } {
+    const normalized = campaign.month
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLocaleLowerCase('pt-BR');
+    const currentIndex = PORTUGUESE_MONTHS.findIndex(
+      (month) =>
+        month
+          .normalize('NFD')
+          .replace(/\p{Diacritic}/gu, '')
+          .toLocaleLowerCase('pt-BR') === normalized,
+    );
+    const year = Number(campaign.year);
+    if (currentIndex < 0 || !Number.isFinite(year)) {
+      const now = new Date();
+      return {
+        month: PORTUGUESE_MONTHS[(now.getMonth() + 1) % 12],
+        year: String(now.getFullYear() + (now.getMonth() === 11 ? 1 : 0)),
+      };
+    }
+
+    return {
+      month: PORTUGUESE_MONTHS[(currentIndex + 1) % 12],
+      year: String(year + (currentIndex === 11 ? 1 : 0)),
+    };
+  }
+
+  private async findCurrentCampaignOrFail(
+    manager: EntityManager = this.dataSource.manager,
+  ): Promise<Campaign> {
+    const campaign = await manager.getRepository(Campaign).findOne({
+      where: { current: true },
+      relations: campaignRelations,
+      lock:
+        manager.queryRunner?.isTransactionActive &&
+        manager.connection.options.type === 'postgres'
+          ? { mode: 'pessimistic_write' }
+          : undefined,
+    });
+    if (!campaign) throw new NotFoundException('No current campaign found');
+    return campaign;
+  }
+
+  private async findCampaignByMonthAndYear(
+    month: string,
+    year: string,
+    manager: EntityManager = this.dataSource.manager,
+  ): Promise<Campaign | null> {
+    const campaigns = await manager.getRepository(Campaign).find();
+    const normalizedMonth = month.trim().toLocaleLowerCase('pt-BR');
+    const normalizedYear = year.trim();
+    return (
+      campaigns.find(
+        (campaign) =>
+          campaign.month.trim().toLocaleLowerCase('pt-BR') ===
+            normalizedMonth && campaign.year.trim() === normalizedYear,
+      ) ?? null
+    );
+  }
+
+  private transitionInput(dto: PreviewCycleTransitionDto): unknown {
+    return {
+      winnerGameId: dto.winnerGameId ?? null,
+      month: dto.month.trim(),
+      year: dto.year.trim(),
+      description: dto.description?.trim() ?? null,
+      meetingAt: dto.meetingAt ?? null,
+      meetingLocation: dto.meetingLocation?.trim() ?? null,
+      discord: dto.discord ?? { enabled: true },
+      allowEarlyClose: dto.allowEarlyClose ?? false,
+    };
+  }
+
+  private discordPlanFingerprint(preview: DiscordCyclePreview): unknown {
+    return {
+      enabled: preview.enabled,
+      oldChannelId: preview.plan.oldChannel?.id ?? null,
+      discussionCategoryId: preview.plan.discussionCategory?.id ?? null,
+      historyCategoryId: preview.plan.historyCategory?.id ?? null,
+      createHistoryCategory: preview.plan.createHistoryCategory,
+      newChannelName: preview.plan.newChannelName,
+      newChannelTopic: preview.plan.newChannelTopic,
+      existingNewChannelId: preview.plan.existingNewChannel?.id ?? null,
+      voiceChannelId: preview.plan.voiceChannel?.id ?? null,
+      eventName: preview.plan.eventName,
+      gameCard: preview.plan.gameCard,
+    };
+  }
+
+  private shuffle<T>(values: T[]): T[] {
+    const result = [...values];
+    for (let index = result.length - 1; index > 0; index -= 1) {
+      const target = randomInt(index + 1);
+      [result[index], result[target]] = [result[target], result[index]];
+    }
+    return result;
+  }
+
+  private sameNumbers(left: number[], right: number[]): boolean {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => value === right[index])
+    );
+  }
+
+  private fingerprint(value: unknown): string {
+    return createHmac('sha256', this.signingSecret)
+      .update(this.stableStringify(value))
+      .digest('base64url');
+  }
+
+  private signToken<T extends { kind: string; expiresAt: number }>(
+    payload: T,
+  ): string {
+    const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const signature = createHmac('sha256', this.signingSecret)
+      .update(encoded)
+      .digest('base64url');
+    return `${encoded}.${signature}`;
+  }
+
+  private verifyToken<T extends { kind: string; expiresAt: number }>(
+    token: string,
+    expectedKind: string,
+  ): T {
+    const [encoded, receivedSignature] = token.split('.');
+    if (!encoded || !receivedSignature) {
+      throw new BadRequestException('Token de confirmação inválido.');
+    }
+    const expectedSignature = createHmac('sha256', this.signingSecret)
+      .update(encoded)
+      .digest('base64url');
+    const received = Buffer.from(receivedSignature);
+    const expected = Buffer.from(expectedSignature);
+    if (
+      received.length !== expected.length ||
+      !timingSafeEqual(received, expected)
+    ) {
+      throw new BadRequestException('Token de confirmação inválido.');
+    }
+
+    let payload: T;
+    try {
+      payload = JSON.parse(Buffer.from(encoded, 'base64url').toString()) as T;
+    } catch {
+      throw new BadRequestException('Token de confirmação inválido.');
+    }
+    if (payload.kind !== expectedKind || payload.expiresAt < Date.now()) {
+      throw new BadRequestException(
+        'A prévia expirou. Gere uma nova antes de continuar.',
+      );
+    }
+    return payload;
+  }
+
+  private stableStringify(value: unknown): string {
+    if (value === null || typeof value !== 'object')
+      return JSON.stringify(value);
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => this.stableStringify(item)).join(',')}]`;
+    }
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map(
+        (key) => `${JSON.stringify(key)}:${this.stableStringify(record[key])}`,
+      )
+      .join(',')}}`;
+  }
+
+  private async writeAudit(
+    manager: EntityManager,
+    action: string,
+    actor: Player,
+    payload: unknown,
+    result: Record<string, unknown>,
+  ): Promise<void> {
+    const repository = manager.getRepository(AdminAuditLog);
+    await repository.save(
+      repository.create({
+        action,
+        actor: `player:${actor.id}`,
+        payload: payload as Record<string, unknown>,
+        result,
+      }),
+    );
+  }
+}

--- a/server/src/cycle/cycle.service.ts
+++ b/server/src/cycle/cycle.service.ts
@@ -639,13 +639,11 @@ export class CycleService {
     const summary =
       game.summary?.replace(/\s+/g, ' ').trim() ||
       'Uma nova jornada escolhida ao redor da fogueira.';
-    const firstSentence = summary.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim();
-    const phrase = firstSentence || summary;
-    if (phrase.length <= 220) return phrase;
+    if (summary.length <= 1000) return summary;
 
-    const shortened = phrase.slice(0, 219);
+    const shortened = summary.slice(0, 999);
     const lastSpace = shortened.lastIndexOf(' ');
-    return `${shortened.slice(0, lastSpace > 160 ? lastSpace : 219).trim()}…`;
+    return `${shortened.slice(0, lastSpace > 900 ? lastSpace : 999).trim()}…`;
   }
 
   private getNextCampaignDefaults(campaign: Campaign): {

--- a/server/src/cycle/discord-cycle.service.spec.ts
+++ b/server/src/cycle/discord-cycle.service.spec.ts
@@ -1,0 +1,148 @@
+import { ConfigService } from '@nestjs/config';
+import { DiscordCycleService } from './discord-cycle.service';
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('DiscordCycleService', () => {
+  const fetchMock = jest.fn<Promise<Response>, Parameters<typeof fetch>>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  it('does not contact Discord when the conductor disables integration explicitly', async () => {
+    const service = new DiscordCycleService(new ConfigService({}));
+
+    const preview = await service.preview({
+      currentGameTitle: 'Old Game',
+      nextGame: { title: 'New Game' },
+      nextMonth: 'Setembro',
+      nextYear: '2026',
+      discord: { enabled: false },
+    });
+
+    expect(preview.enabled).toBe(false);
+    expect(preview.errors).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('previews and idempotently applies the channel archive, new discussion, and meeting event', async () => {
+    const service = new DiscordCycleService(
+      new ConfigService({
+        DISCORD_BOT_TOKEN: 'protected-test-token',
+        DISCORD_GUILD_ID: 'guild-id',
+      }),
+    );
+    const channels = [
+      {
+        id: 'old-channel',
+        name: 'old-game',
+        type: 0,
+        parent_id: 'discussion-category',
+        permission_overwrites: [
+          { id: 'guild-id', type: 0, allow: '4', deny: '8' },
+        ],
+      },
+      {
+        id: 'discussion-category',
+        name: 'Jogos',
+        type: 4,
+        parent_id: null,
+      },
+      {
+        id: 'history-category',
+        name: 'Histórias da Fogueira',
+        type: 4,
+        parent_id: null,
+      },
+      { id: 'voice', name: 'Fogueira', type: 2, parent_id: null },
+    ];
+    fetchMock.mockResolvedValueOnce(jsonResponse(channels));
+
+    const meetingAt = '2026-09-24T20:00:00-03:00';
+    const preview = await service.preview({
+      currentGameTitle: 'Old Game',
+      nextGame: {
+        title: 'New Game',
+        summary: 'A compact adventure.',
+        steam: 'https://store.steampowered.com/app/42/',
+        durationLabel: '10 h',
+      },
+      nextMonth: 'Setembro',
+      nextYear: '2026',
+      meetingAt,
+      discord: { enabled: true },
+    });
+
+    expect(preview.errors).toEqual([]);
+    expect(preview.plan).toMatchObject({
+      oldChannel: { id: 'old-channel' },
+      historyCategory: { id: 'history-category' },
+      voiceChannel: { id: 'voice' },
+      newChannelName: 'new-game',
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ ...channels[0], parent_id: 'history-category' }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'new-channel',
+          name: 'new-game',
+          type: 0,
+          parent_id: 'discussion-category',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'game-message', embeds: [] }))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'event-id',
+          name: 'Encontro de Setembro: New Game',
+          channel_id: 'voice',
+          scheduled_start_time: meetingAt,
+        }),
+      );
+
+    const result = await service.apply(
+      preview,
+      meetingAt,
+      'Descrição do encontro',
+    );
+
+    expect(result).toEqual({
+      archivedChannelId: 'old-channel',
+      historyCategoryId: 'history-category',
+      newChannelId: 'new-channel',
+      eventId: 'event-id',
+      eventUrl: 'https://discord.com/events/guild-id/event-id',
+      gameMessageId: 'game-message',
+      gameMessageUrl:
+        'https://discord.com/channels/guild-id/new-channel/game-message',
+    });
+    const permissionCall = fetchMock.mock.calls.find(([url]) =>
+      requestUrl(url).includes('/permissions/guild-id'),
+    );
+    const permissionBody = permissionCall?.[1]?.body;
+    expect(
+      typeof permissionBody === 'string' ? JSON.parse(permissionBody) : null,
+    ).toEqual({
+      type: 0,
+      allow: '4',
+      deny: String(8 | 2048),
+    });
+  });
+
+  function requestUrl(input: RequestInfo | URL): string {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.href;
+    return input.url;
+  }
+});

--- a/server/src/cycle/discord-cycle.service.ts
+++ b/server/src/cycle/discord-cycle.service.ts
@@ -1,0 +1,530 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+const TEXT_CHANNEL = 0;
+const VOICE_CHANNEL = 2;
+const CATEGORY_CHANNEL = 4;
+const SEND_MESSAGES = 1n << 11n;
+const DEFAULT_HISTORY_CATEGORY = 'Histórias da Fogueira';
+
+interface DiscordPermissionOverwrite {
+  id: string;
+  type: number;
+  allow: string;
+  deny: string;
+}
+
+export interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id: string | null;
+  topic?: string | null;
+  position?: number;
+  permission_overwrites?: DiscordPermissionOverwrite[];
+}
+
+interface DiscordScheduledEvent {
+  id: string;
+  name: string;
+  channel_id: string | null;
+  scheduled_start_time: string;
+}
+
+interface DiscordMessage {
+  id: string;
+  embeds?: Array<{ footer?: { text?: string } }>;
+}
+
+export interface DiscordGameCard {
+  title: string;
+  description: string;
+  url: string | null;
+  imageUrl: string | null;
+  details: string | null;
+  marker: string;
+}
+
+export interface DiscordCycleInput {
+  enabled: boolean;
+  oldChannelId?: string;
+  discussionCategoryId?: string;
+  historyCategoryId?: string;
+  voiceChannelId?: string;
+  newChannelName?: string;
+  newChannelTopic?: string;
+}
+
+export interface DiscordCyclePreview {
+  configured: boolean;
+  enabled: boolean;
+  guildId: string;
+  channels: {
+    text: DiscordChannel[];
+    categories: DiscordChannel[];
+    voice: DiscordChannel[];
+  };
+  plan: {
+    oldChannel: DiscordChannel | null;
+    discussionCategory: DiscordChannel | null;
+    historyCategory: DiscordChannel | null;
+    createHistoryCategory: boolean;
+    newChannelName: string;
+    newChannelTopic: string;
+    existingNewChannel: DiscordChannel | null;
+    voiceChannel: DiscordChannel | null;
+    eventName: string | null;
+    gameCard: DiscordGameCard;
+  };
+  warnings: string[];
+  errors: string[];
+}
+
+export interface DiscordCycleResult {
+  archivedChannelId: string | null;
+  historyCategoryId: string | null;
+  newChannelId: string | null;
+  eventId: string | null;
+  eventUrl: string | null;
+  gameMessageId: string | null;
+  gameMessageUrl: string | null;
+}
+
+@Injectable()
+export class DiscordCycleService {
+  private readonly botToken: string;
+  private readonly guildId: string;
+
+  constructor(config: ConfigService) {
+    this.botToken = config.get<string>('DISCORD_BOT_TOKEN')?.trim() ?? '';
+    this.guildId =
+      config.get<string>('DISCORD_GUILD_ID')?.trim() ?? '1534325844619821170';
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.botToken && this.guildId);
+  }
+
+  async preview(input: {
+    currentGameTitle: string | null;
+    nextGame: {
+      title: string;
+      summary?: string | null;
+      steam?: string | null;
+      trailer?: string | null;
+      howLongToBeatUrl?: string | null;
+      durationLabel?: string | null;
+      cover?: string | null;
+    };
+    nextMonth: string;
+    nextYear: string;
+    meetingAt?: string;
+    discord?: DiscordCycleInput;
+  }): Promise<DiscordCyclePreview> {
+    const enabled = input.discord?.enabled ?? true;
+    const emptyChannels = { text: [], categories: [], voice: [] };
+    const basePlan = {
+      oldChannel: null,
+      discussionCategory: null,
+      historyCategory: null,
+      createHistoryCategory: false,
+      newChannelName: this.slugify(
+        input.discord?.newChannelName ?? input.nextGame.title,
+      ),
+      newChannelTopic:
+        input.discord?.newChannelTopic?.trim() ||
+        `Conversa sobre ${input.nextGame.title}, jogo de ${input.nextMonth} de ${input.nextYear}.`,
+      existingNewChannel: null,
+      voiceChannel: null,
+      eventName: input.meetingAt
+        ? `Encontro de ${input.nextMonth}: ${input.nextGame.title}`.slice(
+            0,
+            100,
+          )
+        : null,
+      gameCard: this.buildGameCard(input),
+    };
+
+    if (!enabled) {
+      return {
+        configured: this.isConfigured(),
+        enabled,
+        guildId: this.guildId,
+        channels: emptyChannels,
+        plan: basePlan,
+        warnings: ['A transição do Discord foi desativada para esta campanha.'],
+        errors: [],
+      };
+    }
+
+    if (!this.isConfigured()) {
+      return {
+        configured: false,
+        enabled,
+        guildId: this.guildId,
+        channels: emptyChannels,
+        plan: basePlan,
+        warnings: [],
+        errors: [
+          'DISCORD_BOT_TOKEN não está configurado no servidor. Desative o Discord explicitamente ou configure o bot.',
+        ],
+      };
+    }
+
+    const channels = await this.getChannels();
+    const text = channels.filter((channel) => channel.type === TEXT_CHANNEL);
+    const categories = channels.filter(
+      (channel) => channel.type === CATEGORY_CHANNEL,
+    );
+    const voice = channels.filter((channel) => channel.type === VOICE_CHANNEL);
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const oldChannel = this.resolveChannel(
+      text,
+      input.discord?.oldChannelId,
+      input.currentGameTitle,
+    );
+    if (input.currentGameTitle && !oldChannel) {
+      errors.push(
+        `Não foi possível localizar o canal atual de ${input.currentGameTitle}. Selecione-o manualmente.`,
+      );
+    }
+
+    const discussionCategory =
+      this.resolveChannel(
+        categories,
+        input.discord?.discussionCategoryId,
+        null,
+      ) ??
+      categories.find((category) => category.id === oldChannel?.parent_id) ??
+      null;
+    const historyCategory =
+      this.resolveChannel(
+        categories,
+        input.discord?.historyCategoryId,
+        DEFAULT_HISTORY_CATEGORY,
+      ) ?? null;
+    const voiceChannel = input.meetingAt
+      ? (this.resolveChannel(
+          voice,
+          input.discord?.voiceChannelId,
+          'Fogueira',
+        ) ?? null)
+      : null;
+
+    if (input.meetingAt && !voiceChannel) {
+      errors.push(
+        'Selecione o canal de voz onde o próximo encontro será realizado.',
+      );
+    }
+
+    const existingNewChannel =
+      text.find(
+        (channel) =>
+          this.normalize(channel.name) ===
+            this.normalize(basePlan.newChannelName) &&
+          channel.id !== oldChannel?.id,
+      ) ?? null;
+    if (existingNewChannel) {
+      warnings.push(
+        `O canal #${existingNewChannel.name} já existe e será reutilizado.`,
+      );
+    }
+
+    return {
+      configured: true,
+      enabled,
+      guildId: this.guildId,
+      channels: { text, categories, voice },
+      plan: {
+        ...basePlan,
+        oldChannel,
+        discussionCategory,
+        historyCategory,
+        createHistoryCategory: !historyCategory,
+        existingNewChannel,
+        voiceChannel,
+      },
+      warnings,
+      errors,
+    };
+  }
+
+  async apply(
+    preview: DiscordCyclePreview,
+    meetingAt: string | undefined,
+    eventDescription: string,
+  ): Promise<DiscordCycleResult> {
+    if (!preview.enabled) {
+      return {
+        archivedChannelId: null,
+        historyCategoryId: null,
+        newChannelId: null,
+        eventId: null,
+        eventUrl: null,
+        gameMessageId: null,
+        gameMessageUrl: null,
+      };
+    }
+
+    if (!preview.configured || preview.errors.length > 0) {
+      throw new BadRequestException({
+        message: 'A transição do Discord ainda não está pronta',
+        errors: preview.errors,
+      });
+    }
+
+    let historyCategory = preview.plan.historyCategory;
+    if (!historyCategory) {
+      historyCategory = await this.request<DiscordChannel>(
+        `/guilds/${this.guildId}/channels`,
+        {
+          method: 'POST',
+          body: { name: DEFAULT_HISTORY_CATEGORY, type: CATEGORY_CHANNEL },
+          reason: 'Criar arquivo de discussões concluídas do Bonfire',
+        },
+      );
+    }
+
+    if (preview.plan.oldChannel) {
+      await this.request<DiscordChannel>(
+        `/channels/${preview.plan.oldChannel.id}`,
+        {
+          method: 'PATCH',
+          body: { parent_id: historyCategory.id },
+          reason: 'Arquivar discussão do jogo concluído',
+        },
+      );
+      const everyoneOverwrite =
+        preview.plan.oldChannel.permission_overwrites?.find(
+          (overwrite) => overwrite.id === this.guildId && overwrite.type === 0,
+        );
+      const allow = BigInt(everyoneOverwrite?.allow ?? '0');
+      const deny = BigInt(everyoneOverwrite?.deny ?? '0') | SEND_MESSAGES;
+      await this.request<void>(
+        `/channels/${preview.plan.oldChannel.id}/permissions/${this.guildId}`,
+        {
+          method: 'PUT',
+          body: { type: 0, allow: allow.toString(), deny: deny.toString() },
+          reason: 'Tornar a discussão arquivada somente leitura',
+        },
+      );
+    }
+
+    const newChannel =
+      preview.plan.existingNewChannel ??
+      (await this.request<DiscordChannel>(`/guilds/${this.guildId}/channels`, {
+        method: 'POST',
+        body: {
+          name: preview.plan.newChannelName,
+          type: TEXT_CHANNEL,
+          parent_id: preview.plan.discussionCategory?.id ?? null,
+          topic: preview.plan.newChannelTopic,
+        },
+        reason: 'Criar discussão do novo jogo do Bonfire',
+      }));
+
+    const gameMessage = await this.ensureGameCard(
+      newChannel,
+      preview.plan.gameCard,
+      Boolean(preview.plan.existingNewChannel),
+    );
+
+    let event: DiscordScheduledEvent | null = null;
+    if (meetingAt && preview.plan.voiceChannel && preview.plan.eventName) {
+      const events = await this.request<DiscordScheduledEvent[]>(
+        `/guilds/${this.guildId}/scheduled-events?with_user_count=false`,
+      );
+      event =
+        events.find(
+          (candidate) =>
+            candidate.name === preview.plan.eventName &&
+            new Date(candidate.scheduled_start_time).getTime() ===
+              new Date(meetingAt).getTime(),
+        ) ??
+        (await this.request<DiscordScheduledEvent>(
+          `/guilds/${this.guildId}/scheduled-events`,
+          {
+            method: 'POST',
+            body: {
+              channel_id: preview.plan.voiceChannel.id,
+              entity_type: 2,
+              privacy_level: 2,
+              name: preview.plan.eventName,
+              description: eventDescription.slice(0, 1000),
+              scheduled_start_time: meetingAt,
+            },
+            reason: 'Agendar encontro do novo ciclo do Bonfire',
+          },
+        ));
+    }
+
+    return {
+      archivedChannelId: preview.plan.oldChannel?.id ?? null,
+      historyCategoryId: historyCategory.id,
+      newChannelId: newChannel.id,
+      eventId: event?.id ?? null,
+      eventUrl: event
+        ? `https://discord.com/events/${this.guildId}/${event.id}`
+        : null,
+      gameMessageId: gameMessage.id,
+      gameMessageUrl: `https://discord.com/channels/${this.guildId}/${newChannel.id}/${gameMessage.id}`,
+    };
+  }
+
+  private buildGameCard(input: {
+    nextGame: {
+      title: string;
+      summary?: string | null;
+      steam?: string | null;
+      trailer?: string | null;
+      howLongToBeatUrl?: string | null;
+      durationLabel?: string | null;
+      cover?: string | null;
+    };
+    nextMonth: string;
+    nextYear: string;
+  }): DiscordGameCard {
+    const links = [
+      input.nextGame.steam ? `[Steam](${input.nextGame.steam})` : null,
+      input.nextGame.trailer ? `[Trailer](${input.nextGame.trailer})` : null,
+      input.nextGame.howLongToBeatUrl
+        ? `[HowLongToBeat](${input.nextGame.howLongToBeatUrl})`
+        : null,
+    ].filter(Boolean);
+    return {
+      title: input.nextGame.title,
+      description:
+        input.nextGame.summary?.trim() ||
+        'Uma nova jornada escolhida ao redor da fogueira.',
+      url: input.nextGame.steam ?? null,
+      imageUrl: input.nextGame.cover ?? null,
+      details: [input.nextGame.durationLabel, links.join(' · ')]
+        .filter(Boolean)
+        .join('\n'),
+      marker: `Sob a Luz do Bonfire · ${input.nextMonth} ${input.nextYear}`,
+    };
+  }
+
+  private async ensureGameCard(
+    channel: DiscordChannel,
+    card: DiscordGameCard,
+    mayAlreadyExist: boolean,
+  ): Promise<DiscordMessage> {
+    if (mayAlreadyExist) {
+      const messages = await this.request<DiscordMessage[]>(
+        `/channels/${channel.id}/messages?limit=50`,
+      );
+      const existing = messages.find((message) =>
+        message.embeds?.some((embed) => embed.footer?.text === card.marker),
+      );
+      if (existing) return existing;
+    }
+
+    return this.request<DiscordMessage>(`/channels/${channel.id}/messages`, {
+      method: 'POST',
+      body: {
+        allowed_mentions: { parse: [] },
+        embeds: [
+          {
+            title: card.title,
+            description: card.description,
+            url: card.url ?? undefined,
+            color: 0xd87649,
+            image: card.imageUrl ? { url: card.imageUrl } : undefined,
+            fields: card.details
+              ? [{ name: 'Para a jornada', value: card.details }]
+              : undefined,
+            footer: { text: card.marker },
+          },
+        ],
+      },
+      reason: 'Publicar informações do novo jogo do Bonfire',
+    });
+  }
+
+  private async getChannels(): Promise<DiscordChannel[]> {
+    return this.request<DiscordChannel[]>(`/guilds/${this.guildId}/channels`);
+  }
+
+  private resolveChannel(
+    channels: DiscordChannel[],
+    id: string | undefined,
+    fallbackName: string | null,
+  ): DiscordChannel | null {
+    if (id) {
+      return channels.find((channel) => channel.id === id) ?? null;
+    }
+
+    if (!fallbackName) return null;
+    const target = this.normalize(this.slugify(fallbackName));
+    return (
+      channels.find(
+        (channel) => this.normalize(this.slugify(channel.name)) === target,
+      ) ?? null
+    );
+  }
+
+  private slugify(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .toLocaleLowerCase('pt-BR')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 100);
+  }
+
+  private normalize(value: string): string {
+    return value.trim().toLocaleLowerCase('pt-BR');
+  }
+
+  private async request<T>(
+    path: string,
+    options: {
+      method?: 'POST' | 'PATCH' | 'PUT';
+      body?: Record<string, unknown>;
+      reason?: string;
+    } = {},
+  ): Promise<T> {
+    let response: Response;
+
+    try {
+      response = await fetch(`${DISCORD_API}${path}`, {
+        method: options.method ?? 'GET',
+        headers: {
+          Authorization: `Bot ${this.botToken}`,
+          'Content-Type': 'application/json',
+          ...(options.reason
+            ? { 'X-Audit-Log-Reason': encodeURIComponent(options.reason) }
+            : {}),
+        },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+    } catch {
+      throw new ServiceUnavailableException(
+        'Discord is temporarily unavailable',
+      );
+    }
+
+    if (!response.ok) {
+      const details = (await response.text()).slice(0, 500);
+      throw new BadGatewayException(
+        `Discord rejected the operation (${response.status}): ${details}`,
+      );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/server/src/cycle/dto/cycle-transition.dto.ts
+++ b/server/src/cycle/dto/cycle-transition.dto.ts
@@ -79,7 +79,7 @@ export class PreviewCycleTransitionDto {
 
   @IsOptional()
   @IsString()
-  @MaxLength(240)
+  @MaxLength(1000)
   description?: string;
 
   @IsOptional()

--- a/server/src/cycle/dto/cycle-transition.dto.ts
+++ b/server/src/cycle/dto/cycle-transition.dto.ts
@@ -1,0 +1,104 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsISO8601,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class StartElectionDto {
+  @IsString()
+  @IsNotEmpty()
+  selectionToken!: string;
+
+  @IsOptional()
+  @IsISO8601()
+  electionEndsAt?: string;
+}
+
+export class DiscordTransitionDto {
+  @IsBoolean()
+  enabled!: boolean;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  oldChannelId?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  discussionCategoryId?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  historyCategoryId?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  voiceChannelId?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  newChannelName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1024)
+  newChannelTopic?: string;
+}
+
+export class PreviewCycleTransitionDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  winnerGameId?: number;
+
+  @IsString()
+  @IsNotEmpty()
+  month!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  year!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  meetingAt?: string;
+
+  @IsOptional()
+  @IsString()
+  meetingLocation?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => DiscordTransitionDto)
+  discord?: DiscordTransitionDto;
+
+  @IsOptional()
+  @IsBoolean()
+  allowEarlyClose?: boolean;
+}
+
+export class ApplyCycleTransitionDto extends PreviewCycleTransitionDto {
+  @IsBoolean()
+  confirm!: boolean;
+
+  @IsString()
+  @IsNotEmpty()
+  confirmationToken!: string;
+}

--- a/server/src/cycle/dto/cycle-transition.dto.ts
+++ b/server/src/cycle/dto/cycle-transition.dto.ts
@@ -21,6 +21,11 @@ export class StartElectionDto {
   electionEndsAt?: string;
 }
 
+export class CancelElectionDto {
+  @IsBoolean()
+  confirm!: boolean;
+}
+
 export class DiscordTransitionDto {
   @IsBoolean()
   enabled!: boolean;
@@ -74,6 +79,7 @@ export class PreviewCycleTransitionDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(240)
   description?: string;
 
   @IsOptional()

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -6,6 +6,7 @@ import { CurrentGameDetails1785736800000 } from './migrations/1785736800000-Curr
 import { GameRecommendations1785795104186 } from './migrations/1785795104186-GameRecommendations';
 import { GameRecommendationRegistry1785796200000 } from './migrations/1785796200000-GameRecommendationRegistry';
 import { GameResearchCache1785797300000 } from './migrations/1785797300000-GameResearchCache';
+import { CycleAutomation1785888000000 } from './migrations/1785888000000-CycleAutomation';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
 const safeRuntimeMigrations = [
@@ -15,6 +16,7 @@ const safeRuntimeMigrations = [
   GameRecommendations1785795104186,
   GameRecommendationRegistry1785796200000,
   GameResearchCache1785797300000,
+  CycleAutomation1785888000000,
 ];
 
 const getDatabasePort = (): number => {

--- a/server/src/db/database.config.ts
+++ b/server/src/db/database.config.ts
@@ -7,6 +7,7 @@ import { GameRecommendations1785795104186 } from './migrations/1785795104186-Gam
 import { GameRecommendationRegistry1785796200000 } from './migrations/1785796200000-GameRecommendationRegistry';
 import { GameResearchCache1785797300000 } from './migrations/1785797300000-GameResearchCache';
 import { CycleAutomation1785888000000 } from './migrations/1785888000000-CycleAutomation';
+import { NavigableTrailerLinks1785974400000 } from './migrations/1785974400000-NavigableTrailerLinks';
 
 const sqlitePath = process.env.DATABASE_SQLITE_PATH || 'data/local.sqlite';
 const safeRuntimeMigrations = [
@@ -17,6 +18,7 @@ const safeRuntimeMigrations = [
   GameRecommendationRegistry1785796200000,
   GameResearchCache1785797300000,
   CycleAutomation1785888000000,
+  NavigableTrailerLinks1785974400000,
 ];
 
 const getDatabasePort = (): number => {

--- a/server/src/db/migrations/1785888000000-CycleAutomation.ts
+++ b/server/src/db/migrations/1785888000000-CycleAutomation.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CycleAutomation1785888000000 implements MigrationInterface {
+  name = 'CycleAutomation1785888000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "election_started_at" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "election_ends_at" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "election_closed_at" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN IF NOT EXISTS "research_checked_at" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" ADD COLUMN IF NOT EXISTS "research_status" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "games" DROP COLUMN IF EXISTS "research_status"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "games" DROP COLUMN IF EXISTS "research_checked_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "election_closed_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "election_ends_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "election_started_at"`,
+    );
+  }
+}

--- a/server/src/db/migrations/1785974400000-NavigableTrailerLinks.spec.ts
+++ b/server/src/db/migrations/1785974400000-NavigableTrailerLinks.spec.ts
@@ -1,0 +1,61 @@
+import { DataSource } from 'typeorm';
+import { NavigableTrailerLinks1785974400000 } from './1785974400000-NavigableTrailerLinks';
+
+describe('NavigableTrailerLinks1785974400000', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({ type: 'sqljs' });
+    await dataSource.initialize();
+    await dataSource.query(`
+      CREATE TABLE "games" (
+        "id" integer PRIMARY KEY,
+        "title" character varying,
+        "steam" character varying,
+        "trailer" character varying
+      )
+    `);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('repairs Silent Hill f and clears every other cached HLS playlist', async () => {
+    await dataSource.query(
+      `INSERT INTO "games" ("id", "title", "steam", "trailer") VALUES
+       (1, ?, ?, ?),
+       (2, ?, ?, ?),
+       (3, ?, ?, ?)`,
+      [
+        'SILENT HILL f',
+        'https://store.steampowered.com/app/2947440/',
+        'https://cdn.example.com/silent-hill.m3u8?token=old',
+        'Another Game',
+        'https://store.steampowered.com/app/10/',
+        'https://cdn.example.com/another.m3u8',
+        'Curated Game',
+        'https://store.steampowered.com/app/20/',
+        'https://www.youtube.com/watch?v=curated',
+      ],
+    );
+
+    await new NavigableTrailerLinks1785974400000().up(
+      dataSource.createQueryRunner(),
+    );
+
+    await expect(
+      dataSource.query(`SELECT "id", "trailer" FROM "games" ORDER BY "id"`),
+    ).resolves.toEqual([
+      {
+        id: 1,
+        trailer: 'https://www.youtube.com/watch?v=0OqTeE3y1x0',
+      },
+      { id: 2, trailer: null },
+      {
+        id: 3,
+        trailer: 'https://www.youtube.com/watch?v=curated',
+      },
+    ]);
+  });
+});

--- a/server/src/db/migrations/1785974400000-NavigableTrailerLinks.ts
+++ b/server/src/db/migrations/1785974400000-NavigableTrailerLinks.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const SILENT_HILL_F_TRAILER = 'https://www.youtube.com/watch?v=0OqTeE3y1x0';
+
+export class NavigableTrailerLinks1785974400000 implements MigrationInterface {
+  name = 'NavigableTrailerLinks1785974400000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "games" SET "trailer" = NULL WHERE LOWER("trailer") LIKE '%.m3u8%'`,
+    );
+    await queryRunner.query(
+      `UPDATE "games" SET "trailer" = $1 WHERE "steam" LIKE '%store.steampowered.com/app/2947440/%'`,
+      [SILENT_HILL_F_TRAILER],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "games" SET "trailer" = NULL WHERE "steam" LIKE '%store.steampowered.com/app/2947440/%' AND "trailer" = $1`,
+      [SILENT_HILL_F_TRAILER],
+    );
+  }
+}

--- a/server/src/games/dto/create-game.dto.ts
+++ b/server/src/games/dto/create-game.dto.ts
@@ -6,6 +6,7 @@ import {
   IsString,
   Min,
 } from 'class-validator';
+import { IsTrailerPageUrl } from '../trailer-url';
 
 export class CreateGameDto {
   @IsString()
@@ -26,6 +27,7 @@ export class CreateGameDto {
 
   @IsString()
   @IsOptional()
+  @IsTrailerPageUrl()
   trailer?: string;
 
   @IsString()

--- a/server/src/games/entities/game.entity.ts
+++ b/server/src/games/entities/game.entity.ts
@@ -37,4 +37,10 @@ export class Game {
 
   @Column({ name: 'how_long_to_beat_title', type: 'varchar', nullable: true })
   howLongToBeatTitle: string | null;
+
+  @Column({ name: 'research_checked_at', type: 'varchar', nullable: true })
+  researchCheckedAt: string | null;
+
+  @Column({ name: 'research_status', type: 'varchar', nullable: true })
+  researchStatus: string | null;
 }

--- a/server/src/games/game-research.service.spec.ts
+++ b/server/src/games/game-research.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { GameResearchService } from './game-research.service';
+import { normalizeTrailerPageUrl } from './trailer-url';
 
 describe('GameResearchService', () => {
   let service: GameResearchService;
@@ -54,7 +55,7 @@ describe('GameResearchService', () => {
         title: 'Example Game',
         cover: 'https://example.com/header.jpg',
         steam: 'https://store.steampowered.com/app/42/',
-        trailer: 'https://example.com/trailer.m3u8',
+        trailer: null,
         howLongToBeatUrl: 'https://howlongtobeat.com/game/99',
         durationLabel: '12–18 h',
         mainHours: 12,
@@ -71,6 +72,65 @@ describe('GameResearchService', () => {
     expect(assessment.eligible).toBe(false);
     expect(assessment.reason).toBe('too_long');
     expect(assessment.game.mainExtraHours).toBeGreaterThan(20);
+  });
+
+  it('prefers the publisher and accepts a verified official franchise channel', async () => {
+    mockAssessmentRequests(18 * 3600, {
+      title: 'SILENT HILL f',
+      developers: ['NeoBards Entertainment Ltd.'],
+      publishers: ['KONAMI'],
+      videos: [
+        youtubeVideo(
+          '0OqTeE3y1x0',
+          'SILENT HILL f | Launch Trailer | KONAMI',
+          'SILENT HILL (Official)',
+        ),
+      ],
+    });
+
+    const assessment = await service.assessSteamGame(42);
+
+    expect(assessment.game.trailer).toBe(
+      'https://www.youtube.com/watch?v=0OqTeE3y1x0',
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        search: '?search_query=SILENT+HILL+f+official+trailer+KONAMI',
+      }),
+    );
+  });
+
+  it('accepts a matching trailer from a verified platform channel', async () => {
+    mockAssessmentRequests(18 * 3600, {
+      videos: [
+        youtubeVideo(
+          'platform-trailer',
+          'Example Game - Official Reveal Trailer',
+          'PlayStation',
+        ),
+      ],
+    });
+
+    const assessment = await service.assessSteamGame(42);
+
+    expect(assessment.game.trailer).toBe(
+      'https://www.youtube.com/watch?v=platform-trailer',
+    );
+  });
+
+  it('rejects HLS playlists and direct media while preserving watch pages', () => {
+    expect(
+      normalizeTrailerPageUrl('https://cdn.example.com/trailer.m3u8?token=1'),
+    ).toBeNull();
+    expect(
+      normalizeTrailerPageUrl('https://cdn.example.com/trailer.mp4'),
+    ).toBeNull();
+    expect(
+      normalizeTrailerPageUrl('https://www.youtube.com/watch?v=0OqTeE3y1x0'),
+    ).toBe('https://www.youtube.com/watch?v=0OqTeE3y1x0');
+    expect(
+      normalizeTrailerPageUrl('https://www.youtube.com/playlist?list=123'),
+    ).toBeNull();
   });
 
   it('researches a legacy catalog title without replacing its curated identity', async () => {
@@ -145,7 +205,16 @@ describe('GameResearchService', () => {
     );
   });
 
-  const mockAssessmentRequests = (mainExtraSeconds: number) => {
+  const mockAssessmentRequests = (
+    mainExtraSeconds: number,
+    options: {
+      title?: string;
+      developers?: string[];
+      publishers?: string[];
+      videos?: unknown[];
+    } = {},
+  ) => {
+    const title = options.title ?? 'Example Game';
     fetchMock
       .mockResolvedValueOnce(
         jsonResponse({
@@ -153,11 +222,11 @@ describe('GameResearchService', () => {
             success: true,
             data: {
               type: 'game',
-              name: 'Example Game',
+              name: title,
               header_image: 'https://example.com/header.jpg',
               short_description: 'A compact adventure.',
-              developers: ['Example Studio'],
-              publishers: ['Example Publisher'],
+              developers: options.developers ?? ['Example Studio'],
+              publishers: options.publishers ?? ['Example Publisher'],
               movies: [
                 {
                   name: 'Official trailer',
@@ -169,7 +238,9 @@ describe('GameResearchService', () => {
         }),
       )
       .mockResolvedValueOnce(
-        htmlResponse('<script>var ytInitialData = {"contents":[]};</script>'),
+        htmlResponse(
+          `<script>var ytInitialData = ${JSON.stringify({ contents: options.videos ?? [] })};</script>`,
+        ),
       )
       .mockResolvedValueOnce(
         jsonResponse({ token: 'token', hpKey: 'field', hpVal: 'value' }),
@@ -179,7 +250,7 @@ describe('GameResearchService', () => {
           data: [
             {
               game_id: 99,
-              game_name: 'Example Game',
+              game_name: title,
               game_alias: '',
               game_type: 'game',
               comp_main: 12 * 3600,
@@ -189,6 +260,22 @@ describe('GameResearchService', () => {
         }),
       );
   };
+
+  const youtubeVideo = (videoId: string, title: string, owner: string) => ({
+    videoRenderer: {
+      videoId,
+      title: { runs: [{ text: title }] },
+      ownerText: { runs: [{ text: owner }] },
+      ownerBadges: [
+        {
+          metadataBadgeRenderer: {
+            style: 'BADGE_STYLE_TYPE_VERIFIED',
+            label: 'Verified',
+          },
+        },
+      ],
+    },
+  });
 
   const jsonResponse = (body: unknown) =>
     new Response(JSON.stringify(body), {

--- a/server/src/games/game-research.service.spec.ts
+++ b/server/src/games/game-research.service.spec.ts
@@ -73,6 +73,56 @@ describe('GameResearchService', () => {
     expect(assessment.game.mainExtraHours).toBeGreaterThan(20);
   });
 
+  it('researches a legacy catalog title without replacing its curated identity', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          '2369900': {
+            success: true,
+            data: {
+              type: 'game',
+              name: 'Castlevania Dominus Collection',
+              header_image: 'https://example.com/collection.jpg',
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ token: 'token' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              game_id: 123,
+              game_name: 'Castlevania: Order of Ecclesia',
+              game_type: 'game',
+              comp_main: 11 * 3600,
+              comp_plus: 16 * 3600,
+            },
+          ],
+        }),
+      );
+
+    const assessment = await service.assessCatalogGame({
+      title: 'Castlevania: Order of Ecclesia',
+      steam:
+        'https://store.steampowered.com/app/2369900/Castlevania_Dominus_Collection/',
+      cover: 'https://example.com/curated.jpg',
+      trailer: 'https://example.com/curated-trailer',
+      summary: 'Curated summary.',
+    });
+
+    expect(assessment).toMatchObject({
+      eligible: true,
+      game: {
+        title: 'Castlevania: Order of Ecclesia',
+        cover: 'https://example.com/curated.jpg',
+        trailer: 'https://example.com/curated-trailer',
+        summary: 'Curated summary.',
+        mainExtraHours: 16,
+      },
+    });
+  });
+
   it('issues player-bound, expiring assessment tokens', () => {
     const game = {
       steamAppId: 42,

--- a/server/src/games/game-research.service.ts
+++ b/server/src/games/game-research.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { normalizeTrailerPageUrl } from './trailer-url';
 
 const STEAM_SEARCH_URL = 'https://store.steampowered.com/search/suggest';
 const STEAM_DETAILS_URL = 'https://store.steampowered.com/api/appdetails';
@@ -60,11 +61,6 @@ export interface CatalogGameResearchInput {
   summary?: string | null;
 }
 
-interface SteamMovie {
-  name?: string;
-  hls_h264?: string;
-}
-
 interface SteamAppDetails {
   type?: string;
   name?: string;
@@ -73,7 +69,6 @@ interface SteamAppDetails {
   short_description?: string;
   developers?: string[];
   publishers?: string[];
-  movies?: SteamMovie[];
 }
 
 interface SteamAppDetailsResponse {
@@ -116,6 +111,13 @@ interface YoutubeVideoRenderer {
   videoId?: string;
   title?: YoutubeText;
   ownerText?: YoutubeText;
+  ownerBadges?: Array<{
+    metadataBadgeRenderer?: {
+      style?: string;
+      label?: string;
+      tooltip?: string;
+    };
+  }>;
 }
 
 const decodeHtml = (value: string): string =>
@@ -248,6 +250,46 @@ const organizationsMatch = (left: string, right: string): boolean => {
   );
 };
 
+const PLATFORM_CHANNELS = ['playstation', 'xbox', 'nintendo'];
+const GENERIC_TITLE_TOKENS = new Set([
+  'and',
+  'edition',
+  'game',
+  'remake',
+  'the',
+]);
+
+const hasVerifiedOwnerBadge = (video: YoutubeVideoRenderer): boolean =>
+  (video.ownerBadges ?? []).some(({ metadataBadgeRenderer: badge }) =>
+    [badge?.style, badge?.label, badge?.tooltip].some((value) =>
+      /verified|verificado/i.test(value ?? ''),
+    ),
+  );
+
+const verifiedChannelMatches = (
+  video: YoutubeVideoRenderer,
+  title: string,
+): boolean => {
+  if (!hasVerifiedOwnerBadge(video)) return false;
+
+  const owner = normalizeGameTitle(textValue(video.ownerText));
+  if (
+    PLATFORM_CHANNELS.some((platform) => owner.split(' ').includes(platform))
+  ) {
+    return true;
+  }
+
+  const franchiseTokens = normalizeGameTitle(title)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_TITLE_TOKENS.has(token));
+  const matchingTokens = franchiseTokens.filter((token) =>
+    owner.split(' ').includes(token),
+  );
+  const requiredMatches = Math.min(2, franchiseTokens.length);
+
+  return requiredMatches > 0 && matchingTokens.length >= requiredMatches;
+};
+
 const formatHours = (hours: number): string => {
   const rounded = Math.round(hours * 2) / 2;
   return Number.isInteger(rounded)
@@ -356,7 +398,7 @@ export class GameResearchService {
         title: input.title,
         cover: input.cover ?? null,
         steam: input.steam ?? '',
-        trailer: input.trailer ?? null,
+        trailer: normalizeTrailerPageUrl(input.trailer),
         summary: input.summary ?? null,
         howLongToBeatUrl: null,
         durationLabel: null,
@@ -374,7 +416,8 @@ export class GameResearchService {
       cover: input.cover ?? steamDetails.header_image ?? null,
       steam: input.steam ?? `https://store.steampowered.com/app/${steamAppId}/`,
       trailer:
-        input.trailer ?? (await this.findOfficialTrailer(steamDetails, title)),
+        normalizeTrailerPageUrl(input.trailer) ??
+        (await this.findOfficialTrailer(steamDetails, title)),
       summary: input.summary ?? steamDetails.short_description?.trim() ?? null,
       howLongToBeatUrl: null,
       durationLabel: null,
@@ -609,8 +652,8 @@ export class GameResearchService {
     title: string,
   ): Promise<string | null> {
     const organizations = [
-      ...(details.developers ?? []),
       ...(details.publishers ?? []),
+      ...(details.developers ?? []),
     ];
 
     try {
@@ -642,9 +685,13 @@ export class GameResearchService {
           const ownerMatches = organizations.some((organization) =>
             organizationsMatch(organization, owner),
           );
+          const verifiedOfficialChannel = verifiedChannelMatches(video, title);
 
           return Boolean(
-            video.videoId && titleMatches && trailerMatches && ownerMatches,
+            video.videoId &&
+              titleMatches &&
+              trailerMatches &&
+              (ownerMatches || verifiedOfficialChannel),
           );
         });
 
@@ -658,7 +705,7 @@ export class GameResearchService {
       );
     }
 
-    return details.movies?.find((movie) => movie.hls_h264)?.hls_h264 ?? null;
+    return null;
   }
 
   private signTokenPayload(encodedPayload: string): string {

--- a/server/src/games/game-research.service.ts
+++ b/server/src/games/game-research.service.ts
@@ -52,6 +52,14 @@ export interface GameResearchAssessment {
   game: ResearchedGame;
 }
 
+export interface CatalogGameResearchInput {
+  title: string;
+  steam: string | null;
+  cover?: string | null;
+  trailer?: string | null;
+  summary?: string | null;
+}
+
 interface SteamMovie {
   name?: string;
   hls_h264?: string;
@@ -333,6 +341,72 @@ export class GameResearchService {
     };
 
     return this.assessResearchedGame(game);
+  }
+
+  async assessCatalogGame(
+    input: CatalogGameResearchInput,
+  ): Promise<GameResearchAssessment> {
+    const appIdMatch = input.steam?.match(
+      /store\.steampowered\.com\/app\/(\d+)/i,
+    );
+    const steamAppId = appIdMatch ? Number(appIdMatch[1]) : NaN;
+    if (!Number.isInteger(steamAppId) || steamAppId < 1) {
+      return this.assessment(false, 'duration_unavailable', {
+        steamAppId: 0,
+        title: input.title,
+        cover: input.cover ?? null,
+        steam: input.steam ?? '',
+        trailer: input.trailer ?? null,
+        summary: input.summary ?? null,
+        howLongToBeatUrl: null,
+        durationLabel: null,
+        mainHours: null,
+        mainExtraHours: null,
+        howLongToBeatTitle: null,
+      });
+    }
+
+    const steamDetails = await this.getSteamDetails(steamAppId);
+    const title = input.title.trim();
+    const baseGame: ResearchedGame = {
+      steamAppId,
+      title,
+      cover: input.cover ?? steamDetails.header_image ?? null,
+      steam: input.steam ?? `https://store.steampowered.com/app/${steamAppId}/`,
+      trailer:
+        input.trailer ?? (await this.findOfficialTrailer(steamDetails, title)),
+      summary: input.summary ?? steamDetails.short_description?.trim() ?? null,
+      howLongToBeatUrl: null,
+      durationLabel: null,
+      mainHours: null,
+      mainExtraHours: null,
+      howLongToBeatTitle: null,
+    };
+
+    if (steamDetails.type !== 'game') {
+      return this.assessment(false, 'not_a_game', baseGame);
+    }
+
+    const hltbMatch = await this.findHowLongToBeatMatch(title);
+    if (!hltbMatch?.game_id || !hltbMatch.comp_plus) {
+      return this.assessment(false, 'duration_unavailable', baseGame);
+    }
+
+    const mainHours = hltbMatch.comp_main ? hltbMatch.comp_main / 3600 : null;
+    const mainExtraHours = hltbMatch.comp_plus / 3600;
+    const durationLabel =
+      mainHours && Math.abs(mainHours - mainExtraHours) >= 0.25
+        ? `${formatHours(mainHours)}–${formatHours(mainExtraHours)} h`
+        : `${formatHours(mainExtraHours)} h`;
+
+    return this.assessResearchedGame({
+      ...baseGame,
+      howLongToBeatUrl: `${HLTB_URL}/game/${hltbMatch.game_id}`,
+      durationLabel,
+      mainHours,
+      mainExtraHours,
+      howLongToBeatTitle: hltbMatch.game_name?.trim() || title,
+    });
   }
 
   assessResearchedGame(game: ResearchedGame): GameResearchAssessment {

--- a/server/src/games/games.controller.ts
+++ b/server/src/games/games.controller.ts
@@ -80,6 +80,16 @@ export class GamesController {
     return this.gamesService.withdrawRecommendation(player);
   }
 
+  @Delete(':id/rotation')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  retireGameFromRotation(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentPlayer() player: Player,
+  ) {
+    return this.gamesService.retireGameFromRotation(id, player);
+  }
+
   @Get(':id')
   findOne(
     @Param('id', ParseIntPipe) id: number,

--- a/server/src/games/games.module.ts
+++ b/server/src/games/games.module.ts
@@ -14,6 +14,6 @@ import { GameResearchService } from './game-research.service';
   ],
   controllers: [GamesController],
   providers: [GamesService, GameResearchService],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, GameResearchService],
 })
 export class GamesModule {}

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -381,6 +381,43 @@ describe('GamesService backlog', () => {
     });
   });
 
+  it('blocks recommendation work while the current election is active', async () => {
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        electionActive: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: false,
+      }),
+    );
+
+    await expect(service.searchRecommendations('game')).rejects.toThrow(
+      'As sugestões ficam fechadas enquanto a votação está acesa.',
+    );
+    await expect(service.assessRecommendation(42, player)).rejects.toThrow(
+      'As sugestões ficam fechadas enquanto a votação está acesa.',
+    );
+    await expect(service.recommend('signed-token', player)).rejects.toThrow(
+      'As sugestões ficam fechadas enquanto a votação está acesa.',
+    );
+    await expect(service.withdrawRecommendation(player)).rejects.toThrow(
+      'As sugestões ficam fechadas enquanto a votação está acesa.',
+    );
+    expect(researchService.searchSteam).not.toHaveBeenCalled();
+    expect(researchService.assessSteamGame).not.toHaveBeenCalled();
+  });
+
   it('keeps an explicitly re-suggested ashes game in the next-vote shelf', async () => {
     const game = (
       await saveGames([{ title: 'A Return From Ashes', suggestion: true }])

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -6,7 +6,7 @@ import { PoolOption } from '../pool/entities/pool-option.entity';
 import { Pool } from '../pool/entities/pool.entity';
 import { Game } from './entities/game.entity';
 import { GameRecommendation } from './entities/game-recommendation.entity';
-import { GamesService } from './games.service';
+import { findEligibleBacklogGames, GamesService } from './games.service';
 import { GameResearchService } from './game-research.service';
 
 describe('GamesService backlog', () => {
@@ -104,6 +104,30 @@ describe('GamesService backlog', () => {
       ['Fourth appearance', 4],
       ['Third chance', 3],
     ]);
+  });
+
+  it('ignores historical options whose pool no longer exists', async () => {
+    const [game] = await saveGames([
+      { title: 'Still eligible', suggestion: true },
+    ]);
+    await dataSource.query('PRAGMA foreign_keys = OFF');
+    await dataSource.query(
+      'INSERT INTO pool_options (game_id, pool_id) VALUES (?, ?)',
+      [game.id, 999_999],
+    );
+    await dataSource.query('PRAGMA foreign_keys = ON');
+
+    await expect(service.findBacklog()).resolves.toMatchObject({
+      games: [
+        expect.objectContaining({
+          id: game.id,
+          electionAppearances: 0,
+        }),
+      ],
+    });
+    await expect(
+      findEligibleBacklogGames(dataSource.manager, new Set()),
+    ).resolves.toContainEqual(expect.objectContaining({ id: game.id }));
   });
 
   it('collapses duplicate records and combines their pool appearances', async () => {

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -521,6 +521,146 @@ describe('GamesService backlog', () => {
     });
   });
 
+  it('retires a historical recommendation from rotation without deleting its provenance or metadata', async () => {
+    const game = (
+      await saveGames([
+        {
+          title: 'A Game From Last Year',
+          suggestion: true,
+          cover: 'https://example.com/cover.jpg',
+          trailer: 'https://www.youtube.com/watch?v=historical',
+          mainExtraHours: 9,
+        },
+      ])
+    )[0];
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    await dataSource
+      .getRepository(GameRecommendation)
+      .save(
+        dataSource.getRepository(GameRecommendation).create({ game, player }),
+      );
+
+    await expect(
+      service.retireGameFromRotation(game.id, player),
+    ).resolves.toMatchObject({
+      game: { id: game.id, suggestion: false },
+      retiredGameIds: [game.id],
+    });
+    await expect(
+      dataSource.getRepository(Game).findOneByOrFail({ id: game.id }),
+    ).resolves.toMatchObject({
+      suggestion: false,
+      cover: 'https://example.com/cover.jpg',
+      trailer: 'https://www.youtube.com/watch?v=historical',
+      mainExtraHours: 9,
+    });
+    await expect(
+      dataSource.getRepository(GameRecommendation).count(),
+    ).resolves.toBe(1);
+    await expect(service.findBacklog()).resolves.toMatchObject({ games: [] });
+  });
+
+  it('rejects catalog retirement when the player never recommended the game', async () => {
+    const game = (
+      await saveGames([{ title: "Someone Else's Game", suggestion: true }])
+    )[0];
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+
+    await expect(
+      service.retireGameFromRotation(game.id, player),
+    ).rejects.toThrow('Somente quem sugeriu este jogo');
+    await expect(
+      dataSource.getRepository(Game).findOneByOrFail({ id: game.id }),
+    ).resolves.toMatchObject({ suggestion: true });
+  });
+
+  it('keeps a retired game visible until its active election finishes', async () => {
+    const game = (
+      await saveGames([{ title: 'Already On The Ballot', suggestion: true }])
+    )[0];
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    await dataSource
+      .getRepository(GameRecommendation)
+      .save(
+        dataSource.getRepository(GameRecommendation).create({ game, player }),
+      );
+    const pool = await dataSource
+      .getRepository(Pool)
+      .save(dataSource.getRepository(Pool).create({ options: [] }));
+    await dataSource.getRepository(PoolOption).save(
+      dataSource.getRepository(PoolOption).create({
+        pool,
+        game,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        electionActive: true,
+        pool,
+        players: [],
+      }),
+    );
+
+    await service.retireGameFromRotation(game.id, player);
+
+    await expect(service.findBacklog()).resolves.toMatchObject({
+      games: [
+        expect.objectContaining({
+          id: game.id,
+          suggestion: false,
+          title: game.title,
+        }),
+      ],
+    });
+  });
+
+  it('keeps current-cycle withdrawal separate from historical catalog retirement', async () => {
+    const game = (
+      await saveGames([{ title: 'Current Suggestion', suggestion: true }])
+    )[0];
+    const player = await dataSource
+      .getRepository(Player)
+      .save(dataSource.getRepository(Player).create({ name: 'Ana' }));
+    await dataSource
+      .getRepository(GameRecommendation)
+      .save(
+        dataSource.getRepository(GameRecommendation).create({ game, player }),
+      );
+    const campaign = await dataSource.getRepository(Campaign).save(
+      dataSource.getRepository(Campaign).create({
+        month: 'Agosto',
+        year: '2026',
+        current: true,
+        players: [],
+      }),
+    );
+    await dataSource.getRepository(CampaignPlayer).save(
+      dataSource.getRepository(CampaignPlayer).create({
+        campaign,
+        player,
+        suggested_a_game: true,
+        suggestedGame: game,
+      }),
+    );
+
+    await expect(
+      service.retireGameFromRotation(game.id, player),
+    ).rejects.toThrow('retirada da sugestão atual');
+    await expect(
+      dataSource.getRepository(Game).findOneByOrFail({ id: game.id }),
+    ).resolves.toMatchObject({ suggestion: true });
+  });
+
   const saveGames = (games: Array<Partial<Game> & Pick<Game, 'title'>>) => {
     const repository = dataSource.getRepository(Game);
     return repository.save(games.map((game) => repository.create(game)));

--- a/server/src/games/games.service.spec.ts
+++ b/server/src/games/games.service.spec.ts
@@ -58,6 +58,15 @@ describe('GamesService backlog', () => {
     await dataSource.destroy();
   });
 
+  it('refuses to persist a direct HLS trailer URL', () => {
+    expect(() =>
+      service.create({
+        title: 'Streaming Asset',
+        trailer: 'https://cdn.example.com/trailer.m3u8',
+      }),
+    ).toThrow('página navegável');
+  });
+
   it('returns unwon suggestions ordered by distinct election appearances', async () => {
     const games = await saveGames([
       { title: 'Third chance', suggestion: true },
@@ -261,7 +270,7 @@ describe('GamesService backlog', () => {
           suggestion: false,
           steam: 'https://store.steampowered.com/app/42/',
           cover: 'https://example.com/header.jpg',
-          trailer: 'https://example.com/trailer',
+          trailer: 'https://example.com/trailer.m3u8',
           howLongToBeatUrl: 'https://howlongtobeat.com/game/42',
           durationLabel: '12–18 h',
           mainHours: 12,
@@ -302,7 +311,7 @@ describe('GamesService backlog', () => {
     expect(assessment).toMatchObject({
       eligible: true,
       assessmentToken: 'cached-token',
-      game: { title: game.title, mainExtraHours: 18 },
+      game: { title: game.title, trailer: null, mainExtraHours: 18 },
     });
     expect(researchService.assessResearchedGame).toHaveBeenCalledTimes(1);
     expect(researchService.assessSteamGame).not.toHaveBeenCalled();

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -142,6 +142,7 @@ export const findEligibleBacklogGames = async (
   const gamesByIdentity = new Map<string, Game[]>();
 
   for (const option of poolOptions) {
+    if (!option.pool) continue;
     const identity = normalizeGameIdentity(option.game);
     const poolIds = appearancesByIdentity.get(identity) ?? new Set<number>();
     poolIds.add(option.pool.id);
@@ -542,6 +543,7 @@ export class GamesService {
 
     const appearancesByIdentity = new Map<string, Set<number>>();
     for (const option of poolOptions) {
+      if (!option.pool) continue;
       const identity = normalizeGameIdentity(option.game);
       const poolIds = appearancesByIdentity.get(identity) ?? new Set<number>();
       poolIds.add(option.pool.id);

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -236,6 +236,11 @@ export class GamesService {
   }
 
   async searchRecommendations(query: string): Promise<SteamGameSearchResult[]> {
+    const campaign = await this.campaignRepository.findOneBy({
+      current: true,
+    });
+    this.assertRecommendationsOpen(campaign);
+
     const normalizedQuery = normalizeGameTitle(query);
     const localResults = (
       await this.gameRepository.find({ order: { title: 'ASC' } })
@@ -284,6 +289,7 @@ export class GamesService {
     if (!campaign) {
       throw new NotFoundException('No current campaign found');
     }
+    this.assertRecommendationsOpen(campaign);
 
     const localGame = (await this.gameRepository.find()).find(
       (game) => extractSteamAppId(game.steam) === steamAppId,
@@ -332,6 +338,10 @@ export class GamesService {
     assessmentToken: string,
     player: Player,
   ): Promise<CreatedGameRecommendation> {
+    this.assertRecommendationsOpen(
+      await this.campaignRepository.findOneBy({ current: true }),
+    );
+
     let researchedGame: ResearchedGame;
 
     try {
@@ -359,6 +369,7 @@ export class GamesService {
       if (!campaign) {
         throw new NotFoundException('No current campaign found');
       }
+      this.assertRecommendationsOpen(campaign);
 
       let game = await this.findEquivalentGame(manager, researchedGame);
       const alreadySuggestedGame = campaign.players.find(
@@ -467,6 +478,7 @@ export class GamesService {
       if (!campaign) {
         throw new NotFoundException('No current campaign found');
       }
+      this.assertRecommendationsOpen(campaign);
 
       const campaignPlayer = campaign.players.find(
         (entry) => entry.player.id === player.id,
@@ -609,6 +621,14 @@ export class GamesService {
         backlogGames.filter((game) => !game.guaranteedNextVote).length,
       ),
     };
+  }
+
+  private assertRecommendationsOpen(campaign: Campaign | null): void {
+    if (campaign?.electionActive) {
+      throw new BadRequestException(
+        'As sugestões ficam fechadas enquanto a votação está acesa.',
+      );
+    }
   }
 
   async findOne(id: number): Promise<GameWithRecommenders | null> {

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -63,6 +64,11 @@ export interface CreatedGameRecommendation {
 export interface WithdrawnGameRecommendation {
   game: Game;
   hiddenFromCatalog: boolean;
+}
+
+export interface RetiredGameRotation {
+  game: Game;
+  retiredGameIds: number[];
 }
 
 export const extractSteamAppId = (steamUrl?: string | null): number | null => {
@@ -528,13 +534,81 @@ export class GamesService {
     });
   }
 
+  async retireGameFromRotation(
+    gameId: number,
+    player: Player,
+  ): Promise<RetiredGameRotation> {
+    return this.dataSource.transaction(async (manager) => {
+      const gameRepository = manager.getRepository(Game);
+      const games = await gameRepository.find();
+      const selectedGame = games.find((game) => game.id === gameId);
+
+      if (!selectedGame) {
+        throw new NotFoundException(`Game #${gameId} not found`);
+      }
+
+      const identity = normalizeGameIdentity(selectedGame);
+      const recommendations = await manager
+        .getRepository(GameRecommendation)
+        .find({ relations: ['game', 'player'] });
+      const wasRecommendedByPlayer = recommendations.some(
+        (recommendation) =>
+          recommendation.player.id === player.id &&
+          normalizeGameIdentity(recommendation.game) === identity,
+      );
+
+      if (!wasRecommendedByPlayer) {
+        throw new ForbiddenException(
+          'Somente quem sugeriu este jogo pode retirá-lo da rotação.',
+        );
+      }
+
+      const currentCampaign = await manager.getRepository(Campaign).findOne({
+        where: { current: true },
+        relations: ['players', 'players.player', 'players.suggestedGame'],
+      });
+      const currentSuggestion = currentCampaign?.players.find(
+        (campaignPlayer) => campaignPlayer.player.id === player.id,
+      )?.suggestedGame;
+
+      if (
+        currentSuggestion &&
+        normalizeGameIdentity(currentSuggestion) === identity
+      ) {
+        throw new BadRequestException(
+          'Use a retirada da sugestão atual para este jogo neste ciclo.',
+        );
+      }
+
+      const matchingGames = games.filter(
+        (game) => normalizeGameIdentity(game) === identity,
+      );
+      matchingGames.forEach((game) => {
+        game.suggestion = false;
+      });
+      await gameRepository.save(matchingGames);
+
+      return {
+        game: { ...selectedGame, suggestion: false },
+        retiredGameIds: matchingGames.map((game) => game.id),
+      };
+    });
+  }
+
   async findBacklog(): Promise<GameBacklog> {
     const [games, poolOptions, campaigns, recommendersByIdentity] =
       await Promise.all([
         this.gameRepository.find({ order: { id: 'ASC' } }),
         this.poolOptionRepository.find({ relations: ['game', 'pool'] }),
         this.campaignRepository.find({
-          relations: ['game', 'players', 'players.suggestedGame'],
+          relations: [
+            'game',
+            'players',
+            'players.suggestedGame',
+            'pool',
+            'pool.options',
+            'pool.options.game',
+          ],
         }),
         this.findRecommendersByIdentity(),
       ]);
@@ -560,6 +634,14 @@ export class GamesService {
         .filter((game): game is Game => Boolean(game))
         .map(normalizeGameIdentity),
     );
+    const currentCampaign = campaigns.find((campaign) => campaign.current);
+    const currentVoteIdentities = new Set(
+      currentCampaign?.electionActive
+        ? (currentCampaign.pool?.options ?? []).map((option) =>
+            normalizeGameIdentity(option.game),
+          )
+        : [],
+    );
 
     const appearancesByIdentity = new Map<string, Set<number>>();
     for (const option of poolOptions) {
@@ -576,7 +658,8 @@ export class GamesService {
       const guaranteedNextVote = guaranteedIdentities.has(identity);
       if (
         (!matchingGames.some((game) => game.suggestion) &&
-          !guaranteedNextVote) ||
+          !guaranteedNextVote &&
+          !currentVoteIdentities.has(identity)) ||
         winningIdentities.has(identity)
       ) {
         continue;

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -20,6 +20,7 @@ import {
   SteamGameSearchResult,
   normalizeGameTitle,
 } from './game-research.service';
+import { normalizeTrailerPageUrl } from './trailer-url';
 
 const MAX_BACKLOG_APPEARANCES = 3;
 export const TARGET_POOL_SIZE = 5;
@@ -227,7 +228,11 @@ export class GamesService {
   ) {}
 
   create(createGameDto: CreateGameDto): Promise<Game> {
-    const entity: Game = this.gameRepository.create(createGameDto);
+    const trailer = this.validateTrailerInput(createGameDto.trailer);
+    const entity: Game = this.gameRepository.create({
+      ...createGameDto,
+      trailer,
+    });
     return this.gameRepository.save(entity);
   }
 
@@ -355,6 +360,8 @@ export class GamesService {
       );
     }
 
+    researchedGame.trailer = normalizeTrailerPageUrl(researchedGame.trailer);
+
     const result = await this.dataSource.transaction(async (manager) => {
       const campaign = await manager.getRepository(Campaign).findOne({
         where: { current: true },
@@ -409,7 +416,7 @@ export class GamesService {
         suggestion: true,
         cover: researchedGame.cover,
         steam: researchedGame.steam,
-        trailer: researchedGame.trailer,
+        trailer: normalizeTrailerPageUrl(researchedGame.trailer),
         summary: researchedGame.summary,
         howLongToBeatUrl: researchedGame.howLongToBeatUrl,
         durationLabel: researchedGame.durationLabel,
@@ -417,7 +424,8 @@ export class GamesService {
       game.suggestion = true;
       game.cover ||= researchedGame.cover;
       game.steam ||= researchedGame.steam;
-      game.trailer ||= researchedGame.trailer;
+      game.trailer =
+        normalizeTrailerPageUrl(game.trailer) ?? researchedGame.trailer;
       game.summary ||= researchedGame.summary;
       game.howLongToBeatUrl ||= researchedGame.howLongToBeatUrl;
       game.durationLabel ||= researchedGame.durationLabel;
@@ -716,7 +724,7 @@ export class GamesService {
       title: game.title,
       cover: game.cover ?? null,
       steam: game.steam ?? `https://store.steampowered.com/app/${steamAppId}/`,
-      trailer: game.trailer ?? null,
+      trailer: normalizeTrailerPageUrl(game.trailer),
       summary: game.summary ?? null,
       howLongToBeatUrl: game.howLongToBeatUrl ?? null,
       durationLabel: game.durationLabel ?? null,
@@ -755,9 +763,11 @@ export class GamesService {
   }
 
   async update(id: number, updateGameDto: UpdateGameDto): Promise<Game> {
+    const trailer = this.validateTrailerInput(updateGameDto.trailer);
     const entity: Game | undefined = await this.gameRepository.preload({
       id,
       ...updateGameDto,
+      ...(updateGameDto.trailer !== undefined ? { trailer } : {}),
     });
 
     if (!entity) {
@@ -765,6 +775,22 @@ export class GamesService {
     }
 
     return this.gameRepository.save(entity);
+  }
+
+  private validateTrailerInput(
+    trailer: string | null | undefined,
+  ): string | null | undefined {
+    if (trailer === undefined) return undefined;
+    if (trailer === null) return null;
+
+    const normalized = normalizeTrailerPageUrl(trailer);
+    if (!normalized) {
+      throw new BadRequestException(
+        'O trailer precisa ser uma página navegável, não um vídeo direto ou playlist HLS.',
+      );
+    }
+
+    return normalized;
   }
 
   remove(id: number): Promise<DeleteResult> {

--- a/server/src/games/games.service.ts
+++ b/server/src/games/games.service.ts
@@ -123,7 +123,7 @@ export const findGuaranteedNextVoteGames = async (
     .sort((left, right) => left.title.localeCompare(right.title, 'pt-BR'));
 };
 
-const findEligibleBacklogGames = async (
+export const findEligibleBacklogGames = async (
   manager: EntityManager,
   excludedIdentities: Set<string>,
 ): Promise<Game[]> => {

--- a/server/src/games/trailer-url.ts
+++ b/server/src/games/trailer-url.ts
@@ -1,0 +1,54 @@
+import { ValidateBy, type ValidationOptions } from 'class-validator';
+
+const DIRECT_MEDIA_EXTENSION =
+  /\.(?:m3u8|m3u|mp4|m4v|mov|webm|mkv|avi)(?:$|[?#])/i;
+const YOUTUBE_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+]);
+
+export const normalizeTrailerPageUrl = (
+  value: string | null | undefined,
+): string | null => {
+  const candidate = value?.trim();
+  if (!candidate || DIRECT_MEDIA_EXTENSION.test(candidate)) return null;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+    const host = url.hostname.toLocaleLowerCase('en-US');
+    if (YOUTUBE_HOSTS.has(host)) {
+      const isWatchPage =
+        url.pathname === '/watch' && Boolean(url.searchParams.get('v'));
+      const isShortPage = /^\/shorts\/[^/]+\/?$/.test(url.pathname);
+      return isWatchPage || isShortPage ? candidate : null;
+    }
+
+    if (host === 'youtu.be') {
+      return /^\/[^/]+\/?$/.test(url.pathname) ? candidate : null;
+    }
+
+    return candidate;
+  } catch {
+    return null;
+  }
+};
+
+export const isTrailerPageUrl = (value: unknown): boolean =>
+  typeof value === 'string' && normalizeTrailerPageUrl(value) !== null;
+
+export const IsTrailerPageUrl = (validationOptions?: ValidationOptions) =>
+  ValidateBy(
+    {
+      name: 'isTrailerPageUrl',
+      validator: {
+        validate: isTrailerPageUrl,
+        defaultMessage: () =>
+          'trailer must be a navigable HTTP page, not a direct video or HLS playlist',
+      },
+    },
+    validationOptions,
+  );


### PR DESCRIPTION
## Summary

- promote the automated campaign cycle conductor and election workflow from #37
- include the catalog, voting hearth, trailer, and rotation refinements validated during local testing
- keep conductor actions restricted to the configured Proper Pedestrian Discord identity

## Validation

- full local client and server suites passed before promotion
- GitHub CI is intentionally not being awaited for this release